### PR TITLE
feat(aws/edge): Add DNS Target for API Gateway

### DIFF
--- a/src/aws/edge/dns-alias-record-targets.ts
+++ b/src/aws/edge/dns-alias-record-targets.ts
@@ -1,13 +1,15 @@
 import { route53Record } from "@cdktf/provider-aws";
 import { IRecordSet, IDnsZone, IDistribution } from ".";
+import { IDomainName } from "../compute/domain-name";
 import {
   ILoadBalancerBaseV2,
   ImportedLoadBalancer,
 } from "../compute/lb-shared/base-load-balancer";
+import { RestApiBase } from "../compute/restapi";
 import { IBucket } from "../storage";
 
 /**
- * Classes that are valid alias record targets, like CloudFront distributions and load
+ * Classes that are valid alias record targets, like CloudFront distributions load
  * balancers, should implement this interface.
  */
 export interface IAliasRecordTarget {
@@ -60,9 +62,9 @@ export class BucketWebsiteTarget implements IAliasRecordTarget {
   }
 }
 
-// /**
-//  * Use an ELBv2 as an alias record target
-//  */
+/**
+ * Use an ELBv2 as an alias record target
+ */
 export class LoadBalancerTarget implements IAliasRecordTarget {
   public static fromAttributes(
     loadBalancerCanonicalHostedZoneId: string,
@@ -83,6 +85,69 @@ export class LoadBalancerTarget implements IAliasRecordTarget {
     return {
       zoneId: this.loadBalancer.loadBalancerCanonicalHostedZoneId,
       name: `dualstack.${this.loadBalancer.loadBalancerDnsName}`,
+      evaluateTargetHealth: true,
+    };
+  }
+}
+
+/**
+ * Defines an API Gateway domain name as the alias target.
+ *
+ * Use the `ApiGatewayTarget` class if you wish to map the alias to an REST API with a
+ * domain name defined through the `RestApiProps.domainName` prop.
+ */
+export class ApiGatewayDomain implements IAliasRecordTarget {
+  constructor(private readonly domainName: IDomainName) {}
+
+  public bind(
+    _record: IRecordSet,
+    _zone?: IDnsZone,
+  ): route53Record.Route53RecordAlias {
+    return {
+      zoneId: this.domainName.domainNameAliasHostedZoneId,
+      name: this.domainName.domainNameAliasDomainName,
+      evaluateTargetHealth: true,
+    };
+  }
+}
+
+/**
+ * Defines an API Gateway REST API as the alias target. Requires that the domain
+ * name will be defined through `RestApiProps.domainName`.
+ *
+ * You can direct the alias to any `apigateway.DomainName` resource through the
+ * `ApiGatewayDomain` class.
+ */
+export class ApiGatewayTarget extends ApiGatewayDomain {
+  constructor(api: RestApiBase) {
+    if (!api.domainName) {
+      throw new Error(`API does not define a default domain name: ${api}`);
+    }
+
+    super(api.domainName);
+  }
+}
+
+/**
+ * Defines an API Gateway V2 domain name as the alias target.
+ */
+export class ApiGatewayv2DomainProperties implements IAliasRecordTarget {
+  /**
+   * @param regionalDomainName the domain name associated with the regional endpoint for this custom domain name.
+   * @param regionalHostedZoneId the region-specific Amazon Route 53 Hosted Zone ID of the regional endpoint.
+   */
+  constructor(
+    private readonly regionalDomainName: string,
+    private readonly regionalHostedZoneId: string,
+  ) {}
+
+  public bind(
+    _record: IRecordSet,
+    _zone?: IDnsZone,
+  ): route53Record.Route53RecordAlias {
+    return {
+      name: this.regionalDomainName,
+      zoneId: this.regionalHostedZoneId,
       evaluateTargetHealth: true,
     };
   }

--- a/test/aws/edge/api-gateway.test.ts
+++ b/test/aws/edge/api-gateway.test.ts
@@ -1,0 +1,150 @@
+// https://github.com/aws/aws-cdk/blob/v2.232.2/packages/aws-cdk-lib/aws-route53-targets/test/apigateway-target.test.ts
+
+import "cdktf/lib/testing/adapters/jest";
+import { route53Record } from "@cdktf/provider-aws";
+import { Testing } from "cdktf";
+import { edge, AwsStack, compute } from "../../../src/aws";
+import { Template } from "../../assertions";
+
+const environmentName = "Test";
+const gridUUID = "123e4567-e89b-12d3";
+const gridBackendConfig = {
+  address: "http://localhost:3000",
+};
+const providerConfig = { region: "us-east-1" };
+
+test("edge.ApiGatewayTarget can be used to the default domain of an APIGW", () => {
+  // GIVEN
+  const stack = getAwsStack();
+  const cert = new edge.PublicCertificate(stack, "cert", {
+    domainName: "example.com",
+  });
+  const api = new compute.RestApi(stack, "api", {
+    domainName: {
+      domainName: "example.com",
+      certificate: cert,
+    },
+  });
+  const zone = new edge.DnsZone(stack, "zone", {
+    zoneName: "example.com",
+  });
+  api.root.addMethod("GET");
+
+  // WHEN
+  new edge.ARecord(stack, "A", {
+    zone,
+    target: edge.RecordTarget.fromAlias(new edge.ApiGatewayTarget(api)),
+  });
+
+  // THEN
+  Template.synth(stack).toHaveResourceWithProperties(
+    route53Record.Route53Record,
+    {
+      alias: {
+        evaluate_target_health: true,
+        name: stack.resolve(api.domainName?.domainNameAliasDomainName),
+        zone_id: stack.resolve(api.domainName?.domainNameAliasHostedZoneId),
+      },
+    },
+  );
+});
+
+test("edge.ApiGatewayDomain can be used to directly reference a domain", () => {
+  // GIVEN
+  const stack = getAwsStack();
+  const cert = new edge.PublicCertificate(stack, "cert", {
+    domainName: "example.com",
+  });
+  const domain = new compute.DomainName(stack, "domain", {
+    domainName: "example.com",
+    certificate: cert,
+  });
+  const zone = new edge.DnsZone(stack, "zone", {
+    zoneName: "example.com",
+  });
+
+  // WHEN
+  new edge.ARecord(stack, "A", {
+    zone,
+    target: edge.RecordTarget.fromAlias(new edge.ApiGatewayDomain(domain)),
+  });
+
+  // THEN
+  Template.synth(stack).toHaveResourceWithProperties(
+    route53Record.Route53Record,
+    {
+      alias: {
+        evaluate_target_health: true,
+        name: stack.resolve(domain.domainNameAliasDomainName),
+        zone_id: stack.resolve(domain.domainNameAliasHostedZoneId),
+      },
+    },
+  );
+});
+
+test("fails if an ApiGateway is used with an API that does not define a domain name", () => {
+  // GIVEN
+  const stack = getAwsStack();
+  const api = new compute.RestApi(stack, "api");
+  const zone = new edge.DnsZone(stack, "zone", {
+    zoneName: "example.com",
+  });
+  api.root.addMethod("GET");
+
+  // THEN
+  expect(() => {
+    new edge.ARecord(stack, "A", {
+      zone,
+      target: edge.RecordTarget.fromAlias(new edge.ApiGatewayTarget(api)),
+    });
+  }).toThrow(/API does not define a default domain name/);
+});
+
+test("edge.ApiGatewayTarget accepts a SpecRestApi", () => {
+  // GIVEN
+  const stack = getAwsStack();
+  const cert = new edge.PublicCertificate(stack, "cert", {
+    domainName: "example.com",
+  });
+  const api = new compute.SpecRestApi(stack, "api", {
+    domainName: {
+      domainName: "example.com",
+      certificate: cert,
+    },
+    apiDefinition: compute.ApiDefinition.fromInline({
+      key1: "val1",
+    }),
+  });
+  const zone = new edge.DnsZone(stack, "zone", {
+    zoneName: "example.com",
+  });
+  api.root.addMethod("GET");
+
+  // WHEN
+  new edge.ARecord(stack, "A", {
+    zone,
+    target: edge.RecordTarget.fromAlias(new edge.ApiGatewayTarget(api)),
+  });
+
+  // THEN
+  Template.synth(stack).toHaveResourceWithProperties(
+    route53Record.Route53Record,
+    {
+      alias: {
+        evaluate_target_health: true,
+        name: stack.resolve(api.domainName?.domainNameAliasDomainName),
+        zone_id: stack.resolve(api.domainName?.domainNameAliasHostedZoneId),
+      },
+    },
+  );
+});
+
+function getAwsStack(): AwsStack {
+  const app = Testing.app();
+  return new AwsStack(app, "TestStack", {
+    environmentName,
+    gridUUID,
+    providerConfig,
+    gridBackendConfig,
+  });
+}


### PR DESCRIPTION
This will add `aws_route53_record` alias resource with an API Gateway's domain as target. Following the AWS CDK repository, it will support both API Gateways: v1 and v2.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.