### PR TITLE
feat(aws/compute): Add Node.js v24 runtime for Lambda

### DIFF
--- a/src/aws/compute/runtime.ts
+++ b/src/aws/compute/runtime.ts
@@ -159,7 +159,7 @@ export class Runtime {
    * available in YOUR region).
    */
   public static readonly NODEJS_LATEST = new Runtime(
-    "nodejs18.x",
+    "nodejs18.x", // TODO: review this
     RuntimeFamily.NODEJS,
     { supportsInlineCode: true, isVariable: true },
   );


### PR DESCRIPTION
Add support for Node.js v24 runtime for Lambda.

Implements: https://github.com/TerraConstructs/base/issues/66


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.