### PR TITLE
chore: Resolve GitHub security advisories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Dependabot configuration for Go module updates
+# Projen manages NodeJS updates
+# Groups dependencies into: aws-sdk, terratest, and others
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "go"
+      - "botmerge"
+    commit-message:
+      prefix: "chore"
+    groups:
+      aws-sdk:
+        patterns:
+          - "github.com/aws/aws-sdk-go-v2*"
+          - "github.com/aws/smithy-go*"
+      terratest:
+        patterns:
+          - "github.com/gruntwork-io/terratest*"
+          - "github.com/gruntwork-io/go-commons*"
+      gomod:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "github.com/aws/aws-sdk-go-v2*"
+          - "github.com/aws/smithy-go*"
+          - "github.com/gruntwork-io/terratest*"
+          - "github.com/gruntwork-io/go-commons*"

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,41 @@
+# Auto-approve and auto-merge Dependabot PRs with botmerge label
+name: dependabot-automerge
+on:
+  pull_request_target:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+
+permissions:
+  pull-requests: write
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependabot-automerge:
+    runs-on: ubuntu-latest
+    # Only run for dependabot PRs with botmerge label
+    if: github.actor == 'dependabot[bot]' && contains(github.event.pull_request.labels.*.name, 'botmerge')
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_PAT }}
+
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.DEPENDABOT_PAT }}

--- a/.github/workflows/dependabot-go-check.yml
+++ b/.github/workflows/dependabot-go-check.yml
@@ -1,0 +1,54 @@
+# Verify Go compilation for Dependabot Go module PRs
+# This check ensures dependency updates don't break compilation
+name: dependabot-go-check
+on:
+  pull_request:
+    paths:
+      - "go.mod"
+      - "go.sum"
+
+jobs:
+  go-compile-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if Dependabot Go PR
+        id: check
+        run: |
+          # Check if this is a dependabot PR for go_modules
+          if [[ "${{ github.actor }}" == "dependabot[bot]" && "${{ github.head_ref }}" == dependabot/go_modules/* ]]; then
+            echo "is_dependabot_go=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_dependabot_go=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Checkout
+        if: steps.check.outputs.is_dependabot_go == 'true'
+        uses: actions/checkout@v5
+
+      - name: Setup Go
+        if: steps.check.outputs.is_dependabot_go == 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Verify Go modules
+        if: steps.check.outputs.is_dependabot_go == 'true'
+        run: |
+          go mod download
+          go mod verify
+
+      - name: Compile integration tests
+        if: steps.check.outputs.is_dependabot_go == 'true'
+        run: |
+          # Compile all test files without running them
+          # -run=^$ matches zero tests, but compilation still happens
+          # This catches: syntax errors, import errors, broken dependencies
+          go test ./integ/... -run=^$
+
+      - name: Skip for non-Dependabot Go PRs
+        if: steps.check.outputs.is_dependabot_go == 'false'
+        run: |
+          echo "Not a Dependabot Go modules PR, skipping compilation check"
+          echo "Actor: ${{ github.actor }}"
+          echo "Branch: ${{ github.head_ref }}"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -178,6 +178,15 @@ const project = new cdk.JsiiProject({
   autoMerge: false,
 });
 
+// Fix CVE in form-data transitive dependency (via commit-and-tag-version -> jsdom)
+// form-data <4.0.4 uses predictable Math.random() for boundary values
+// https://github.com/advisories/GHSA-fjxv-7rqg-78g4 (form-data advisory)
+project.package.addField("pnpm", {
+  overrides: {
+    "form-data": ">=4.0.4",
+  },
+});
+
 const releaseWorkflow = project.tryFindObjectFile(
   ".github/workflows/release.yml",
 );

--- a/package.json
+++ b/package.json
@@ -94,7 +94,11 @@
     "mime-types",
     "minimatch"
   ],
-  "pnpm": {},
+  "pnpm": {
+    "overrides": {
+      "form-data": ">=4.0.4"
+    }
+  },
   "keywords": [
     "terraconstructs"
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  form-data: '>=4.0.4'
+
 importers:
 
   .:
@@ -1643,8 +1646,8 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
-  form-data@4.0.0:
-    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
   fs-extra@10.1.0:
@@ -5312,10 +5315,12 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  form-data@4.0.0:
+  form-data@4.0.5:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.2
       mime-types: 2.1.35
 
   fs-extra@10.1.0:
@@ -6147,7 +6152,7 @@ snapshots:
       cssstyle: 4.1.0
       data-urls: 5.0.0
       decimal.js: 10.4.3
-      form-data: 4.0.0
+      form-data: 4.0.5
       html-encoding-sniffer: 4.0.0
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.5


### PR DESCRIPTION
Several critical and high security advisories are related to the
terratest dev dependencies. This PR adds automated Dependabot PR
workflow to keep golang modules up to date and improve repository
security reports.
