### PR TITLE
fix: Add non-ts files to lib

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -89,6 +89,9 @@
       "steps": [
         {
           "exec": "jsii --silence-warnings=reserved-word"
+        },
+        {
+          "exec": "find src -name \"*.vtl\" -or -name \"Dockerfile\" -type f -exec sh -c 'mkdir -p \"lib/$(dirname \"${1#src/}\")\" && cp \"$1\" \"lib/${1#src/}\"' _ {} \\;"
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -212,4 +212,9 @@ new SqsQueueConfigStructBuilder(project);
 new LbListenerConfigStructBuilder(project);
 new LbTargetGroupAttachmentConfigStructBuilder(project);
 
+// Copy non-TypeScript resource files (e.g., .vtl templates) to lib/ after compilation
+project.compileTask.exec(
+  'find src -name "*.vtl" -or -name "Dockerfile" -type f -exec sh -c \'mkdir -p "lib/$(dirname "${1#src/}")" && cp "$1" "lib/${1#src/}"\' _ {} \\;',
+);
+
 project.synth();


### PR DESCRIPTION
- Api Gateway stepfunctions integration was failing due to missing
stepfunctions.vtl file
- NodeJS Lambda Function missing Dockerfile
