### PR TITLE
feat(integ/storage): implement table.policy integration test validation

### DIFF
--- a/integ/aws/storage/apps/table.policy.ts
+++ b/integ/aws/storage/apps/table.policy.ts
@@ -35,6 +35,8 @@ export class TestStack extends aws.AwsStack {
       },
       // removalPolicy: RemovalPolicy.DESTROY,
       resourcePolicy: doc,
+      registerOutputs: true,
+      outputName: "table",
     });
 
     this.tableTwo = new aws.storage.Table(this, "TableTest2", {
@@ -43,6 +45,8 @@ export class TestStack extends aws.AwsStack {
         type: aws.storage.AttributeType.STRING,
       },
       // removalPolicy: RemovalPolicy.DESTROY,
+      registerOutputs: true,
+      outputName: "table_two",
     });
 
     this.tableTwo.grantReadData(new aws.iam.AccountPrincipal(awsAccountId));


### PR DESCRIPTION
## Summary

- Implement comprehensive DynamoDB table resource policy validation for table.policy integration test
- Add schema validation for both TableTest1 and TableTest2 with proper key validation
- Add resource policy validation using AWS GetResourcePolicy API with retry logic for eventual consistency

## Test plan

- [x] Schema validation verifies correct partition keys ("id" for TableTest1, "PK" for TableTest2)
- [x] TableTest1 explicit resource policy validation (dynamodb:* wildcard actions)  
- [x] TableTest2 grantReadData policy validation (read-only actions with specific table ARN)
- [x] Robust JSON policy parsing handling string/array formats for Action/Principal/Resource
- [x] Integration with terratest patterns using LoadOutputAttribute
- [x] End-to-end test passes: synth, deploy, validate, cleanup

### Helper Functions Added

- `validateTableSchema` - DynamoDB table schema validation with flexible key validation
- `getDynamoDBTableResourcePolicy` - AWS GetResourcePolicy API wrapper with retry logic for eventual consistency
- `validateResourcePolicyContent` - Validates explicit resource policies (wildcard actions)
- `validateGrantReadDataPolicyContent` - Validates read-only policies from grantReadData

### Key Insights

- grantReadData creates resource policies (not just IAM policies) when `iam.Grant.addToPrincipalOrResource()` falls back to the resource's `addToResourcePolicy` method
- AWS DynamoDB resource policies return Action/Resource fields as either strings or arrays depending on content
- Both explicit `resourcePolicy` and implicit `grantReadData` policies use the same DynamoDB resource policy mechanism

🤖 Generated with [Claude Code](https://claude.ai/code)