### PR TITLE
fix(aws/compute): Correctly map security group ids for ec2 instance

### DIFF
--- a/src/aws/compute/instance.ts
+++ b/src/aws/compute/instance.ts
@@ -704,7 +704,7 @@ export class Instance extends AwsConstructBase implements IInstance {
       keyName: props.keyPair?.keyPairName ?? props?.keyName,
       instanceType: props.instanceType.toString(),
       subnetId: networkInterfaces ? undefined : subnet.subnetId,
-      securityGroups: networkInterfaces ? undefined : securityGroupsToken,
+      vpcSecurityGroupIds: networkInterfaces ? undefined : securityGroupsToken,
       associatePublicIpAddress: props.associatePublicIpAddress,
       networkInterface: networkInterfaces,
       iamInstanceProfile,


### PR DESCRIPTION
aws_instance resource created in a VPC should use
`vpc_security_group_ids` instead.

fixes:
- https://github.com/TerraConstructs/base/issues/26