### PR TITLE
feat(aws/storage): Support Contributor Insights config per DynamoDB global secondary index

### DIFF
--- a/src/aws/storage/dynamodb-perms.ts
+++ b/src/aws/storage/dynamodb-perms.ts
@@ -1,27 +1,21 @@
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/aws-cdk-lib/aws-dynamodb/lib/perms.ts
+
+export const RESOURCE_READ_DATA_ACTIONS = [
+  "dynamodb:BatchGetItem",
+  "dynamodb:Query",
+  "dynamodb:GetItem",
+  "dynamodb:Scan",
+  "dynamodb:ConditionCheckItem",
+];
+
+export const PRINCIPAL_ONLY_READ_DATA_ACTIONS = [
+  "dynamodb:GetRecords",
+  "dynamodb:GetShardIterator",
+];
+
 export const READ_DATA_ACTIONS = [
-  "dynamodb:BatchGetItem",
-  "dynamodb:GetRecords",
-  "dynamodb:GetShardIterator",
-  "dynamodb:Query",
-  "dynamodb:GetItem",
-  "dynamodb:Scan",
-  "dynamodb:ConditionCheckItem",
-];
-
-// Table-safe actions that can be used in DynamoDB resource policies
-// Excludes stream-specific actions that are not valid for table resource policies
-export const READ_DATA_ACTIONS_TABLE_SAFE = [
-  "dynamodb:BatchGetItem",
-  "dynamodb:Query",
-  "dynamodb:GetItem",
-  "dynamodb:Scan",
-  "dynamodb:ConditionCheckItem",
-];
-
-// Stream-specific actions that should only be used with stream ARNs
-export const READ_DATA_ACTIONS_STREAM_ONLY = [
-  "dynamodb:GetRecords",
-  "dynamodb:GetShardIterator",
+  ...RESOURCE_READ_DATA_ACTIONS,
+  ...PRINCIPAL_ONLY_READ_DATA_ACTIONS,
 ];
 
 export const KEY_READ_ACTIONS = ["kms:Decrypt", "kms:DescribeKey"];

--- a/src/aws/storage/index.ts
+++ b/src/aws/storage/index.ts
@@ -26,6 +26,9 @@ export * from "./capacity";
 export * from "./billing";
 export * from "./encryption";
 
+export * from "./stream-grants";
+export * from "./table-grants";
+
 // aws-ecr
 export * from "./ecr-repository";
 export * from "./ecr-lifecycle";

--- a/src/aws/storage/stream-grants.ts
+++ b/src/aws/storage/stream-grants.ts
@@ -1,0 +1,98 @@
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/aws-cdk-lib/aws-dynamodb/lib/streams-grants.ts
+
+import * as perms from "./dynamodb-perms";
+import * as kms from "../encryption";
+import * as iam from "../iam";
+import { ITable } from "./shared";
+
+/**
+ * Construction properties for StreamGrants
+ */
+export interface StreamGrantsProps {
+  /**
+   * The table this stream is for
+   */
+  readonly table: ITable;
+
+  /**
+   * The ARN of the Stream
+   */
+  readonly tableStreamArn: string;
+
+  /**
+   * The encryption key of the table
+   *
+   * Required permissions will be added to the key as well.
+   *
+   * @default - No key
+   */
+  readonly encryptionKey?: kms.IKey;
+}
+
+/**
+ * A set of permissions to grant on a Table Stream
+ */
+export class StreamGrants {
+  private readonly table: ITable;
+  private readonly tableStreamArn: string;
+  private readonly encryptionKey?: kms.IKey;
+
+  constructor(props: StreamGrantsProps) {
+    this.table = props.table;
+    this.tableStreamArn = props.tableStreamArn;
+    this.encryptionKey = props?.encryptionKey;
+  }
+
+  /**
+   * Adds an IAM policy statement associated with this table's stream to an
+   * IAM principal's policy.
+   *
+   * If `encryptionKey` is present, appropriate grants to the key needs to be added
+   * separately using the `table.encryptionKey.grant*` methods.
+   *
+   * @param grantee The principal (no-op if undefined)
+   * @param actions The set of actions to allow (i.e. "dynamodb:DescribeStream", "dynamodb:GetRecords", ...)
+   */
+  public actions(grantee: iam.IGrantable, ...actions: string[]): iam.Grant {
+    return iam.Grant.addToPrincipal({
+      grantee,
+      actions,
+      resourceArns: [this.tableStreamArn],
+      scope: this.table,
+    });
+  }
+
+  /**
+   * Permits an IAM Principal to list streams attached to current dynamodb table.
+   *
+   * @param grantee The principal (no-op if undefined)
+   */
+  public list(grantee: iam.IGrantable): iam.Grant {
+    return iam.Grant.addToPrincipal({
+      grantee,
+      actions: ["dynamodb:ListStreams"],
+      resourceArns: ["*"],
+    });
+  }
+
+  /**
+   * Permits an IAM principal all stream data read operations for this
+   * table's stream:
+   * DescribeStream, GetRecords, GetShardIterator, ListStreams.
+   *
+   * Appropriate grants will also be added to the customer-managed KMS key
+   * if one was configured.
+   *
+   * @param grantee The principal to grant access to
+   */
+  public read(grantee: iam.IGrantable): iam.Grant {
+    this.list(grantee);
+    this.encryptionKey?.grant(grantee, ...perms.KEY_READ_ACTIONS);
+    return iam.Grant.addToPrincipal({
+      grantee,
+      actions: perms.READ_STREAM_DATA_ACTIONS,
+      resourceArns: [this.tableStreamArn],
+      scope: this.table,
+    });
+  }
+}

--- a/src/aws/storage/table-grants.ts
+++ b/src/aws/storage/table-grants.ts
@@ -1,0 +1,203 @@
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/aws-cdk-lib/aws-dynamodb/lib/table-grants.ts
+
+import * as perms from "./dynamodb-perms";
+import { AwsStack } from "../aws-stack";
+import * as iam from "../iam";
+import { ITable } from "./shared";
+
+/**
+ * Construction properties for TableGrants
+ */
+export interface TableGrantsProps {
+  /**
+   * The table to grant permissions on
+   */
+  readonly table: ITable;
+
+  /**
+   * Additional regions other than the main one that this table is replicated to
+   *
+   * @default - No regions
+   */
+  readonly regions?: string[];
+
+  /**
+   * Whether this table has indexes
+   *
+   * If so, permissions are granted on all table indexes as well.
+   *
+   * @default false
+   */
+  readonly hasIndex?: boolean;
+
+  /**
+   * The encrypted resource on which actions will be allowed
+   *
+   * @default - No permission is added to the KMS key, even if it exists
+   */
+  readonly encryptedResource?: iam.IEncryptedResource;
+
+  /**
+   * The resource with policy on which actions will be allowed
+   *
+   * @default - No resource policy is created
+   */
+  readonly policyResource?: iam.IAwsConstructWithPolicy;
+}
+
+/**
+ * A set of permissions to grant on a Table
+ */
+export class TableGrants {
+  private readonly table: ITable;
+  private readonly arns: string[] = [];
+  private readonly encryptedResource?: iam.IEncryptedResource;
+  private readonly policyResource?: iam.IAwsConstructWithPolicy;
+
+  constructor(props: TableGrantsProps) {
+    this.table = props.table;
+    this.encryptedResource = props.encryptedResource;
+    this.policyResource = props.policyResource;
+
+    const stack = AwsStack.ofAwsConstruct(this.table);
+
+    this.arns = [
+      this.table.tableArn,
+      ...(props.regions ?? []).map((region) =>
+        stack.formatArn({
+          region,
+          service: "dynamodb",
+          resource: "table",
+          resourceName: this.table.tableName,
+        }),
+      ),
+    ];
+
+    if (props.hasIndex) {
+      this.arns.push(...this.arns.map((arn) => `${arn}/index/*`));
+    }
+  }
+
+  /**
+   * Adds an IAM policy statement associated with this table to an IAM
+   * principal's policy.
+   *
+   * If `encryptionKey` is present, appropriate grants to the key needs to be added
+   * separately using the `table.encryptionKey.grant*` methods.
+   *
+   * @param grantee The principal (no-op if undefined)
+   * @param actions The set of actions to allow (i.e. "dynamodb:PutItem", "dynamodb:GetItem", ...)
+   */
+  public actions(grantee: iam.IGrantable, ...actions: string[]): iam.Grant {
+    return this.policyResource
+      ? iam.Grant.addToPrincipalOrResource({
+          grantee,
+          actions,
+          resourceArns: this.arns,
+          resource: this.policyResource,
+          // Use wildcard for resource policy to avoid circular dependency when grantee is a resource principal
+          // (e.g., AccountRootPrincipal). This follows the same pattern as KMS (aws-kms/lib/key.ts).
+          // resourceArns is used for principal policies, resourceSelfArns is used for resource policies.
+          resourceSelfArns: ["*"],
+        })
+      : iam.Grant.addToPrincipal({
+          grantee,
+          actions,
+          resourceArns: this.arns,
+        });
+  }
+
+  /**
+   * Permits an IAM principal all data read operations from this table:
+   * BatchGetItem, GetRecords, GetShardIterator, Query, GetItem, Scan, DescribeTable.
+   *
+   * Appropriate grants will also be added to the customer-managed KMS key
+   * if one was configured.
+   *
+   * @param grantee The principal to grant access to
+   */
+  public readData(grantee: iam.IGrantable): iam.Grant {
+    const actions = [...perms.RESOURCE_READ_DATA_ACTIONS, perms.DESCRIBE_TABLE];
+    this.encryptedResource?.grantOnKey(grantee, ...perms.KEY_READ_ACTIONS);
+    const result = this.actions(grantee, ...actions);
+
+    return result.combine(
+      iam.Grant.addToPrincipal({
+        grantee,
+        actions: perms.PRINCIPAL_ONLY_READ_DATA_ACTIONS,
+        resourceArns: this.arns,
+      }),
+    );
+  }
+
+  /**
+   * Permits an IAM principal all data write operations to this table:
+   * BatchWriteItem, PutItem, UpdateItem, DeleteItem, DescribeTable.
+   *
+   * Appropriate grants will also be added to the customer-managed KMS key
+   * if one was configured.
+   *
+   * @param grantee The principal to grant access to
+   */
+  public writeData(grantee: iam.IGrantable): iam.Grant {
+    const actions = [...perms.WRITE_DATA_ACTIONS, perms.DESCRIBE_TABLE];
+    const result = this.actions(grantee, ...actions);
+    this.encryptedResource?.grantOnKey(
+      grantee,
+      ...perms.KEY_READ_ACTIONS,
+      ...perms.KEY_WRITE_ACTIONS,
+    );
+    return result;
+  }
+
+  /**
+   * Permits an IAM principal to all data read/write operations to this table.
+   * BatchGetItem, GetRecords, GetShardIterator, Query, GetItem, Scan,
+   * BatchWriteItem, PutItem, UpdateItem, DeleteItem, DescribeTable
+   *
+   * Appropriate grants will also be added to the customer-managed KMS key
+   * if one was configured.
+   *
+   * @param grantee The principal to grant access to
+   */
+  public readWriteData(grantee: iam.IGrantable): iam.Grant {
+    const actions = [
+      ...perms.RESOURCE_READ_DATA_ACTIONS,
+      ...perms.WRITE_DATA_ACTIONS,
+      perms.DESCRIBE_TABLE,
+    ];
+    const result = this.actions(grantee, ...actions);
+    this.encryptedResource?.grantOnKey(
+      grantee,
+      ...perms.KEY_READ_ACTIONS,
+      ...perms.KEY_WRITE_ACTIONS,
+    );
+
+    return result.combine(
+      iam.Grant.addToPrincipal({
+        grantee,
+        actions: perms.PRINCIPAL_ONLY_READ_DATA_ACTIONS,
+        resourceArns: this.arns,
+      }),
+    );
+  }
+
+  /**
+   * Permits all DynamoDB operations ("dynamodb:*") to an IAM principal.
+   *
+   * Appropriate grants will also be added to the customer-managed KMS key
+   * if one was configured.
+   *
+   * @param grantee The principal to grant access to
+   */
+  public fullAccess(grantee: iam.IGrantable) {
+    const actions = ["dynamodb:*"];
+    const result = this.actions(grantee, ...actions);
+    this.encryptedResource?.grantOnKey(
+      grantee,
+      ...perms.KEY_READ_ACTIONS,
+      ...perms.KEY_WRITE_ACTIONS,
+    );
+    return result;
+  }
+}


### PR DESCRIPTION
Support for the full Contributor Insights configuration within DynamoDB resource (including to specify the mode) while also allowing to set the same per Global Secondary Index. Additionally, support for `recoveryPeriodInDays` and `warmThroughput` will be added as the AWS Provider for Terraform now have them available.

Related to: #35 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.