### PR TITLE
feat(aws/notify): Support FIFO throughtput config in SNS Topic

### DIFF
--- a/src/aws/notify/index.ts
+++ b/src/aws/notify/index.ts
@@ -28,6 +28,10 @@ export * from "./subscription-filter";
 export * from "./delivery-policy";
 
 import "./sns-augmentations.generated";
+
+// Exporting as it is part of the public API
+export * from "./sns-grants.generated";
+
 // codestarnotifications
 export * from "./notification-rule";
 export * from "./notification-rule-source";

--- a/src/aws/notify/sns-grants.generated.ts
+++ b/src/aws/notify/sns-grants.generated.ts
@@ -1,0 +1,108 @@
+/* eslint-disable prettier/prettier,max-len */
+import * as sns from './';
+import * as iam from '../iam';
+
+export interface TopicGrantsProps {
+  /**
+   * The SQS topic interface (ITopic) this helper will operate on.
+   */
+  readonly resource: sns.ITopic;
+
+  /**
+   * If the topic is an encrypted resource, provides access to grant KMS key permissions.
+   * Typically present if the resource implements iam.IEncryptedResource.
+   */
+  readonly encryptedResource?: iam.IEncryptedResource;
+
+  /**
+   * If the topic supports a resource policy, this enables addToPrincipalOrResource grants.
+   * Typically present if the resource implements iam.IResourceWithPolicy.
+   */
+  readonly policyResource?: iam.IAwsConstructWithPolicy;
+}
+
+/**
+ * Collection of grant methods for a ITopic
+ */
+export class TopicGrants {
+  /**
+   * Creates grants for TopicGrants
+   */
+  public static fromTopic(resource: sns.ITopic): TopicGrants {
+    // Use IAM helper type-guards to discover capabilities on the resource.
+    const encryptedResource = iam.GrantableResources.isEncryptedResource(resource)
+      ? (resource as unknown as iam.IEncryptedResource)
+      : undefined;
+
+    const policyResource = iam.GrantableResources.isResourceWithPolicy(resource)
+      ? (resource as unknown as iam.IAwsConstructWithPolicy)
+      : undefined;
+
+    return new TopicGrants({
+      resource,
+      encryptedResource,
+      policyResource,
+    });
+  }
+
+  public readonly resource: sns.ITopic;
+  private readonly encryptedResource?: iam.IEncryptedResource;
+  private readonly policyResource?: iam.IAwsConstructWithPolicy;
+
+  private constructor(props: TopicGrantsProps) {
+    this.resource = props.resource;
+    this.encryptedResource = props.encryptedResource;
+    this.policyResource = props.policyResource;
+  }
+
+  /**
+   * Grant topic publishing permissions to the given identity
+   */
+  public publish(grantee: iam.IGrantable): iam.Grant {
+    const actions = ['sns:Publish'];
+
+    const resourceArns = [this.resource.topicArn];
+
+    const result = this.policyResource
+      ? iam.Grant.addToPrincipalOrResource({
+          actions,
+          grantee,
+          resourceArns,
+          resource: this.policyResource,
+        })
+      : iam.Grant.addToPrincipal({
+          actions,
+          grantee,
+          resourceArns,
+        });
+
+    this.encryptedResource?.grantOnKey(
+      grantee,
+      'kms:Decrypt',
+      'kms:GenerateDataKey*'
+    );
+
+    return result;
+  }
+
+  /**
+   * Grant topic subscribing permissions to the given identity
+   */
+  public subscribe(grantee: iam.IGrantable): iam.Grant {
+    const actions = ['sns:Subscribe'];
+    const resourceArns = [this.resource.topicArn];
+
+    return this.policyResource
+      ? iam.Grant.addToPrincipalOrResource({
+          actions,
+          grantee,
+          resourceArns,
+          resource: this.policyResource,
+        })
+      : iam.Grant.addToPrincipal({
+          actions,
+          grantee,
+          resourceArns,
+        });
+  }
+}

--- a/src/aws/notify/subscription.ts
+++ b/src/aws/notify/subscription.ts
@@ -6,7 +6,7 @@ import { DeliveryPolicy } from "./delivery-policy";
 import { SubscriptionFilter } from "./subscription-filter";
 import { ITopic } from "./topic-base";
 import { ValidationError } from "../../errors";
-import { AwsConstructBase, AwsConstructProps } from "../aws-construct";
+import { AwsConstructBase } from "../aws-construct";
 import * as iam from "../iam";
 import * as notify from "../notify";
 
@@ -23,7 +23,7 @@ export interface SubscriptionOutputs {
 /**
  * Options for creating a new subscription
  */
-export interface SubscriptionOptions extends AwsConstructProps {
+export interface SubscriptionOptions {
   /**
    * What type of subscription to add.
    */
@@ -62,14 +62,12 @@ export interface SubscriptionOptions extends AwsConstructProps {
     [attribute: string]: FilterOrPolicy;
   };
 
-  // TODO: Cross-region subscriptions might require provider aliases in CDKTF.
-  // The sns_topic_subscription resource itself doesn't have a region parameter.
-  // /**
-  //  * The region where the topic resides, in the case of cross-region subscriptions
-  //  * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-region
-  //  * @default - the region where the stack is being deployed.
-  //  */
-  // readonly region?: string;
+  /**
+   * The region where the topic resides, in the case of cross-region subscriptions
+   * @link https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-sns-subscription.html#cfn-sns-subscription-region
+   * @default - the region where the stack is being deployed.
+   */
+  readonly region?: string;
 
   /**
    * Queue to be used as dead letter queue.
@@ -221,8 +219,8 @@ export class Subscription extends AwsConstructBase {
         redrivePolicy: redrivePolicyJson,
         subscriptionRoleArn: props.subscriptionRoleArn,
         deliveryPolicy: deliveryPolicyJson,
-        // TODO: Bump to newer provider-aws version to get 'region' property support
-        // region: props.topic.stack.region,
+        region:
+          props.region ?? props.topic.env.region ?? props.topic.stack.region,
         // confirmationTimeoutInMinutes: // Not directly available in CDK props
         // endpointAutoConfirms: // Not directly available in CDK props
         // replayPolicy: // Not directly available in CDK props (missing in AWS CDK)


### PR DESCRIPTION
This will allow the user to set the `fifoThroughputScope` config in a SNS topic. Additionally, the `region` config will be available when creating a SNS topic subscription.

Implements: #32 

Related to: #35 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.