### PR TITLE
fix(aws/notify): Wrong Event Bus in EventBridge Rule with target

### DIFF
--- a/src/aws/notify/rule.ts
+++ b/src/aws/notify/rule.ts
@@ -176,6 +176,8 @@ export class Rule extends AwsConstructBase implements IRule {
 
   private readonly scheduleExpression?: string;
   private readonly description?: string;
+  private readonly eventBusName?: string;
+
   constructor(scope: Construct, name: string, props: RuleProps = {}) {
     super(scope, name, props);
 
@@ -195,6 +197,7 @@ export class Rule extends AwsConstructBase implements IRule {
     }
     this.description = props.description;
     this.scheduleExpression = props.schedule?.expressionString;
+    this.eventBusName = props.eventBus?.eventBusName;
 
     // add a warning on synth when minute is not defined in a cron schedule
     props.schedule?._bind(this);
@@ -218,7 +221,7 @@ export class Rule extends AwsConstructBase implements IRule {
         }),
         // terraform-provider-aws separates targets to different resources.
         // targets: Lazy.anyValue({ produce: () => this.renderTargets() }),
-        eventBusName: props.eventBus?.eventBusName,
+        eventBusName: this.eventBusName,
         dependsOn: props.dependsOn,
       },
     );
@@ -330,6 +333,7 @@ export class Rule extends AwsConstructBase implements IRule {
       targetId,
       roleArn: targetProps.role?.roleArn,
       rule: this.resource.name,
+      eventBusName: this.eventBusName, // If omitted, it will use `default` event bus
       arn: targetProps.arn,
       ecsTarget: targetProps.ecsParameters,
       httpTarget: targetProps.httpParameters,

--- a/test/aws/notify/rule.test.ts
+++ b/test/aws/notify/rule.test.ts
@@ -808,6 +808,37 @@ describe("rule", () => {
     ).toThrow(/Cannot associate rule with 'eventBus' when using 'schedule'/);
   });
 
+  test("event bus name is present in target props", () => {
+    // GIVEN
+    const eventBus = new EventBus(stack, "EventBus");
+
+    // WHEN
+    const rule = new Rule(stack, "MyRule", {
+      eventPattern: {
+        detail: ["detail"],
+      },
+      eventBus,
+      targets: [new SomeTarget()],
+    });
+
+    // THEN
+    const t = new Template(stack);
+    t.expect.toHaveResourceWithProperties(
+      cloudwatchEventRule.CloudwatchEventRule,
+      {
+        event_bus_name: stack.resolve(eventBus.eventBusName),
+      },
+    );
+    t.expect.toHaveResourceWithProperties(
+      cloudwatchEventTarget.CloudwatchEventTarget,
+      {
+        arn: "ARN1",
+        rule: stack.resolve(rule.ruleName),
+        event_bus_name: stack.resolve(eventBus.eventBusName),
+      },
+    );
+  });
+
   test("allow an imported target if is in the same account and region", () => {
     const sourceAccount = "123456789012";
     const sourceRegion = "us-west-2";

--- a/test/aws/notify/targets/function.test.ts
+++ b/test/aws/notify/targets/function.test.ts
@@ -5,6 +5,7 @@ import {
   cloudwatchEventTarget,
   dataAwsIamPolicyDocument,
   sqsQueuePolicy,
+  cloudwatchEventRule,
 } from "@cdktf/provider-aws";
 import { Testing, App } from "cdktf";
 import { Construct } from "constructs";
@@ -69,6 +70,10 @@ describe("LambdaFunction as an event rule target", () => {
       principal: "events.amazonaws.com",
       source_arn: "${aws_cloudwatch_event_rule.Rule2_70732244.arn}",
     });
+    Template.resources(
+      stack,
+      cloudwatchEventRule.CloudwatchEventRule,
+    ).toHaveLength(2);
     template.toHaveResourceWithProperties(
       cloudwatchEventTarget.CloudwatchEventTarget,
       {
@@ -85,34 +90,6 @@ describe("LambdaFunction as an event rule target", () => {
         arn: lambdaArn,
       },
     );
-
-    // .hasResourceProperties("AWS::Lambda::Permission", {
-    //   Action: "lambda:InvokeFunction",
-    //   FunctionName: {
-    //     "Fn::GetAtt": [lambdaId, "Arn"],
-    //   },
-    //   Principal: "events.amazonaws.com",
-    //   SourceArn: { "Fn::GetAtt": ["Rule4C995B7F", "Arn"] },
-    // });
-
-    // .hasResourceProperties("AWS::Lambda::Permission", {
-    //   Action: "lambda:InvokeFunction",
-    //   FunctionName: {
-    //     "Fn::GetAtt": [lambdaId, "Arn"],
-    //   },
-    //   Principal: "events.amazonaws.com",
-    //   SourceArn: { "Fn::GetAtt": ["Rule270732244", "Arn"] },
-    // });
-
-    // .resourceCountIs("AWS::Events::Rule", 2);
-    // .hasResourceProperties("AWS::Events::Rule", {
-    //   Targets: [
-    //     {
-    //       Arn: { "Fn::GetAtt": [lambdaId, "Arn"] },
-    //       Id: "Target0",
-    //     },
-    //   ],
-    // });
   });
 
   test("adding same lambda function as target mutiple times creates permission only once", () => {


### PR DESCRIPTION
The property `event_bus_name` is missing when creating a `cloudwatch_event_target` resource in AWS.

Fixes: https://github.com/TerraConstructs/base/issues/88


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.