### PR TITLE
chore: replace prettier Legacy

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
     "recommendations": [
         "dbaeumer.vscode-eslint",
-        "esbenp.prettier-vscode"
+        "Prettier.prettier-vscode"
     ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.formatOnSave": true,
-  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "editor.defaultFormatter": "Prettier.prettier-vscode",
   "[go]": {
     "editor.defaultFormatter": "golang.go"
   }


### PR DESCRIPTION
extension migration notice on readme:
https://github.com/prettier/prettier-vscode/blob/main/README.md?plain=1#L57

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.