### PR TITLE
fix: terraform-provider-aws lt tags inputs

### DIFF
--- a/src/aws/compute/launch-template.ts
+++ b/src/aws/compute/launch-template.ts
@@ -811,10 +811,6 @@ export class LaunchTemplate
               resourceType: "volume",
               tags: this._tags,
             },
-            {
-              resourceType: "launch-template",
-              tags: this._tags,
-            },
           ].map(tfLaunchTemplate.launchTemplateTagSpecificationsToTerraform);
         }
         return undefined;

--- a/test/aws/compute/launch-template.test.ts
+++ b/test/aws/compute/launch-template.test.ts
@@ -79,12 +79,6 @@ describe("LaunchTemplate", () => {
               Name: "MyStack/Template",
             },
           },
-          {
-            resource_type: "launch-template",
-            tags: {
-              Name: "MyStack/Template",
-            },
-          },
         ],
         // These are GRID backend specific tags
         tags: {
@@ -338,13 +332,10 @@ describe("LaunchTemplate", () => {
             Name: "MyStack/Template",
           },
         },
-        {
-          resource_type: "launch-template",
-          tags: {
-            Name: "MyStack/Template",
-          },
-        },
       ],
+      tags: expect.objectContaining({
+        Name: "MyStack/Template",
+      }),
     });
     expect(template.role).toBeDefined();
     expect(template.grantPrincipal).toBeDefined();
@@ -871,14 +862,11 @@ describe("LaunchTemplate", () => {
               TestKey: "TestValue",
             },
           },
-          {
-            resource_type: "launch-template",
-            tags: {
-              Name: "MyStack/Template",
-              TestKey: "TestValue",
-            },
-          },
         ],
+        tags: expect.objectContaining({
+          Name: "MyStack/Template",
+          TestKey: "TestValue",
+        }),
       },
     );
   });


### PR DESCRIPTION
terraform provider aws consistenly handles tags on the `aws_launch_template` itself, unlike `CfnLaunchTemplate` which uses tags_specifications at 2 different levels

See: 
- `tags` in all tf provider resources.. [docs](https://github.com/hashicorp/terraform-provider-aws/blob/main/internal/generate/tags/README.md)
- CfnLaunchTemplate expects `TagSpecifications` with only valid resource type `launch-template` [docs](https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-resource-ec2-launchtemplate.html#cfn-ec2-launchtemplate-tagspecifications)
