### PR TITLE
feat(aws/compute): Allow import from lookup of VPC

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -1,6 +1,11 @@
 {
   "dependencies": [
     {
+      "name": "@aws-cdk/cloud-assembly-schema",
+      "version": "^49.4.0",
+      "type": "build"
+    },
+    {
       "name": "@aws-cdk/region-info",
       "version": "^2.233.0",
       "type": "build"
@@ -189,6 +194,11 @@
       "name": "minimatch",
       "version": "^3.1.2",
       "type": "bundled"
+    },
+    {
+      "name": "@aws-cdk/cloud-assembly-schema",
+      "version": "^49.4.0",
+      "type": "peer"
     },
     {
       "name": "@aws-cdk/region-info",

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -271,7 +271,7 @@
           "exec": "pnpm i --no-frozen-lockfile"
         },
         {
-          "exec": "pnpm update @aws-cdk/region-info @cdktf/provider-archive @cdktf/provider-aws @cdktf/provider-cloudinit @cdktf/provider-docker @cdktf/provider-time @cdktf/provider-tls @jsii/spec @mrgrain/jsii-struct-builder @types/jest @types/mime-types @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser cdktf commit-and-tag-version constructs delay eslint-config-prettier eslint-import-resolver-typescript eslint-plugin-import eslint fast-check jest jest-junit jsii-diff jsii-pacmak jsii-rosetta jsii projen ts-jest ts-node typescript @balena/dockerignore change-case esbuild-wasm ignore mime-types minimatch"
+          "exec": "pnpm update @aws-cdk/cloud-assembly-schema @aws-cdk/region-info @cdktf/provider-archive @cdktf/provider-aws @cdktf/provider-cloudinit @cdktf/provider-docker @cdktf/provider-time @cdktf/provider-tls @jsii/spec @mrgrain/jsii-struct-builder @types/jest @types/mime-types @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser cdktf commit-and-tag-version constructs delay eslint-config-prettier eslint-import-resolver-typescript eslint-plugin-import eslint fast-check jest jest-junit jsii-diff jsii-pacmak jsii-rosetta jsii projen ts-jest ts-node typescript @balena/dockerignore change-case esbuild-wasm ignore mime-types minimatch"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -59,6 +59,7 @@ const project = new cdk.JsiiProject({
     "@cdktf/provider-cloudinit@^11.0.0",
     "@cdktf/provider-docker@^12.0.2",
     "constructs@^10.4.2",
+    "@aws-cdk/cloud-assembly-schema@^49.4.0",
     "@aws-cdk/region-info@^2.233.0",
   ],
   devDeps: [
@@ -70,6 +71,7 @@ const project = new cdk.JsiiProject({
     "@cdktf/provider-cloudinit@^11.0.0",
     "@cdktf/provider-docker@^12.0.2",
     "constructs@^10.4.2",
+    "@aws-cdk/cloud-assembly-schema@^49.4.0",
     "@aws-cdk/region-info@^2.233.0",
     "@jsii/spec@^1.102.0",
     "@mrgrain/jsii-struct-builder",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "organization": false
   },
   "devDependencies": {
+    "@aws-cdk/cloud-assembly-schema": "49.4.0",
     "@aws-cdk/region-info": "2.233.0",
     "@cdktf/provider-archive": "11.0.0",
     "@cdktf/provider-aws": "21.22.0",
@@ -70,6 +71,7 @@
     "typescript": "~5.9"
   },
   "peerDependencies": {
+    "@aws-cdk/cloud-assembly-schema": "^49.4.0",
     "@aws-cdk/region-info": "^2.233.0",
     "@cdktf/provider-archive": "^11.0.0",
     "@cdktf/provider-aws": "^21.22.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,6 +30,9 @@ importers:
         specifier: ^3.1.2
         version: 3.1.2
     devDependencies:
+      '@aws-cdk/cloud-assembly-schema':
+        specifier: 49.4.0
+        version: 49.4.0
       '@aws-cdk/region-info':
         specifier: 2.233.0
         version: 2.233.0
@@ -65,7 +68,7 @@ importers:
         version: 2.1.4
       '@types/node':
         specifier: ts5.9
-        version: 25.0.3
+        version: 25.0.8
       '@typescript-eslint/eslint-plugin':
         specifier: ^8
         version: 8.51.0(@typescript-eslint/parser@8.51.0(eslint@9.39.2)(typescript@5.9.3))(eslint@9.39.2)(typescript@5.9.3)
@@ -104,7 +107,7 @@ importers:
         version: 3.23.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.0.3)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+        version: 29.7.0(@types/node@25.0.8)(ts-node@10.9.2(@types/node@25.0.8)(typescript@5.9.3))
       jest-junit:
         specifier: ^16
         version: 16.0.0
@@ -128,10 +131,10 @@ importers:
         version: 0.98.32(constructs@10.4.2)
       ts-jest:
         specifier: ^29.4.6
-        version: 29.4.6(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.0.3)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.6(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.0.8)(ts-node@10.9.2(@types/node@25.0.8)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@25.0.3)(typescript@5.9.3)
+        version: 10.9.2(@types/node@25.0.8)(typescript@5.9.3)
       typescript:
         specifier: ~5.9
         version: 5.9.3
@@ -141,6 +144,13 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@aws-cdk/cloud-assembly-schema@49.4.0':
+    resolution: {integrity: sha512-gZh5tHe5mtTuwWj92Hso2j1FKo7yYzRg72bKn2QfL3Nm6JRkATZKQ1uRlIR1VZcU/cN19YxeLF1Ud7ag72rbRg==}
+    engines: {node: '>= 18.0.0'}
+    bundledDependencies:
+      - jsonschema
+      - semver
 
   '@aws-cdk/region-info@2.233.0':
     resolution: {integrity: sha512-6RIkgymaJ7UvfkbvwQV3DJmm+Xa2NiRyblZpNYT/5IymFQY17pjcDjfgvjGdhusJnOxXvVJP7F529n8vGAQc1w==}
@@ -620,8 +630,8 @@ packages:
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
-  '@types/node@25.0.3':
-    resolution: {integrity: sha512-W609buLVRVmeW693xKfzHeIV6nJGGz98uCPfeXI1ELMLXVeKYZ9m15fAMSaUPBHYLGFsVRcMmSCksQOrZV9BYA==}
+  '@types/node@25.0.8':
+    resolution: {integrity: sha512-powIePYMmC3ibL0UJ2i2s0WIbq6cg6UyVFQxSCpaPxxzAaziRfimGivjdF943sSGV6RADVbk0Nvlm5P/FB44Zg==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -3320,6 +3330,8 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
+  '@aws-cdk/cloud-assembly-schema@49.4.0': {}
+
   '@aws-cdk/region-info@2.233.0': {}
 
   '@babel/code-frame@7.24.7':
@@ -3632,27 +3644,27 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.0.3
+      '@types/node': 25.0.8
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@25.0.8)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.0.3
+      '@types/node': 25.0.8
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@25.0.3)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@25.0.8)(ts-node@10.9.2(@types/node@25.0.8)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -3677,7 +3689,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.0.3
+      '@types/node': 25.0.8
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -3695,7 +3707,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 25.0.3
+      '@types/node': 25.0.8
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -3717,7 +3729,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 25.0.3
+      '@types/node': 25.0.8
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -3787,7 +3799,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 25.0.3
+      '@types/node': 25.0.8
       '@types/yargs': 17.0.33
       chalk: 4.1.2
 
@@ -3900,7 +3912,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 25.0.3
+      '@types/node': 25.0.8
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -3925,7 +3937,7 @@ snapshots:
 
   '@types/minimist@1.2.5': {}
 
-  '@types/node@25.0.3':
+  '@types/node@25.0.8':
     dependencies:
       undici-types: 7.16.0
 
@@ -4575,13 +4587,13 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  create-jest@29.7.0(@types/node@25.0.3)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)):
+  create-jest@29.7.0(@types/node@25.0.8)(ts-node@10.9.2(@types/node@25.0.8)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.0.3)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@25.0.8)(ts-node@10.9.2(@types/node@25.0.8)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -4917,7 +4929,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2))(eslint@9.39.2):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -4939,7 +4951,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.51.0(eslint@9.39.2)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2))(eslint@9.39.2)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -5620,7 +5632,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.0.3
+      '@types/node': 25.0.8
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -5640,16 +5652,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@25.0.3)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)):
+  jest-cli@29.7.0(@types/node@25.0.8)(ts-node@10.9.2(@types/node@25.0.8)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.0.8)(typescript@5.9.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.0.3)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      create-jest: 29.7.0(@types/node@25.0.8)(ts-node@10.9.2(@types/node@25.0.8)(typescript@5.9.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.0.3)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@25.0.8)(ts-node@10.9.2(@types/node@25.0.8)(typescript@5.9.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -5659,7 +5671,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@25.0.3)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)):
+  jest-config@29.7.0(@types/node@25.0.8)(ts-node@10.9.2(@types/node@25.0.8)(typescript@5.9.3)):
     dependencies:
       '@babel/core': 7.25.2
       '@jest/test-sequencer': 29.7.0
@@ -5684,8 +5696,8 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 25.0.3
-      ts-node: 10.9.2(@types/node@25.0.3)(typescript@5.9.3)
+      '@types/node': 25.0.8
+      ts-node: 10.9.2(@types/node@25.0.8)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -5714,7 +5726,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.0.3
+      '@types/node': 25.0.8
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -5724,7 +5736,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 25.0.3
+      '@types/node': 25.0.8
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -5770,7 +5782,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.0.3
+      '@types/node': 25.0.8
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -5805,7 +5817,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.0.3
+      '@types/node': 25.0.8
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -5833,7 +5845,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.0.3
+      '@types/node': 25.0.8
       chalk: 4.1.2
       cjs-module-lexer: 1.3.1
       collect-v8-coverage: 1.0.2
@@ -5879,7 +5891,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 25.0.3
+      '@types/node': 25.0.8
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -5898,7 +5910,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 25.0.3
+      '@types/node': 25.0.8
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -5907,17 +5919,17 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 25.0.3
+      '@types/node': 25.0.8
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@25.0.3)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)):
+  jest@29.7.0(@types/node@25.0.8)(ts-node@10.9.2(@types/node@25.0.8)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@25.0.8)(typescript@5.9.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.0.3)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      jest-cli: 29.7.0(@types/node@25.0.8)(ts-node@10.9.2(@types/node@25.0.8)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -6832,12 +6844,12 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.4.6(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.0.3)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.6(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest-util@29.7.0)(jest@29.7.0(@types/node@25.0.8)(ts-node@10.9.2(@types/node@25.0.8)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.8
-      jest: 29.7.0(@types/node@25.0.3)(ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@25.0.8)(ts-node@10.9.2(@types/node@25.0.8)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -6852,14 +6864,14 @@ snapshots:
       babel-jest: 29.7.0(@babel/core@7.25.2)
       jest-util: 29.7.0
 
-  ts-node@10.9.2(@types/node@25.0.3)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@25.0.8)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 25.0.3
+      '@types/node': 25.0.8
       acorn: 8.12.1
       acorn-walk: 8.3.3
       arg: 4.1.3

--- a/src/aws/aws-stack.ts
+++ b/src/aws/aws-stack.ts
@@ -1,3 +1,4 @@
+import * as cxschema from "@aws-cdk/cloud-assembly-schema";
 import { Fact, RegionInfo } from "@aws-cdk/region-info";
 import {
   dataAwsAvailabilityZones,
@@ -156,6 +157,13 @@ export class AwsStack extends StackBase implements IAwsStack {
   private regionalAwsProviders: { [region: string]: provider.AwsProvider } = {};
 
   /**
+   * Lists all missing contextual information.
+   * This is returned when the stack is synthesized under the 'missing' attribute
+   * and allows tooling to obtain the context and re-synthesize.
+   */
+  private readonly _missingContext: cxschema.MissingContext[];
+
+  /**
    * Cache these tokens for reliable comparisons.
    *
    * Every call for the same Token will produce a new unique string, no
@@ -180,6 +188,7 @@ export class AwsStack extends StackBase implements IAwsStack {
     //   "cdktf:stack",
     //   props.providerConfig.defaultTags,
     // );
+    this._missingContext = new Array<cxschema.MissingContext>();
     this._providerConfig = props.providerConfig;
     this._assetOptions = props.assetOptions;
     this._assetManager = props.assetManager;
@@ -535,6 +544,18 @@ export class AwsStack extends StackBase implements IAwsStack {
   //   // ref: https://github.com/aws/aws-cdk/blob/v2.150.0/packages/aws-cdk-lib/core/lib/stack.ts#L572
   //   return resolve(this, obj);
   // }
+
+  /**
+   * Indicate that a context key was expected
+   *
+   * Contains instructions which will be emitted into the cloud assembly on how
+   * the key should be supplied.
+   *
+   * @param report The set of parameters needed to obtain the context
+   */
+  public reportMissingContextKey(report: cxschema.MissingContext) {
+    this._missingContext.push(report);
+  }
 
   /**
    * Look up a fact value for the given fact for the region of this stack

--- a/src/aws/compute/route.ts
+++ b/src/aws/compute/route.ts
@@ -1084,6 +1084,7 @@ function routerTypeToPropName(routerType: RouterType) {
     [RouterType.TRANSIT_GATEWAY]: "transitGatewayId",
     [RouterType.VPC_PEERING_CONNECTION]: "vpcPeeringConnectionId",
     [RouterType.VPC_ENDPOINT]: "vpcEndpointId",
+    [RouterType.CORE_NETWORK]: "coreNetworkArn",
   };
   return lookupMap[routerType];
 }

--- a/src/aws/compute/vpc.ts
+++ b/src/aws/compute/vpc.ts
@@ -1,5 +1,6 @@
-// https://github.com/aws/aws-cdk/blob/v2.175.1/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/aws-cdk-lib/aws-ec2/lib/vpc.ts
 
+import * as cxschema from "@aws-cdk/cloud-assembly-schema";
 import {
   eip,
   egressOnlyInternetGateway,
@@ -16,9 +17,9 @@ import {
   vpnGatewayAttachment,
   vpnGatewayRoutePropagation,
   dataAwsSubnet,
+  dataAwsVpc,
 } from "@cdktf/provider-aws";
 import {
-  // ContextProvider,
   // CustomResource,
   // FeatureFlags,
   Annotations,
@@ -69,7 +70,7 @@ import {
   InterfaceVpcEndpointOptions,
 } from "./vpc-endpoint";
 import { FlowLog, FlowLogOptions, FlowLogResourceType } from "./vpc-flow-logs";
-// import { VpcLookupOptions } from "./vpc-lookup";
+import { VpcLookupOptions } from "./vpc-lookup";
 import {
   EnableVpnGatewayOptions,
   VpnConnection,
@@ -77,11 +78,14 @@ import {
   VpnConnectionType,
   VpnGateway,
 } from "./vpn";
+import { UnscopedValidationError, ValidationError } from "../../errors";
 import { Arn } from "../arn";
 import { AwsConstructBase, IAwsConstruct } from "../aws-construct";
 import { AwsStack } from "../aws-stack";
-// TODO: Use TagManager and tag-aspect instead
 import { Tags } from "../aws-tags";
+import { ContextProvider } from "../context-provider";
+import * as cxapi from "../cx-api";
+// TODO: Use TagManager and tag-aspect instead
 // import { Tags } from "../tag-aspect";
 
 const VPC_SUBNET_SYMBOL = Symbol.for(
@@ -617,21 +621,6 @@ abstract class VpcBase extends AwsConstructBase implements IVpc {
    */
   public abstract readonly internetConnectivityEstablished: IDependable;
 
-  public get vpcOutputs(): VpcOutputs {
-    return {
-      availabilityZones: this.availabilityZones,
-      isolatedSubnetIds: this.isolatedSubnets.map((s) => s.subnetId),
-      privateSubnetIds: this.privateSubnets.map((s) => s.subnetId),
-      publicSubnetIds: this.publicSubnets.map((s) => s.subnetId),
-      vpcArn: this.vpcArn,
-      vpcCidrBlock: this.vpcCidrBlock,
-      vpcId: this.vpcId,
-      vpnGatewayId: this.vpnGatewayId,
-    };
-  }
-  public get outputs(): Record<string, any> {
-    return this.vpcOutputs;
-  }
   /**
    * Dependencies for NAT connectivity
    *
@@ -650,6 +639,22 @@ abstract class VpcBase extends AwsConstructBase implements IVpc {
    * @internal
    */
   protected _vpnGatewayId?: string;
+
+  public get vpcOutputs(): VpcOutputs {
+    return {
+      availabilityZones: this.availabilityZones,
+      isolatedSubnetIds: this.isolatedSubnets.map((s) => s.subnetId),
+      privateSubnetIds: this.privateSubnets.map((s) => s.subnetId),
+      publicSubnetIds: this.publicSubnets.map((s) => s.subnetId),
+      vpcArn: this.vpcArn,
+      vpcCidrBlock: this.vpcCidrBlock,
+      vpcId: this.vpcId,
+      vpnGatewayId: this.vpnGatewayId,
+    };
+  }
+  public get outputs(): Record<string, any> {
+    return this.vpcOutputs;
+  }
 
   /**
    * Returns IDs of selected subnets
@@ -677,7 +682,10 @@ abstract class VpcBase extends AwsConstructBase implements IVpc {
    */
   public enableVpnGateway(options: EnableVpnGatewayOptions): void {
     if (this.vpnGatewayId) {
-      throw new Error("The VPN Gateway has already been enabled.");
+      throw new ValidationError(
+        "The VPN Gateway has already been enabled.",
+        this,
+      );
     }
 
     const vpnGateway = new VpnGateway(this, "VpnGateway", {
@@ -847,8 +855,9 @@ abstract class VpcBase extends AwsConstructBase implements IVpc {
       const names = Array.from(
         new Set(allSubnets.map(subnetGroupNameFromConstructId)),
       );
-      throw new Error(
+      throw new ValidationError(
         `There are no subnet groups with name '${groupName}' in this VPC. Available names: ${names}`,
+        this,
       );
     }
 
@@ -874,8 +883,9 @@ abstract class VpcBase extends AwsConstructBase implements IVpc {
       const availableTypes = Object.entries(allSubnets)
         .filter(([_, subs]) => subs.length > 0)
         .map(([typeName, _]) => typeName);
-      throw new Error(
+      throw new ValidationError(
         `There are no '${subnetType}' subnet groups in this VPC. Available types: ${availableTypes}`,
+        this,
       );
     }
 
@@ -891,8 +901,9 @@ abstract class VpcBase extends AwsConstructBase implements IVpc {
   private reifySelectionDefaults(placement: SubnetSelection): SubnetSelection {
     if (placement.subnetName !== undefined) {
       if (placement.subnetGroupName !== undefined) {
-        throw new Error(
+        throw new ValidationError(
           "Please use only 'subnetGroupName' ('subnetName' is deprecated and has the same behavior)",
+          this,
         );
       } else {
         // "@aws-cdk/aws-ec2:subnetNameDeprecated",
@@ -912,8 +923,9 @@ abstract class VpcBase extends AwsConstructBase implements IVpc {
       (key) => placement[key] !== undefined,
     );
     if (providedSelections.length > 1) {
-      throw new Error(
+      throw new ValidationError(
         `Only one of '${providedSelections}' can be supplied to subnet selection.`,
+        this,
       );
     }
 
@@ -1125,8 +1137,17 @@ export interface SubnetAttributes {
 
   /**
    * The subnetId for this particular subnet
+   *
+   * You must specify either this property or the `subnetName` property.
    */
-  readonly subnetId: string;
+  readonly subnetId?: string;
+
+  /**
+   * The subnetName for this particular subnet
+   *
+   * You must specify either this property or the `subnetId` property.
+   */
+  readonly subnetName?: string;
 
   /**
    * Whether to register Terraform outputs for this TerraConstruct
@@ -1521,6 +1542,12 @@ export interface SubnetConfiguration {
  */
 export class Vpc extends VpcBase {
   /**
+   * Uniquely identifies this class.
+   */
+  public static readonly PROPERTY_INJECTION_ID: string =
+    "terraconstructs.aws.ec2.Vpc";
+
+  /**
    * The default CIDR range used when creating VPCs.
    * This can be overridden using VpcProps when creating a VPCNetwork resource.
    * e.g. new Vpc(this, { cidr: '192.168.0.0./16' })
@@ -1569,9 +1596,10 @@ export class Vpc extends VpcBase {
    * constructs that need a list of subnets (like `AutoScalingGroup` and `eks.Cluster`)
    * but it does not work for constructs that need individual subnets (like`Instance`).
    * See https://github.com/aws/aws-cdk/issues/4118 for more information.
+   *
+   * Prefer to use `Vpc.fromLookup()` instead.
    */
   public static fromVpcAttributes(
-    // TODO: Prefer to use `Vpc.fromLookup()` instead.
     scope: Construct,
     id: string,
     attrs: VpcAttributes,
@@ -1579,95 +1607,106 @@ export class Vpc extends VpcBase {
     return new ImportedVpc(scope, id, attrs, false);
   }
 
-  // TODO: Add Grid Lookup support
-  // /**
-  //  * Import an existing VPC by querying the AWS environment this stack is deployed to.
-  //  *
-  //  * This function only needs to be used to use VPCs not defined in your CDK
-  //  * application. If you are looking to share a VPC between stacks, you can
-  //  * pass the `Vpc` object between stacks and use it as normal.
-  //  *
-  //  * Calling this method will lead to a lookup when the CDK CLI is executed.
-  //  * You can therefore not use any values that will only be available at
-  //  * CloudFormation execution time (i.e., Tokens).
-  //  *
-  //  * The VPC information will be cached in `cdk.context.json` and the same VPC
-  //  * will be used on future runs. To refresh the lookup, you will have to
-  //  * evict the value from the cache using the `cdk context` command. See
-  //  * https://docs.aws.amazon.com/cdk/latest/guide/context.html for more information.
-  //  */
-  // public static fromLookup(
-  //   scope: Construct,
-  //   id: string,
-  //   options: VpcLookupOptions,
-  // ): IVpc {
-  //   if (
-  //     Token.isUnresolved(options.vpcId) ||
-  //     Token.isUnresolved(options.vpcName) ||
-  //     Object.values(options.tags || {}).some(Token.isUnresolved) ||
-  //     Object.keys(options.tags || {}).some(Token.isUnresolved)
-  //   ) {
-  //     throw new Error(
-  //       "All arguments to Vpc.fromLookup() must be concrete (no Tokens)",
-  //     );
-  //   }
+  /**
+   * Import an existing VPC by querying the AWS environment this stack is deployed to.
+   *
+   * This function only needs to be used to use VPCs not defined in your CDK
+   * application. If you are looking to share a VPC between stacks, you can
+   * pass the `Vpc` object between stacks and use it as normal.
+   *
+   * Calling this method will lead to a lookup when the CDK CLI is executed.
+   * You can therefore not use any values that will only be available at
+   * Terraform execution time (i.e., Tokens).
+   */
+  public static fromLookup(
+    scope: Construct,
+    id: string,
+    options: VpcLookupOptions,
+  ): IVpc {
+    if (
+      Token.isUnresolved(options.vpcId) ||
+      Token.isUnresolved(options.vpcName) ||
+      Object.values(options.tags || {}).some(Token.isUnresolved) ||
+      Object.keys(options.tags || {}).some(Token.isUnresolved)
+    ) {
+      throw new ValidationError(
+        "All arguments to Vpc.fromLookup() must be concrete (no Tokens)",
+        scope,
+      );
+    }
 
-  //   const filter: { [key: string]: string } = makeTagFilter(options.tags);
+    const filter: { [key: string]: string } = makeTagFilter(options.tags);
 
-  //   // We give special treatment to some tags
-  //   if (options.vpcId) {
-  //     filter["vpc-id"] = options.vpcId;
-  //   }
-  //   if (options.vpcName) {
-  //     filter["tag:Name"] = options.vpcName;
-  //   }
-  //   if (options.ownerAccountId) {
-  //     filter["owner-id"] = options.ownerAccountId;
-  //   }
-  //   if (options.isDefault !== undefined) {
-  //     filter.isDefault = options.isDefault ? "true" : "false";
-  //   }
+    // We give special treatment to some tags
+    if (options.vpcId) {
+      filter["vpc-id"] = options.vpcId;
+    }
+    if (options.vpcName) {
+      filter["tag:Name"] = options.vpcName;
+    }
+    if (options.ownerAccountId) {
+      filter["owner-id"] = options.ownerAccountId;
+    }
+    if (options.isDefault !== undefined) {
+      filter.isDefault = options.isDefault ? "true" : "false";
+    }
 
-  //   const overrides: { [key: string]: string } = {};
-  //   if (options.region) {
-  //     overrides.region = options.region;
-  //   }
+    const overrides: { [key: string]: string } = {};
+    if (options.region) {
+      overrides.region = options.region;
+    }
 
-  //   const attributes: cxapi.VpcContextResponse = ContextProvider.getValue(
-  //     scope,
-  //     {
-  //       provider: cxschema.ContextProvider.VPC_PROVIDER,
-  //       props: {
-  //         ...overrides,
-  //         filter,
-  //         returnAsymmetricSubnets: true,
-  //         returnVpnGateways: options.returnVpnGateways,
-  //         subnetGroupNameTag: options.subnetGroupNameTag,
-  //       } as cxschema.VpcContextQuery,
-  //       dummyValue: undefined,
-  //     },
-  //   ).value;
+    // TODO: Use context provider in the future
+    let attributes: cxapi.VpcContextResponse = ContextProvider.getValue(scope, {
+      provider: cxschema.ContextProvider.VPC_PROVIDER,
+      props: {
+        ...overrides,
+        filter,
+        returnAsymmetricSubnets: true,
+        returnVpnGateways: options.returnVpnGateways,
+        subnetGroupNameTag: options.subnetGroupNameTag,
+      } as cxschema.VpcContextQuery,
+      dummyValue: undefined,
+    }).value;
 
-  //   return new LookedUpVpc(
-  //     scope,
-  //     id,
-  //     attributes ?? DUMMY_VPC_PROPS,
-  //     attributes === undefined,
-  //   );
+    const isIncomplete = attributes === undefined;
+    if (isIncomplete) {
+      const data = new dataAwsVpc.DataAwsVpc(scope, "Data" + id, {
+        region: options.region,
+        filter: Object.entries(filter).map(([key, value]) => ({
+          name: key,
+          values: [value],
+        })),
+      });
+      const stack = AwsStack.ofAwsConstruct(scope);
+      attributes = {
+        vpcId: data.id,
+        vpcCidrBlock: data.cidrBlock,
+        availabilityZones: stack.availabilityZones(),
+        region: options.region,
+      };
+    }
 
-  //   /**
-  //    * Prefixes all keys in the argument with `tag:`.`
-  //    */
-  //   function makeTagFilter(tags: { [name: string]: string } | undefined): {
-  //     [name: string]: string;
-  //   } {
-  //     const result: { [name: string]: string } = {};
-  //     for (const [name, value] of Object.entries(tags || {})) {
-  //       result[`tag:${name}`] = value;
-  //     }
-  //     return result;
-  //   }
-  // }
+    return new LookedUpVpc(
+      scope,
+      id,
+      attributes ?? DUMMY_VPC_PROPS,
+      isIncomplete,
+    );
+
+    /**
+     * Prefixes all keys in the argument with `tag:`.`
+     */
+    function makeTagFilter(tags: { [name: string]: string } | undefined): {
+      [name: string]: string;
+    } {
+      const result: { [name: string]: string } = {};
+      for (const [name, value] of Object.entries(tags || {})) {
+        result[`tag:${name}`] = value;
+      }
+      return result;
+    }
+  }
 
   /**
    * Identifier for this VPC
@@ -1812,26 +1851,32 @@ export class Vpc extends VpcBase {
 
     // Can't have enabledDnsHostnames without enableDnsSupport
     if (props.enableDnsHostnames && !props.enableDnsSupport) {
-      throw new Error(
+      throw new ValidationError(
         "To use DNS Hostnames, DNS Support must be enabled, however, it was explicitly disabled.",
+        this,
       );
     }
 
     if (props.availabilityZones && props.maxAzs) {
-      throw new Error(
+      throw new ValidationError(
         "Vpc supports 'availabilityZones' or 'maxAzs', but not both.",
+        this,
       );
     }
 
     const cidrBlock = ifUndefined(props.cidr, Vpc.DEFAULT_CIDR_RANGE);
     if (Token.isUnresolved(cidrBlock)) {
-      throw new Error(
+      throw new ValidationError(
         "'cidr' property must be a concrete CIDR string, got a Token (we need to parse it for automatic subdivision)",
+        this,
       );
     }
 
     if (props.ipAddresses && props.cidr) {
-      throw new Error("supply at most one of ipAddresses or cidr");
+      throw new ValidationError(
+        "supply at most one of ipAddresses or cidr",
+        this,
+      );
     }
 
     const ipProtocol = props.ipProtocol ?? IpProtocol.IPV4_ONLY;
@@ -1846,8 +1891,9 @@ export class Vpc extends VpcBase {
     if (!this.useIpv6) {
       for (const prop of ipv6OnlyProps) {
         if (props[prop] !== undefined) {
-          throw new Error(
+          throw new ValidationError(
             `${prop} can only be set if IPv6 is enabled. Set ipProtocol to DUAL_STACK`,
+            this,
           );
         }
       }
@@ -1895,8 +1941,9 @@ export class Vpc extends VpcBase {
       //     (az) => Token.isUnresolved(az) || resolvedStackAzs.includes(az),
       //   );
       // if (!areGivenAzsSubsetOfStack) {
-      //   throw new Error(
+      //   throw new ValidationError(
       //     `Given VPC 'availabilityZones' ${props.availabilityZones} must be a subset of the stack's availability zones ${resolvedStackAzs}`,
+      //     this,
       //   );
       // }
       this.availabilityZones = props.availabilityZones;
@@ -2016,8 +2063,9 @@ export class Vpc extends VpcBase {
       this.privateSubnets.length === 0 &&
       this.isolatedSubnets.length === 0
     ) {
-      throw new Error(
+      throw new ValidationError(
         "Can not enable the VPN gateway while the VPC has no subnets at all",
+        this,
       );
     }
 
@@ -2025,8 +2073,9 @@ export class Vpc extends VpcBase {
       (props.vpnConnections || props.vpnGatewayAsn) &&
       props.vpnGateway === false
     ) {
-      throw new Error(
+      throw new ValidationError(
         "Cannot specify `vpnConnections` or `vpnGatewayAsn` when `vpnGateway` is set to false.",
+        this,
       );
     }
 
@@ -2123,8 +2172,9 @@ export class Vpc extends VpcBase {
     ) as PublicSubnet[];
     for (const sub of natSubnets) {
       if (this.publicSubnets.indexOf(sub) === -1) {
-        throw new Error(
+        throw new ValidationError(
           `natGatewayPlacement ${placement} contains non public subnet ${sub}`,
+          this,
         );
       }
     }
@@ -2159,19 +2209,21 @@ export class Vpc extends VpcBase {
     });
 
     if (allocatedSubnets.length != requestedSubnets.length) {
-      throw new Error(
+      throw new ValidationError(
         "Incomplete Subnet Allocation; response array dose not equal input array",
+        this,
       );
     }
 
     if (this.useIpv6) {
       if (this.ipv6SelectedCidr === undefined) {
-        throw new Error(
+        throw new ValidationError(
           "No IPv6 CIDR block associated with this VPC could be found",
+          this,
         );
       }
       if (this.ipv6Addresses === undefined) {
-        throw new Error("No IPv6 IpAddresses were found");
+        throw new ValidationError("No IPv6 IpAddresses were found", this);
       }
       // create the IPv6 CIDR blocks
       const subnetIpv6Cidrs = this.ipv6Addresses.createIpv6CidrBlocks({
@@ -2225,8 +2277,9 @@ export class Vpc extends VpcBase {
         : !this.useIpv6; // changes default based on protocol of vpc
     } else {
       if (subnetConfig.mapPublicIpOnLaunch !== undefined) {
-        throw new Error(
+        throw new ValidationError(
           `${subnetConfig.subnetType} subnet cannot include mapPublicIpOnLaunch parameter`,
+          this,
         );
       }
       return false;
@@ -2259,8 +2312,9 @@ export class Vpc extends VpcBase {
       if (!this.useIpv6) {
         for (const prop of ipv6OnlyProps) {
           if (subnetConfig[prop] !== undefined) {
-            throw new Error(
+            throw new ValidationError(
               `${prop} can only be set if IPv6 is enabled. Set ipProtocol to DUAL_STACK`,
+              this,
             );
           }
         }
@@ -2310,8 +2364,9 @@ export class Vpc extends VpcBase {
           sn = isolatedSubnet;
           break;
         default:
-          throw new Error(
+          throw new ValidationError(
             `Unrecognized subnet type: ${subnetConfig.subnetType}`,
+            this,
           );
       }
 
@@ -2447,6 +2502,12 @@ export interface SubnetProps {
  * @resource aws_subnet
  */
 export class Subnet extends AwsConstructBase implements ISubnet {
+  /**
+   * Uniquely identifies this class.
+   */
+  public static readonly PROPERTY_INJECTION_ID: string =
+    "terraconstructs.aws.ec2.Subnet";
+
   public static isVpcSubnet(x: any): x is Subnet {
     return VPC_SUBNET_SYMBOL in x;
   }
@@ -2618,7 +2679,7 @@ export class Subnet extends AwsConstructBase implements ISubnet {
     });
     r.node.addDependency(gatewayAttachment);
 
-    // Since the 'r' depends on the gateway attachment, just
+    // Since the 'route' depends on the gateway attachment, just
     // depending on the route is enough.
     this._internetConnectivityEstablished.add(r);
   }
@@ -2697,8 +2758,9 @@ export class Subnet extends AwsConstructBase implements ISubnet {
    */
   public addRoute(id: string, options: AddRouteOptions) {
     if (options.destinationCidrBlock && options.destinationIpv6CidrBlock) {
-      throw new Error(
+      throw new ValidationError(
         "Cannot specify both 'destinationCidrBlock' and 'destinationIpv6CidrBlock'",
+        this,
       );
     }
 
@@ -2824,12 +2886,13 @@ export enum RouterType {
    * VPC Endpoint for gateway load balancers
    */
   VPC_ENDPOINT = "VpcEndpoint",
+
+  /**
+   * AWS Network Manager Core Network
+   */
+  CORE_NETWORK = "CoreNetwork",
 }
 
-/**
- * inverse of
- * https://github.com/hashicorp/terraform-provider-aws/blob/v5.87.0/internal/service/ec2/vpc_route.go#L219-L239
- */
 function routerTypeToPropName(routerType: RouterType) {
   const lookupMap: Record<RouterType, keyof route.RouteConfig> = {
     [RouterType.CARRIER_GATEWAY]: "carrierGatewayId",
@@ -2844,6 +2907,7 @@ function routerTypeToPropName(routerType: RouterType) {
     [RouterType.TRANSIT_GATEWAY]: "transitGatewayId",
     [RouterType.VPC_PEERING_CONNECTION]: "vpcPeeringConnectionId",
     [RouterType.VPC_ENDPOINT]: "vpcEndpointId",
+    [RouterType.CORE_NETWORK]: "coreNetworkArn",
   };
   return lookupMap[routerType];
 }
@@ -2858,6 +2922,12 @@ export interface PublicSubnetAttributes extends SubnetAttributes {}
  * Represents a public VPC subnet resource
  */
 export class PublicSubnet extends Subnet implements IPublicSubnet {
+  /**
+   * Uniquely identifies this class.
+   */
+  public static readonly PROPERTY_INJECTION_ID: string =
+    "terraconstructs.aws.ec2.PublicSubnet";
+
   public static fromPublicSubnetAttributes(
     scope: Construct,
     id: string,
@@ -2900,6 +2970,12 @@ export interface PrivateSubnetAttributes extends SubnetAttributes {}
  * Represents a private VPC subnet resource
  */
 export class PrivateSubnet extends Subnet implements IPrivateSubnet {
+  /**
+   * Uniquely identifies this class.
+   */
+  public static readonly PROPERTY_INJECTION_ID: string =
+    "terraconstructs.aws.ec2.PrivateSubnet";
+
   public static fromPrivateSubnetAttributes(
     scope: Construct,
     id: string,
@@ -2918,6 +2994,9 @@ function ifUndefined<T>(value: T | undefined, defaultValue: T): T {
 }
 
 class ImportedVpc extends VpcBase {
+  /** Uniquely identifies this class. */
+  public static readonly PROPERTY_INJECTION_ID: string =
+    "terraconstructs.aws.ec2.ImportedVpc";
   public readonly vpcId: string;
   public readonly vpcArn: string;
   public readonly publicSubnets: ISubnet[];
@@ -3006,123 +3085,135 @@ class ImportedVpc extends VpcBase {
 
   public get vpcCidrBlock(): string {
     if (this.cidr === undefined) {
-      throw new Error(
+      throw new ValidationError(
         "Cannot perform this operation: 'vpcCidrBlock' was not supplied when creating this VPC",
+        this,
       );
     }
     return this.cidr;
   }
 }
 
-// class LookedUpVpc extends VpcBase {
-//   public readonly vpcId: string;
-//   public readonly vpcArn: string;
-//   public readonly internetConnectivityEstablished: IDependable =
-//     new DependencyGroup();
-//   public readonly availabilityZones: string[];
-//   public readonly publicSubnets: ISubnet[];
-//   public readonly privateSubnets: ISubnet[];
-//   public readonly isolatedSubnets: ISubnet[];
-//   private readonly cidr?: string | undefined;
+class LookedUpVpc extends VpcBase {
+  /** Uniquely identifies this class. */
+  public static readonly PROPERTY_INJECTION_ID: string =
+    "terraconstructs.aws.ec2.LookedUpVpc";
+  public readonly vpcId: string;
+  public readonly vpcArn: string;
+  public readonly internetConnectivityEstablished: IDependable =
+    new DependencyGroup();
+  public readonly availabilityZones: string[];
+  public readonly publicSubnets: ISubnet[];
+  public readonly privateSubnets: ISubnet[];
+  public readonly isolatedSubnets: ISubnet[];
+  private readonly cidr?: string | undefined;
 
-//   constructor(
-//     scope: Construct,
-//     id: string,
-//     props: cxapi.VpcContextResponse,
-//     isIncomplete: boolean,
-//   ) {
-//     super(scope, id, {
-//       region: props.region,
-//       account: props.ownerAccountId,
-//     });
+  constructor(
+    scope: Construct,
+    id: string,
+    props: cxapi.VpcContextResponse,
+    isIncomplete: boolean,
+  ) {
+    super(scope, id, {
+      region: props.region,
+      account: props.ownerAccountId,
+    });
 
-//     this.vpcId = props.vpcId;
-//     this.vpcArn = Arn.format(
-//       {
-//         service: "ec2",
-//         resource: "vpc",
-//         resourceName: this.vpcId,
-//         region: this.env.region,
-//         account: this.env.account,
-//       },
-//       AwsStack.ofAwsConstruct(this),
-//     );
-//     this.cidr = props.vpcCidrBlock;
-//     this._vpnGatewayId = props.vpnGatewayId;
-//     this.incompleteSubnetDefinition = isIncomplete;
+    this.vpcId = props.vpcId;
+    this.vpcArn = Arn.format(
+      {
+        service: "ec2",
+        resource: "vpc",
+        resourceName: this.vpcId,
+        region: this.env.region,
+        account: this.env.account,
+      },
+      AwsStack.ofAwsConstruct(this),
+    );
+    this.cidr = props.vpcCidrBlock;
+    this._vpnGatewayId = props.vpnGatewayId;
+    this.incompleteSubnetDefinition = isIncomplete;
 
-//     const subnetGroups = props.subnetGroups || [];
-//     const availabilityZones = Array.from(
-//       new Set<string>(
-//         flatMap(subnetGroups, (subnetGroup) => {
-//           return subnetGroup.subnets.map((subnet) => subnet.availabilityZone);
-//         }),
-//       ),
-//     );
-//     availabilityZones.sort((az1, az2) => az1.localeCompare(az2));
-//     this.availabilityZones = availabilityZones;
+    const subnetGroups = props.subnetGroups || [];
 
-//     this.publicSubnets = this.extractSubnetsOfType(
-//       subnetGroups,
-//       cxapi.VpcSubnetGroupType.PUBLIC,
-//     );
-//     this.privateSubnets = this.extractSubnetsOfType(
-//       subnetGroups,
-//       cxapi.VpcSubnetGroupType.PRIVATE,
-//     );
-//     this.isolatedSubnets = this.extractSubnetsOfType(
-//       subnetGroups,
-//       cxapi.VpcSubnetGroupType.ISOLATED,
-//     );
-//   }
+    const subnetAvailabilityZones = Array.from(
+      new Set<string>(
+        flatMap(subnetGroups, (subnetGroup) =>
+          subnetGroup.subnets.map((sn) => sn.availabilityZone),
+        ),
+      ),
+    );
 
-//   public get vpcCidrBlock(): string {
-//     if (this.cidr === undefined) {
-//       // Value might be cached from an old CLI version, so bumping the CX API protocol to
-//       // force the value to exist would not have helped.
-//       throw new Error(
-//         "Cannot perform this operation: 'vpcCidrBlock' was not found when looking up this VPC. Use a newer version of the CDK CLI and clear the old context value.",
-//       );
-//     }
-//     return this.cidr;
-//   }
+    const availabilityZones =
+      subnetAvailabilityZones.length > 0
+        ? subnetAvailabilityZones
+        : (props.availabilityZones ?? []);
 
-//   private extractSubnetsOfType(
-//     subnetGroups: cxapi.VpcSubnetGroup[],
-//     subnetGroupType: cxapi.VpcSubnetGroupType,
-//   ): ISubnet[] {
-//     return flatMap(
-//       subnetGroups.filter(
-//         (subnetGroup) => subnetGroup.type === subnetGroupType,
-//       ),
-//       (subnetGroup) => this.subnetGroupToSubnets(subnetGroup),
-//     );
-//   }
+    availabilityZones.sort((az1, az2) => az1.localeCompare(az2));
+    this.availabilityZones = availabilityZones;
 
-//   private subnetGroupToSubnets(subnetGroup: cxapi.VpcSubnetGroup): ISubnet[] {
-//     const ret = new Array<ISubnet>();
-//     for (let i = 0; i < subnetGroup.subnets.length; i++) {
-//       const vpcSubnet = subnetGroup.subnets[i];
-//       ret.push(
-//         Subnet.fromSubnetAttributes(this, `${subnetGroup.name}Subnet${i + 1}`, {
-//           availabilityZone: vpcSubnet.availabilityZone,
-//           subnetId: vpcSubnet.subnetId,
-//           routeTableId: vpcSubnet.routeTableId,
-//           ipv4CidrBlock: vpcSubnet.cidr,
-//         }),
-//       );
-//     }
-//     return ret;
-//   }
-// }
+    this.publicSubnets = this.extractSubnetsOfType(
+      subnetGroups,
+      cxapi.VpcSubnetGroupType.PUBLIC,
+    );
+    this.privateSubnets = this.extractSubnetsOfType(
+      subnetGroups,
+      cxapi.VpcSubnetGroupType.PRIVATE,
+    );
+    this.isolatedSubnets = this.extractSubnetsOfType(
+      subnetGroups,
+      cxapi.VpcSubnetGroupType.ISOLATED,
+    );
+  }
 
-// function flatMap<T, U>(xs: T[], fn: (x: T) => U[]): U[] {
-//   const ret = new Array<U>();
-//   for (const x of xs) {
-//     ret.push(...fn(x));
-//   }
-//   return ret;
-// }
+  public get vpcCidrBlock(): string {
+    if (this.cidr === undefined) {
+      // Value might be cached from an old CLI version, so bumping the CX API protocol to
+      // force the value to exist would not have helped.
+      throw new ValidationError(
+        "Cannot perform this operation: 'vpcCidrBlock' was not found when looking up this VPC. Use a newer version of the CDK CLI and clear the old context value.",
+        this,
+      );
+    }
+    return this.cidr;
+  }
+
+  private extractSubnetsOfType(
+    subnetGroups: cxapi.VpcSubnetGroup[],
+    subnetGroupType: cxapi.VpcSubnetGroupType,
+  ): ISubnet[] {
+    return flatMap(
+      subnetGroups.filter(
+        (subnetGroup) => subnetGroup.type === subnetGroupType,
+      ),
+      (subnetGroup) => this.subnetGroupToSubnets(subnetGroup),
+    );
+  }
+
+  private subnetGroupToSubnets(subnetGroup: cxapi.VpcSubnetGroup): ISubnet[] {
+    const ret = new Array<ISubnet>();
+    for (let i = 0; i < subnetGroup.subnets.length; i++) {
+      const vpcSubnet = subnetGroup.subnets[i];
+      ret.push(
+        Subnet.fromSubnetAttributes(this, `${subnetGroup.name}Subnet${i + 1}`, {
+          availabilityZone: vpcSubnet.availabilityZone,
+          subnetId: vpcSubnet.subnetId,
+          routeTableId: vpcSubnet.routeTableId,
+          ipv4CidrBlock: vpcSubnet.cidr,
+        }),
+      );
+    }
+    return ret;
+  }
+}
+
+function flatMap<T, U>(xs: T[], fn: (x: T) => U[]): U[] {
+  const ret = new Array<U>();
+  for (const x of xs) {
+    ret.push(...fn(x));
+  }
+  return ret;
+}
 
 class CompositeDependable implements IDependable {
   private readonly dependables = new Array<IDependable>();
@@ -3160,6 +3251,9 @@ class ImportedSubnet
   extends AwsConstructBase
   implements ISubnet, IPublicSubnet, IPrivateSubnet
 {
+  /** Uniquely identifies this class. */
+  public static readonly PROPERTY_INJECTION_ID: string =
+    "terraconstructs.aws.ec2.ImportedSubnet";
   public readonly subnetOutputs: SubnetOutputs;
   public get outputs(): Record<string, any> {
     return this.subnetOutputs;
@@ -3177,7 +3271,7 @@ class ImportedSubnet
       registerOutputs: attrs.registerOutputs,
     });
 
-    if (!attrs.routeTableId) {
+    if (!attrs.routeTableId && !attrs.subnetName) {
       // The following looks a little weird, but comes down to:
       //
       // * Is the subnetId itself unresolved ({ Ref: Subnet }); or
@@ -3203,13 +3297,36 @@ class ImportedSubnet
         `No routeTableId was provided to the subnet ${ref}. Attempting to read its .routeTable.routeTableId will return null/undefined. (More info: https://github.com/aws/aws-cdk/pull/3171)`,
       );
     }
-    const lookup = new dataAwsSubnet.DataAwsSubnet(this, "Resource", {
-      id: attrs.subnetId,
-    });
+    let lookupConfig: dataAwsSubnet.DataAwsSubnetConfig | undefined;
+    if (attrs.subnetId) {
+      lookupConfig = {
+        id: attrs.subnetId,
+      };
+    } else if (attrs.subnetName) {
+      lookupConfig = {
+        filter: [
+          {
+            name: "tag:Name",
+            values: [attrs.subnetName],
+          },
+        ],
+      };
+    }
+    if (!lookupConfig) {
+      throw new ValidationError(
+        "Either 'subnetId' or 'subnetName' must be specified",
+        this,
+      );
+    }
+    const lookup = new dataAwsSubnet.DataAwsSubnet(
+      this,
+      "Resource",
+      lookupConfig,
+    );
 
     this._ipv4CidrBlock = attrs.ipv4CidrBlock; // ?? lookup.cidrBlock;
     this._availabilityZone = attrs.availabilityZone; // ?? lookup.availabilityZone;
-    this.subnetId = attrs.subnetId;
+    this.subnetId = attrs.subnetId ?? lookup.id;
     this.routeTable = {
       // Forcing routeTableId to pretend non-null to maintain backwards-compatibility. See https://github.com/aws/aws-cdk/pull/3171
       routeTableId: attrs.routeTableId!,
@@ -3223,8 +3340,9 @@ class ImportedSubnet
 
   public get availabilityZone(): string {
     if (!this._availabilityZone) {
-      throw new Error(
+      throw new ValidationError(
         "You cannot reference a Subnet's availability zone if it was not supplied. Add the availabilityZone when importing using Subnet.fromSubnetAttributes()",
+        this,
       );
     }
     return this._availabilityZone;
@@ -3233,8 +3351,9 @@ class ImportedSubnet
   public get ipv4CidrBlock(): string {
     if (!this._ipv4CidrBlock) {
       // tslint:disable-next-line: max-line-length
-      throw new Error(
+      throw new ValidationError(
         "You cannot reference an imported Subnet's IPv4 CIDR if it was not supplied. Add the ipv4CidrBlock when importing using Subnet.fromSubnetAttributes()",
+        this,
       );
     }
     return this._ipv4CidrBlock;
@@ -3288,13 +3407,13 @@ function determineNatGatewayCount(
         : 0;
 
   if (count === 0 && hasPrivateSubnets && !hasCustomEgress) {
-    throw new Error(
+    throw new UnscopedValidationError(
       "If you do not want NAT gateways (natGateways=0), make sure you don't configure any PRIVATE(_WITH_NAT) subnets in 'subnetConfiguration' (make them PUBLIC or ISOLATED instead)",
     );
   }
 
   if (count > 0 && !hasPublicSubnets) {
-    throw new Error(
+    throw new UnscopedValidationError(
       `If you configure PRIVATE subnets in 'subnetConfiguration', you must also configure PUBLIC subnets to put the NAT gateways into (got ${JSON.stringify(subnetConfig)}.`,
     );
   }
@@ -3302,98 +3421,78 @@ function determineNatGatewayCount(
   return count;
 }
 
-// /**
-//  * There are returned when the provider has not supplied props yet
-//  *
-//  * It's only used for testing and on the first run-through.
-//  */
-// const DUMMY_VPC_PROPS: cxapi.VpcContextResponse = {
-//   availabilityZones: [],
-//   vpcCidrBlock: "1.2.3.4/5",
-//   isolatedSubnetIds: undefined,
-//   isolatedSubnetNames: undefined,
-//   isolatedSubnetRouteTableIds: undefined,
-//   privateSubnetIds: undefined,
-//   privateSubnetNames: undefined,
-//   privateSubnetRouteTableIds: undefined,
-//   publicSubnetIds: undefined,
-//   publicSubnetNames: undefined,
-//   publicSubnetRouteTableIds: undefined,
-//   subnetGroups: [
-//     {
-//       name: "Public",
-//       type: cxapi.VpcSubnetGroupType.PUBLIC,
-//       subnets: [
-//         {
-//           availabilityZone: "dummy1a",
-//           subnetId: "s-12345",
-//           routeTableId: "rtb-12345s",
-//           cidr: "1.2.3.4/5",
-//         },
-//         {
-//           availabilityZone: "dummy1b",
-//           subnetId: "s-67890",
-//           routeTableId: "rtb-67890s",
-//           cidr: "1.2.3.4/5",
-//         },
-//       ],
-//     },
-//     {
-//       name: "Private",
-//       type: cxapi.VpcSubnetGroupType.PRIVATE,
-//       subnets: [
-//         {
-//           availabilityZone: "dummy1a",
-//           subnetId: "p-12345",
-//           routeTableId: "rtb-12345p",
-//           cidr: "1.2.3.4/5",
-//         },
-//         {
-//           availabilityZone: "dummy1b",
-//           subnetId: "p-67890",
-//           routeTableId: "rtb-57890p",
-//           cidr: "1.2.3.4/5",
-//         },
-//       ],
-//     },
-//     {
-//       name: "Isolated",
-//       type: cxapi.VpcSubnetGroupType.ISOLATED,
-//       subnets: [
-//         {
-//           availabilityZone: "dummy1a",
-//           subnetId: "p-12345",
-//           routeTableId: "rtb-12345p",
-//           cidr: "1.2.3.4/5",
-//         },
-//         {
-//           availabilityZone: "dummy1b",
-//           subnetId: "p-67890",
-//           routeTableId: "rtb-57890p",
-//           cidr: "1.2.3.4/5",
-//         },
-//       ],
-//     },
-//   ],
-//   vpcId: "vpc-12345",
-// };
-
-// moved due to cycles
-// ref: https://github.com/aws/aws-cdk/blob/a2c633f1e698249496f11338312ab42bd7b1e4f0/packages/aws-cdk-lib/aws-ec2/lib/util.ts
-
-// /**
-//  * The default names for every subnet type
-//  */
-// export function defaultSubnetName(type: SubnetType) {
-//   switch (type) {
-//     case SubnetType.PUBLIC:
-//       return "Public";
-//     case SubnetType.PRIVATE_WITH_NAT:
-//     case SubnetType.PRIVATE_WITH_EGRESS:
-//     case SubnetType.PRIVATE:
-//       return "Private";
-//     case SubnetType.PRIVATE_ISOLATED:
-//     case SubnetType.ISOLATED:
-//       return "Isolated";
-//   }
-// }
+/**
+ * There are returned when the provider has not supplied props yet
+ *
+ * It's only used for testing and on the first run-through.
+ */
+const DUMMY_VPC_PROPS: cxapi.VpcContextResponse = {
+  availabilityZones: [],
+  vpcCidrBlock: "1.2.3.4/5",
+  isolatedSubnetIds: undefined,
+  isolatedSubnetNames: undefined,
+  isolatedSubnetRouteTableIds: undefined,
+  privateSubnetIds: undefined,
+  privateSubnetNames: undefined,
+  privateSubnetRouteTableIds: undefined,
+  publicSubnetIds: undefined,
+  publicSubnetNames: undefined,
+  publicSubnetRouteTableIds: undefined,
+  subnetGroups: [
+    {
+      name: "Public",
+      type: cxapi.VpcSubnetGroupType.PUBLIC,
+      subnets: [
+        {
+          availabilityZone: "dummy1a",
+          subnetId: "s-12345",
+          routeTableId: "rtb-12345s",
+          cidr: "1.2.3.4/5",
+        },
+        {
+          availabilityZone: "dummy1b",
+          subnetId: "s-67890",
+          routeTableId: "rtb-67890s",
+          cidr: "1.2.3.4/5",
+        },
+      ],
+    },
+    {
+      name: "Private",
+      type: cxapi.VpcSubnetGroupType.PRIVATE,
+      subnets: [
+        {
+          availabilityZone: "dummy1a",
+          subnetId: "p-12345",
+          routeTableId: "rtb-12345p",
+          cidr: "1.2.3.4/5",
+        },
+        {
+          availabilityZone: "dummy1b",
+          subnetId: "p-67890",
+          routeTableId: "rtb-57890p",
+          cidr: "1.2.3.4/5",
+        },
+      ],
+    },
+    {
+      name: "Isolated",
+      type: cxapi.VpcSubnetGroupType.ISOLATED,
+      subnets: [
+        {
+          availabilityZone: "dummy1a",
+          subnetId: "p-12345",
+          routeTableId: "rtb-12345p",
+          cidr: "1.2.3.4/5",
+        },
+        {
+          availabilityZone: "dummy1b",
+          subnetId: "p-67890",
+          routeTableId: "rtb-57890p",
+          cidr: "1.2.3.4/5",
+        },
+      ],
+    },
+  ],
+  vpcId: "vpc-12345",
+};

--- a/src/aws/context-provider.ts
+++ b/src/aws/context-provider.ts
@@ -1,0 +1,274 @@
+import * as cxschema from "@aws-cdk/cloud-assembly-schema";
+import { Annotations, Token } from "cdktf";
+import { Construct, Node } from "constructs";
+import { ValidationError } from "../errors";
+import { AwsStack } from "./aws-stack";
+import * as cxapi from "./cx-api";
+
+/**
+ */
+export interface GetContextKeyOptions {
+  /**
+   * The context provider to query.
+   */
+  readonly provider: string;
+
+  /**
+   * Provider-specific properties.
+   */
+  readonly props?: { [key: string]: any };
+
+  /**
+   * Whether to include the stack's account and region automatically.
+   *
+   * @default false
+   */
+  readonly includeEnvironment?: boolean;
+
+  /**
+   * Adds an additional discriminator to the `cdk.context.json` cache key.
+   *
+   * @default - no additional cache key
+   */
+  readonly additionalCacheKey?: string;
+}
+
+/**
+ */
+export interface GetContextValueOptions extends GetContextKeyOptions {
+  /**
+   * The value to return if the lookup has not yet been performed.
+   *
+   * Upon first synthesis, the lookups has not yet been performed. The
+   * `getValue()` operation returns this value instead, so that synthesis can
+   * proceed. After synthesis completes the first time, the actual lookup will
+   * be performed and synthesis will run again with the *real* value.
+   *
+   * Dummy values should preferably have valid shapes so that downstream
+   * consumers of lookup values don't throw validation exceptions if they
+   * encounter a dummy value (or all possible downstream consumers need to
+   * effectively check for the well-known shape of the dummy value); throwing an
+   * exception would error out the synthesis operation and prevent the lookup
+   * and the second, real, synthesis from happening.
+   *
+   * ## Connection to mustExist
+   *
+   * `dummyValue` is also used as the official value to return if the lookup has
+   * failed and `mustExist == false`.
+   */
+  readonly dummyValue: any;
+
+  /**
+   * Whether the resource must exist
+   *
+   * If this is set (the default), the query fails if the value or resource we
+   * tried to look up doesn't exist.
+   *
+   * If this is `false` and the value we tried to look up could not be found, the
+   * failure is suppressed and `dummyValue` is officially returned instead.
+   *
+   * When this happens, `dummyValue` is encoded into cached context and it will
+   * never be refreshed anymore until the user runs `cdk context --reset <key>`.
+   *
+   * Note that it is not possible for the CDK app code to make a distinction
+   * between "the lookup has not been performed yet" and "the lookup didn't
+   * find anything and we returned a default value instead".
+   *
+   * ## Context providers
+   *
+   * This feature must explicitly be supported by context providers. It is
+   * currently supported by:
+   *
+   * - KMS key provider
+   * - SSM parameter provider
+   *
+   * ## Note to implementors
+   *
+   * The dummy value should not be returned for all SDK lookup failures. For
+   * example, "no network" or "no credentials" or "malformed query" should
+   * not lead to the dummy value being returned. Only the case of "no such
+   * resource" should.
+   *
+   * @default true
+   */
+  readonly mustExist?: boolean;
+}
+
+/**
+ */
+export interface GetContextKeyResult {
+  readonly key: string;
+  readonly props: { [key: string]: any };
+}
+
+/**
+ */
+export interface GetContextValueResult {
+  readonly value?: any;
+}
+
+/**
+ * Base class for the model side of context providers
+ *
+ * Instances of this class communicate with context provider plugins in the 'cdk
+ * toolkit' via context variables (input), outputting specialized queries for
+ * more context variables (output).
+ *
+ * ContextProvider needs access to a Construct to hook into the context mechanism.
+ *
+ */
+export class ContextProvider {
+  /**
+   * @returns the context key or undefined if a key cannot be rendered (due to tokens used in any of the props)
+   */
+  public static getKey(
+    scope: Construct,
+    options: GetContextKeyOptions,
+  ): GetContextKeyResult {
+    const stack = AwsStack.ofAwsConstruct(scope);
+
+    const props = {
+      // Defaults to false because we do not support static value for account
+      ...((options.includeEnvironment ?? false)
+        ? { account: stack.account, region: stack.region }
+        : {}),
+      ...(options.additionalCacheKey
+        ? { additionalCacheKey: options.additionalCacheKey }
+        : {}),
+      ...options.props,
+    };
+
+    if (Object.values(props).find((x) => Token.isUnresolved(x))) {
+      throw new ValidationError(
+        `Cannot determine scope for context provider ${options.provider}.\n` +
+          "This usually happens when one or more of the provider props have unresolved tokens",
+        scope,
+      );
+    }
+
+    const propStrings = propsToArray(props);
+    return {
+      key: `${options.provider}:${propStrings.join(":")}`,
+      props,
+    };
+  }
+
+  public static getValue(
+    scope: Construct,
+    options: GetContextValueOptions,
+  ): GetContextValueResult {
+    if (options.mustExist !== undefined) {
+      throw new ValidationError(
+        "Only supply one of 'mustExist' and 'ignoreErrorOnMissingContext'",
+        scope,
+      );
+    }
+
+    const stack = AwsStack.ofAwsConstruct(scope);
+
+    // TODO: re-enable whenever environment details can be set directly
+    // if (Token.isUnresolved(stack.account) || Token.isUnresolved(stack.region)) {
+    //   throw new ValidationError(
+    //     `Cannot retrieve value from context provider ${options.provider} since account/region ` +
+    //       'are not specified at the stack level. Configure "env" with an account and region when ' +
+    //       "you define your stack." +
+    //       "See https://docs.aws.amazon.com/cdk/latest/guide/environments.html for more details.",
+    //     scope,
+    //   );
+    // }
+
+    const { key, props } = this.getKey(scope, options);
+    const value = Node.of(scope).tryGetContext(key);
+    const providerError = extractProviderError(value);
+
+    // if context is missing or an error occurred during context retrieval,
+    // report and return a dummy value.
+    if (value === undefined || providerError !== undefined) {
+      // Render 'ignoreErrorOnMissingContext' iff one of the parameters is supplied.
+      const ignoreErrorOnMissingContext =
+        options.mustExist !== undefined ? !options.mustExist : undefined;
+
+      // build a version of the props which includes the dummyValue and ignoreError flag
+      const extendedProps: { [p: string]: any } = {
+        dummyValue: options.dummyValue,
+
+        // Even though we renamed the user-facing property, the field in the
+        // cloud assembly still has the original name, which is somewhat wrong
+        // because it's not about missing context.
+        ignoreErrorOnMissingContext,
+        ...(options.additionalCacheKey
+          ? { additionalCacheKey: options.additionalCacheKey }
+          : {}),
+        ...props,
+      };
+
+      // We'll store the extendedProps in the missingContextKey report
+      // so that we can retrieve the dummyValue and ignoreError flag
+      // in the aws-cdk's ssm-context and kms key provider
+      stack.reportMissingContextKey({
+        key,
+        provider: options.provider as cxschema.ContextProvider,
+        props: extendedProps as cxschema.ContextQueryProperties,
+      });
+
+      if (providerError !== undefined) {
+        Annotations.of(scope).addError(providerError);
+      }
+
+      return { value: options.dummyValue };
+    }
+
+    return { value };
+  }
+
+  private constructor() {}
+}
+
+/**
+ * If the context value represents an error, return the error message
+ */
+function extractProviderError(value: any): string | undefined {
+  if (typeof value === "object" && value !== null) {
+    return value[cxapi.PROVIDER_ERROR_KEY];
+  }
+  return undefined;
+}
+
+/**
+ * Quote colons in all strings so that we can undo the quoting at a later point
+ *
+ * We'll use $ as a quoting character, for no particularly good reason other
+ * than that \ is going to lead to quoting hell when the keys are stored in JSON.
+ */
+function colonQuote(xs: string): string {
+  return xs.replace(/\$/g, "$$").replace(/:/g, "$:");
+}
+
+function propsToArray(props: { [key: string]: any }, keyPrefix = ""): string[] {
+  const ret: string[] = [];
+
+  for (const key of Object.keys(props)) {
+    // skip undefined values
+    if (props[key] === undefined) {
+      continue;
+    }
+
+    switch (typeof props[key]) {
+      case "object": {
+        ret.push(...propsToArray(props[key], `${keyPrefix}${key}.`));
+        break;
+      }
+      case "string": {
+        ret.push(`${keyPrefix}${key}=${colonQuote(props[key])}`);
+        break;
+      }
+      default: {
+        ret.push(`${keyPrefix}${key}=${JSON.stringify(props[key])}`);
+        break;
+      }
+    }
+  }
+
+  ret.sort();
+  return ret;
+}

--- a/src/aws/cx-api.ts
+++ b/src/aws/cx-api.ts
@@ -1,3 +1,209 @@
-// https://github.com/aws/aws-cdk/blob/v2.232.2/packages/aws-cdk-lib/cx-api/lib/features.ts
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/aws-cdk-lib/cx-api/lib/cxapi.ts
+
+/**
+ * If a context value is an object with this key, it indicates an error
+ */
+export const PROVIDER_ERROR_KEY = "$providerError";
+
+// Ref: https://github.com/aws/aws-cdk/blob/v2.232.2/packages/aws-cdk-lib/cx-api/lib/features.ts
 
 export const TARGET_PARTITIONS = "terraconstructs/core:target-partitions";
+
+// Ref: https://github.com/aws/aws-cdk/blob/v2.232.2/packages/aws-cdk-lib/cx-api/lib/context/vpc.ts
+
+/**
+ * The type of subnet group.
+ * Same as SubnetType in the aws-cdk-lib/aws-ec2 package,
+ * but we can't use that because of cyclical dependencies.
+ */
+export enum VpcSubnetGroupType {
+  /** Public subnet group type. */
+  PUBLIC = "Public",
+
+  /** Private subnet group type. */
+  PRIVATE = "Private",
+
+  /** Isolated subnet group type. */
+  ISOLATED = "Isolated",
+}
+
+/**
+ * A subnet representation that the VPC provider uses.
+ */
+export interface VpcSubnet {
+  /** The identifier of the subnet. */
+  readonly subnetId: string;
+
+  /**
+   * The code of the availability zone this subnet is in
+   * (for example, 'us-west-2a').
+   */
+  readonly availabilityZone: string;
+
+  /** The identifier of the route table for this subnet. */
+  readonly routeTableId: string;
+
+  /**
+   * CIDR range of the subnet
+   *
+   * @default - CIDR information not available
+   */
+  readonly cidr?: string;
+}
+
+/**
+ * A group of subnets returned by the VPC provider.
+ * The included subnets do NOT have to be symmetric!
+ */
+export interface VpcSubnetGroup {
+  /**
+   * The name of the subnet group,
+   * determined by looking at the tags of of the subnets
+   * that belong to it.
+   */
+  readonly name: string;
+
+  /** The type of the subnet group. */
+  readonly type: VpcSubnetGroupType;
+
+  /**
+   * The subnets that are part of this group.
+   * There is no condition that the subnets have to be symmetric
+   * in the group.
+   */
+  readonly subnets: VpcSubnet[];
+}
+
+/**
+ * Properties of a discovered VPC
+ */
+export interface VpcContextResponse {
+  /**
+   * VPC id
+   */
+  readonly vpcId: string;
+
+  /**
+   * VPC cidr
+   *
+   * @default - CIDR information not available
+   */
+  readonly vpcCidrBlock?: string;
+
+  /**
+   * AZs
+   */
+  readonly availabilityZones: string[];
+
+  /**
+   * IDs of all public subnets
+   *
+   * Element count: #(availabilityZones) · #(publicGroups)
+   */
+  readonly publicSubnetIds?: string[];
+
+  /**
+   * Name of public subnet groups
+   *
+   * Element count: #(publicGroups)
+   */
+  readonly publicSubnetNames?: string[];
+
+  /**
+   * Route Table IDs of public subnet groups.
+   *
+   * Element count: #(availabilityZones) · #(publicGroups)
+   */
+  readonly publicSubnetRouteTableIds?: string[];
+
+  /**
+   * IDs of all private subnets
+   *
+   * Element count: #(availabilityZones) · #(privateGroups)
+   */
+  readonly privateSubnetIds?: string[];
+
+  /**
+   * Name of private subnet groups
+   *
+   * Element count: #(privateGroups)
+   */
+  readonly privateSubnetNames?: string[];
+
+  /**
+   * Route Table IDs of private subnet groups.
+   *
+   * Element count: #(availabilityZones) · #(privateGroups)
+   */
+  readonly privateSubnetRouteTableIds?: string[];
+
+  /**
+   * IDs of all isolated subnets
+   *
+   * Element count: #(availabilityZones) · #(isolatedGroups)
+   */
+  readonly isolatedSubnetIds?: string[];
+
+  /**
+   * Name of isolated subnet groups
+   *
+   * Element count: #(isolatedGroups)
+   */
+  readonly isolatedSubnetNames?: string[];
+
+  /**
+   * Route Table IDs of isolated subnet groups.
+   *
+   * Element count: #(availabilityZones) · #(isolatedGroups)
+   */
+  readonly isolatedSubnetRouteTableIds?: string[];
+
+  /**
+   * The VPN gateway ID
+   */
+  readonly vpnGatewayId?: string;
+
+  /**
+   * The subnet groups discovered for the given VPC.
+   * Unlike the above properties, this will include asymmetric subnets,
+   * if the VPC has any.
+   * This property will only be populated if `VpcContextQuery.returnAsymmetricSubnets`
+   * is true.
+   *
+   * @default - no subnet groups will be returned unless `VpcContextQuery.returnAsymmetricSubnets` is true
+   */
+  readonly subnetGroups?: VpcSubnetGroup[];
+
+  /**
+   * The region in which the VPC is in.
+   *
+   * @default - Region of the parent stack
+   */
+  readonly region?: string;
+
+  /**
+   * The ID of the AWS account that owns the VPC.
+   *
+   * @default the account id of the parent stack
+   */
+  readonly ownerAccountId?: string;
+}
+
+// Ref: https://github.com/aws/aws-cdk/blob/v2.232.2/packages/aws-cdk-lib/cx-api/lib/context/security-group.ts
+
+/**
+ * Properties of a discovered SecurityGroup.
+ */
+export interface SecurityGroupContextResponse {
+  /**
+   * The security group's id.
+   */
+  readonly securityGroupId: string;
+
+  /**
+   * Whether the security group allows all outbound traffic. This will be true
+   * when the security group has all-protocol egress permissions to access both
+   * `0.0.0.0/0` and `::/0`.
+   */
+  readonly allowAllOutbound: boolean;
+}

--- a/test/assertions.ts
+++ b/test/assertions.ts
@@ -215,6 +215,19 @@ export class Template {
     return Object.values(this.dataSourcesByType(type));
   }
 
+  /**
+   * Jest Matcher for dataSourceTypeArray
+   *
+   * shortcut for expect(template.dataSourceTypeArray(type))
+   */
+  public expectDataSources(type: TerraformConstructor): jest.JestMatchers<any> {
+    return expect(this.dataSourceTypeArray(type));
+  }
+
+  public dataSourceCountIs(type: TerraformConstructor, count: number): void {
+    return this.expectDataSources(type).toHaveLength(count);
+  }
+
   public get output(): object | undefined {
     return this.template.output;
   }

--- a/test/aws/compute/vpc.from-lookup.test.ts
+++ b/test/aws/compute/vpc.from-lookup.test.ts
@@ -1,0 +1,482 @@
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/aws-cdk-lib/aws-ec2/test/vpc.from-lookup.test.ts
+
+import * as cxschema from "@aws-cdk/cloud-assembly-schema";
+import { dataAwsSubnet, dataAwsVpc } from "@cdktf/provider-aws";
+import { Lazy } from "cdktf";
+import "cdktf/lib/testing/adapters/jest";
+import { Construct } from "constructs";
+import { AwsStack } from "../../../src/aws";
+import {
+  GenericLinuxImage,
+  Instance,
+  InstanceType,
+  PublicSubnet,
+  SubnetType,
+  Vpc,
+} from "../../../src/aws/compute";
+import {
+  ContextProvider,
+  GetContextValueOptions,
+  GetContextValueResult,
+} from "../../../src/aws/context-provider";
+import * as cxapi from "../../../src/aws/cx-api";
+import { Template } from "../../assertions";
+
+describe("vpc from lookup", () => {
+  describe("Vpc.fromLookup()", () => {
+    test("requires concrete values", () => {
+      // GIVEN
+      const stack = new AwsStack();
+
+      expect(() => {
+        Vpc.fromLookup(stack, "Vpc", {
+          vpcId: Lazy.stringValue({ produce: () => "some-id" }),
+        });
+      }).toThrow("All arguments to Vpc.fromLookup() must be concrete");
+    });
+
+    test("selecting subnets by name from a looked-up VPC does not throw", () => {
+      // GIVEN
+      const stack = new AwsStack(undefined, undefined, {
+        providerConfig: { region: "us-east-1" },
+      });
+      const vpc = Vpc.fromLookup(stack, "VPC", {
+        vpcId: "vpc-1234",
+      });
+
+      // WHEN
+      vpc.selectSubnets({ subnetName: "Bleep" });
+
+      // THEN: no exception
+    });
+
+    test("accepts asymmetric subnets", () => {
+      const previous = mockVpcContextProviderWith(
+        {
+          vpcId: "vpc-1234",
+          subnetGroups: [
+            {
+              name: "Public",
+              type: cxapi.VpcSubnetGroupType.PUBLIC,
+              subnets: [
+                {
+                  subnetId: "pub-sub-in-us-east-1a",
+                  availabilityZone: "us-east-1a",
+                  routeTableId: "rt-123",
+                },
+                {
+                  subnetId: "pub-sub-in-us-east-1b",
+                  availabilityZone: "us-east-1b",
+                  routeTableId: "rt-123",
+                },
+              ],
+            },
+            {
+              name: "Private",
+              type: cxapi.VpcSubnetGroupType.PRIVATE,
+              subnets: [
+                {
+                  subnetId: "pri-sub-1-in-us-east-1c",
+                  availabilityZone: "us-east-1c",
+                  routeTableId: "rt-123",
+                },
+                {
+                  subnetId: "pri-sub-2-in-us-east-1c",
+                  availabilityZone: "us-east-1c",
+                  routeTableId: "rt-123",
+                },
+                {
+                  subnetId: "pri-sub-1-in-us-east-1d",
+                  availabilityZone: "us-east-1d",
+                  routeTableId: "rt-123",
+                },
+                {
+                  subnetId: "pri-sub-2-in-us-east-1d",
+                  availabilityZone: "us-east-1d",
+                  routeTableId: "rt-123",
+                },
+              ],
+            },
+          ],
+        },
+        (options) => {
+          expect(options.filter).toEqual({
+            isDefault: "true",
+          });
+
+          expect(options.subnetGroupNameTag).toEqual(undefined);
+        },
+      );
+
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        isDefault: true,
+      });
+
+      expect(vpc.availabilityZones).toEqual([
+        "us-east-1a",
+        "us-east-1b",
+        "us-east-1c",
+        "us-east-1d",
+      ]);
+      expect(vpc.publicSubnets.length).toEqual(2);
+      expect(vpc.privateSubnets.length).toEqual(4);
+      expect(vpc.isolatedSubnets.length).toEqual(0);
+
+      restoreContextProvider(previous);
+    });
+
+    test("selectSubnets onePerAz works on imported VPC", () => {
+      const previous = mockVpcContextProviderWith(
+        {
+          vpcId: "vpc-1234",
+          subnetGroups: [
+            {
+              name: "Public",
+              type: cxapi.VpcSubnetGroupType.PUBLIC,
+              subnets: [
+                {
+                  subnetId: "pub-sub-in-us-east-1a",
+                  availabilityZone: "us-east-1a",
+                  routeTableId: "rt-123",
+                },
+                {
+                  subnetId: "pub-sub-in-us-east-1b",
+                  availabilityZone: "us-east-1b",
+                  routeTableId: "rt-123",
+                },
+              ],
+            },
+            {
+              name: "Private",
+              type: cxapi.VpcSubnetGroupType.PRIVATE,
+              subnets: [
+                {
+                  subnetId: "pri-sub-1-in-us-east-1c",
+                  availabilityZone: "us-east-1c",
+                  routeTableId: "rt-123",
+                },
+                {
+                  subnetId: "pri-sub-2-in-us-east-1c",
+                  availabilityZone: "us-east-1c",
+                  routeTableId: "rt-123",
+                },
+                {
+                  subnetId: "pri-sub-1-in-us-east-1d",
+                  availabilityZone: "us-east-1d",
+                  routeTableId: "rt-123",
+                },
+                {
+                  subnetId: "pri-sub-2-in-us-east-1d",
+                  availabilityZone: "us-east-1d",
+                  routeTableId: "rt-123",
+                },
+              ],
+            },
+          ],
+        },
+        (options) => {
+          expect(options.filter).toEqual({
+            isDefault: "true",
+          });
+
+          expect(options.subnetGroupNameTag).toEqual(undefined);
+        },
+      );
+
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        isDefault: true,
+      });
+
+      // WHEN
+      const subnets = vpc.selectSubnets({
+        subnetType: SubnetType.PRIVATE_WITH_EGRESS,
+        onePerAz: true,
+      });
+
+      // THEN: we got 2 subnets and not 4
+      expect(subnets.subnets.map((s) => s.availabilityZone)).toEqual([
+        "us-east-1c",
+        "us-east-1d",
+      ]);
+
+      restoreContextProvider(previous);
+    });
+
+    // TODO: context provider needs to be fully implemented
+    test.skip("AZ in dummy lookup VPC matches AZ in Stack", () => {
+      // GIVEN
+      const stack = new AwsStack(undefined, "MyTestStack", {
+        providerConfig: { region: "dummy" },
+      });
+      const vpc = Vpc.fromLookup(stack, "vpc", { isDefault: true });
+
+      // WHEN
+      const subnets = vpc.selectSubnets({
+        availabilityZones: stack.availabilityZones(),
+      });
+
+      // THEN
+      expect(subnets.subnets.length).toEqual(2);
+    });
+
+    test("don't crash when using subnetgroup name in lookup VPC", () => {
+      // GIVEN
+      const stack = new AwsStack(undefined, "MyTestStack", {
+        providerConfig: { region: "dummy" },
+      });
+      const vpc = Vpc.fromLookup(stack, "vpc", { isDefault: true });
+
+      // WHEN
+      new Instance(stack, "Instance", {
+        vpc,
+        instanceType: new InstanceType("t2.large"),
+        machineImage: new GenericLinuxImage({ dummy: "ami-1234" }),
+        vpcSubnets: {
+          subnetGroupName: "application_layer",
+        },
+      });
+
+      // THEN -- no exception occurred
+    });
+    test("subnets in imported VPC has all expected attributes", () => {
+      const previous = mockVpcContextProviderWith(
+        {
+          vpcId: "vpc-1234",
+          subnetGroups: [
+            {
+              name: "Public",
+              type: cxapi.VpcSubnetGroupType.PUBLIC,
+              subnets: [
+                {
+                  subnetId: "pub-sub-in-us-east-1a",
+                  availabilityZone: "us-east-1a",
+                  routeTableId: "rt-123",
+                  cidr: "10.100.0.0/24",
+                },
+              ],
+            },
+          ],
+        },
+        (options) => {
+          expect(options.filter).toEqual({
+            isDefault: "true",
+          });
+
+          expect(options.subnetGroupNameTag).toEqual(undefined);
+        },
+      );
+
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        isDefault: true,
+      });
+
+      let subnet = vpc.publicSubnets[0];
+
+      expect(subnet.availabilityZone).toEqual("us-east-1a");
+      expect(subnet.subnetId).toEqual("pub-sub-in-us-east-1a");
+      expect(subnet.routeTable.routeTableId).toEqual("rt-123");
+      expect(subnet.ipv4CidrBlock).toEqual("10.100.0.0/24");
+
+      restoreContextProvider(previous);
+    });
+    test("passes account and region", () => {
+      const previous = mockVpcContextProviderWith(
+        {
+          vpcId: "vpc-1234",
+          subnetGroups: [],
+        },
+        (options) => {
+          expect(options.region).toEqual("region-1234");
+        },
+      );
+
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        vpcId: "vpc-1234",
+        region: "region-1234",
+      });
+
+      expect(vpc.vpcId).toEqual("vpc-1234");
+
+      restoreContextProvider(previous);
+    });
+
+    test("passes region to LookedUpVpc correctly", () => {
+      const previous = mockVpcContextProviderWith(
+        {
+          vpcId: "vpc-1234",
+          subnetGroups: [],
+          region: "region-1234",
+        },
+        (options) => {
+          expect(options.region).toEqual("region-1234");
+        },
+      );
+
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        vpcId: "vpc-1234",
+        region: "region-1234",
+      });
+
+      expect(vpc.env.region).toEqual("region-1234");
+      restoreContextProvider(previous);
+    });
+
+    test("passes owner account id to LookedUpVpc correctly", () => {
+      const previous = mockVpcContextProviderWith({
+        vpcId: "vpc-1234",
+        subnetGroups: [],
+        region: "region-1234",
+        ownerAccountId: "123456789012",
+      });
+
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        vpcId: "vpc-1234",
+      });
+      expect(vpc.env.account).toEqual("123456789012");
+      restoreContextProvider(previous);
+    });
+
+    test("passes owner account id to context query correctly", () => {
+      const previous = mockVpcContextProviderWith(
+        {
+          vpcId: "vpc-1234",
+          subnetGroups: [],
+          region: "region-1234",
+          ownerAccountId: "123456789012",
+        },
+        (options) => {
+          expect(options.filter["owner-id"]).toEqual("123456789012");
+        },
+      );
+
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        vpcId: "vpc-1234",
+        ownerAccountId: "123456789012",
+      });
+      expect(vpc.env.account).toEqual("123456789012");
+      restoreContextProvider(previous);
+    });
+
+    test("a looked up VPC in a different region shared from an account has correct VPC", () => {
+      const previous = mockVpcContextProviderWith({
+        vpcId: "vpc-1234",
+        subnetGroups: [],
+        region: "region-1234",
+        ownerAccountId: "123456789012",
+      });
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        vpcId: "vpc-1234",
+      });
+      expect(stack.resolve(vpc.vpcArn)).toEqual(
+        "arn:${data.aws_partition.Partitition.partition}:ec2:region-1234:123456789012:vpc/vpc-1234",
+      );
+      restoreContextProvider(previous);
+    });
+
+    test("a looked up VPC falls back to the parent stack's account and region", () => {
+      const previous = mockVpcContextProviderWith({
+        vpcId: "vpc-1234",
+        subnetGroups: [],
+      });
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        vpcId: "vpc-1234",
+      });
+      expect(stack.resolve(vpc.vpcArn)).toEqual(
+        "arn:${data.aws_partition.Partitition.partition}:ec2:${data.aws_region.Region.name}:${data.aws_caller_identity.CallerIdentity.account_id}:vpc/vpc-1234",
+      );
+      restoreContextProvider(previous);
+    });
+
+    test("can have looked up vpc and lookep up subnet", () => {
+      // GIVEN
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        vpcName: "vpc-name",
+      });
+
+      // WHEN
+      PublicSubnet.fromSubnetAttributes(vpc, "PublicSubnet", {
+        subnetName: "public-subnet",
+      });
+
+      const t = new Template(stack);
+      t.expect.toHaveDataSourceWithProperties(dataAwsVpc.DataAwsVpc, {
+        filter: [
+          {
+            name: "tag:Name",
+            values: ["vpc-name"],
+          },
+        ],
+      });
+      t.expect.toHaveDataSourceWithProperties(dataAwsSubnet.DataAwsSubnet, {
+        filter: [
+          {
+            name: "tag:Name",
+            values: ["public-subnet"],
+          },
+        ],
+      });
+    });
+  });
+});
+
+interface MockVpcContextResponse {
+  readonly vpcId: string;
+  readonly subnetGroups: cxapi.VpcSubnetGroup[];
+  readonly ownerAccountId?: string;
+  readonly region?: string;
+}
+
+function mockVpcContextProviderWith(
+  response: MockVpcContextResponse,
+  paramValidator?: (options: cxschema.VpcContextQuery) => void,
+) {
+  const previous = ContextProvider.getValue;
+  ContextProvider.getValue = (
+    _scope: Construct,
+    options: GetContextValueOptions,
+  ) => {
+    // do some basic sanity checks
+    expect(options.provider).toEqual(cxschema.ContextProvider.VPC_PROVIDER);
+    expect((options.props || {}).returnAsymmetricSubnets).toEqual(true);
+
+    if (paramValidator) {
+      paramValidator(options.props as any);
+    }
+
+    return {
+      value: {
+        availabilityZones: [],
+        isolatedSubnetIds: undefined,
+        isolatedSubnetNames: undefined,
+        isolatedSubnetRouteTableIds: undefined,
+        privateSubnetIds: undefined,
+        privateSubnetNames: undefined,
+        privateSubnetRouteTableIds: undefined,
+        publicSubnetIds: undefined,
+        publicSubnetNames: undefined,
+        publicSubnetRouteTableIds: undefined,
+        ...response,
+      } as cxapi.VpcContextResponse,
+    };
+  };
+  return previous;
+}
+
+function restoreContextProvider(
+  previous: (
+    scope: Construct,
+    options: GetContextValueOptions,
+  ) => GetContextValueResult,
+): void {
+  ContextProvider.getValue = previous;
+}

--- a/test/aws/compute/vpc.from-lookup.test.ts
+++ b/test/aws/compute/vpc.from-lookup.test.ts
@@ -1,0 +1,553 @@
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/aws-cdk-lib/aws-ec2/test/vpc.from-lookup.test.ts
+
+import * as cxschema from "@aws-cdk/cloud-assembly-schema";
+import { dataAwsSubnet, dataAwsVpc } from "@cdktf/provider-aws";
+import { Lazy } from "cdktf";
+import "cdktf/lib/testing/adapters/jest";
+import { Construct } from "constructs";
+import { AwsStack } from "../../../src/aws";
+import {
+  GenericLinuxImage,
+  Instance,
+  InstanceType,
+  PublicSubnet,
+  SubnetType,
+  Vpc,
+} from "../../../src/aws/compute";
+import {
+  ContextProvider,
+  GetContextValueOptions,
+  GetContextValueResult,
+} from "../../../src/aws/context-provider";
+import * as cxapi from "../../../src/aws/cx-api";
+import { Template } from "../../assertions";
+
+describe("vpc from lookup", () => {
+  describe("Vpc.fromLookup()", () => {
+    test("requires concrete values", () => {
+      // GIVEN
+      const stack = new AwsStack();
+
+      expect(() => {
+        Vpc.fromLookup(stack, "Vpc", {
+          vpcId: Lazy.stringValue({ produce: () => "some-id" }),
+        });
+      }).toThrow("All arguments to Vpc.fromLookup() must be concrete");
+    });
+
+    test("selecting subnets by name from a looked-up VPC does not throw", () => {
+      // GIVEN
+      const stack = new AwsStack(undefined, undefined, {
+        providerConfig: { region: "us-east-1" },
+      });
+      const vpc = Vpc.fromLookup(stack, "VPC", {
+        vpcId: "vpc-1234",
+      });
+
+      // WHEN
+      vpc.selectSubnets({ subnetName: "Bleep" });
+
+      // THEN: no exception
+    });
+
+    test("accepts asymmetric subnets", () => {
+      const previous = mockVpcContextProviderWith(
+        {
+          vpcId: "vpc-1234",
+          subnetGroups: [
+            {
+              name: "Public",
+              type: cxapi.VpcSubnetGroupType.PUBLIC,
+              subnets: [
+                {
+                  subnetId: "pub-sub-in-us-east-1a",
+                  availabilityZone: "us-east-1a",
+                  routeTableId: "rt-123",
+                },
+                {
+                  subnetId: "pub-sub-in-us-east-1b",
+                  availabilityZone: "us-east-1b",
+                  routeTableId: "rt-123",
+                },
+              ],
+            },
+            {
+              name: "Private",
+              type: cxapi.VpcSubnetGroupType.PRIVATE,
+              subnets: [
+                {
+                  subnetId: "pri-sub-1-in-us-east-1c",
+                  availabilityZone: "us-east-1c",
+                  routeTableId: "rt-123",
+                },
+                {
+                  subnetId: "pri-sub-2-in-us-east-1c",
+                  availabilityZone: "us-east-1c",
+                  routeTableId: "rt-123",
+                },
+                {
+                  subnetId: "pri-sub-1-in-us-east-1d",
+                  availabilityZone: "us-east-1d",
+                  routeTableId: "rt-123",
+                },
+                {
+                  subnetId: "pri-sub-2-in-us-east-1d",
+                  availabilityZone: "us-east-1d",
+                  routeTableId: "rt-123",
+                },
+              ],
+            },
+          ],
+        },
+        (options) => {
+          expect(options.filter).toEqual({
+            isDefault: "true",
+          });
+
+          expect(options.subnetGroupNameTag).toEqual(undefined);
+        },
+      );
+
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        isDefault: true,
+      });
+
+      expect(vpc.availabilityZones).toEqual([
+        "us-east-1a",
+        "us-east-1b",
+        "us-east-1c",
+        "us-east-1d",
+      ]);
+      expect(vpc.publicSubnets.length).toEqual(2);
+      expect(vpc.privateSubnets.length).toEqual(4);
+      expect(vpc.isolatedSubnets.length).toEqual(0);
+
+      restoreContextProvider(previous);
+    });
+
+    test("selectSubnets onePerAz works on imported VPC", () => {
+      const previous = mockVpcContextProviderWith(
+        {
+          vpcId: "vpc-1234",
+          subnetGroups: [
+            {
+              name: "Public",
+              type: cxapi.VpcSubnetGroupType.PUBLIC,
+              subnets: [
+                {
+                  subnetId: "pub-sub-in-us-east-1a",
+                  availabilityZone: "us-east-1a",
+                  routeTableId: "rt-123",
+                },
+                {
+                  subnetId: "pub-sub-in-us-east-1b",
+                  availabilityZone: "us-east-1b",
+                  routeTableId: "rt-123",
+                },
+              ],
+            },
+            {
+              name: "Private",
+              type: cxapi.VpcSubnetGroupType.PRIVATE,
+              subnets: [
+                {
+                  subnetId: "pri-sub-1-in-us-east-1c",
+                  availabilityZone: "us-east-1c",
+                  routeTableId: "rt-123",
+                },
+                {
+                  subnetId: "pri-sub-2-in-us-east-1c",
+                  availabilityZone: "us-east-1c",
+                  routeTableId: "rt-123",
+                },
+                {
+                  subnetId: "pri-sub-1-in-us-east-1d",
+                  availabilityZone: "us-east-1d",
+                  routeTableId: "rt-123",
+                },
+                {
+                  subnetId: "pri-sub-2-in-us-east-1d",
+                  availabilityZone: "us-east-1d",
+                  routeTableId: "rt-123",
+                },
+              ],
+            },
+          ],
+        },
+        (options) => {
+          expect(options.filter).toEqual({
+            isDefault: "true",
+          });
+
+          expect(options.subnetGroupNameTag).toEqual(undefined);
+        },
+      );
+
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        isDefault: true,
+      });
+
+      // WHEN
+      const subnets = vpc.selectSubnets({
+        subnetType: SubnetType.PRIVATE_WITH_EGRESS,
+        onePerAz: true,
+      });
+
+      // THEN: we got 2 subnets and not 4
+      expect(subnets.subnets.map((s) => s.availabilityZone)).toEqual([
+        "us-east-1c",
+        "us-east-1d",
+      ]);
+
+      restoreContextProvider(previous);
+    });
+
+    test("AZ in fallback lookup VPC matches AZ in Stack", () => {
+      // GIVEN
+      const stack = new AwsStack(undefined, "MyTestStack", {
+        providerConfig: { region: "us-east-1" },
+      });
+      const vpc = Vpc.fromLookup(stack, "vpc", { isDefault: true });
+
+      // THEN - fallback VPC has non-empty AZs derived from the stack
+      expect(vpc.availabilityZones.length).toEqual(2);
+    });
+
+    test("don't crash when using subnetgroup name in lookup VPC", () => {
+      // GIVEN
+      const stack = new AwsStack(undefined, "MyTestStack", {
+        providerConfig: { region: "dummy" },
+      });
+      const vpc = Vpc.fromLookup(stack, "vpc", { isDefault: true });
+
+      // WHEN
+      new Instance(stack, "Instance", {
+        vpc,
+        instanceType: new InstanceType("t2.large"),
+        machineImage: new GenericLinuxImage({ dummy: "ami-1234" }),
+        vpcSubnets: {
+          subnetGroupName: "application_layer",
+        },
+      });
+
+      // THEN -- no exception occurred
+    });
+    test("subnets in imported VPC has all expected attributes", () => {
+      const previous = mockVpcContextProviderWith(
+        {
+          vpcId: "vpc-1234",
+          subnetGroups: [
+            {
+              name: "Public",
+              type: cxapi.VpcSubnetGroupType.PUBLIC,
+              subnets: [
+                {
+                  subnetId: "pub-sub-in-us-east-1a",
+                  availabilityZone: "us-east-1a",
+                  routeTableId: "rt-123",
+                  cidr: "10.100.0.0/24",
+                },
+              ],
+            },
+          ],
+        },
+        (options) => {
+          expect(options.filter).toEqual({
+            isDefault: "true",
+          });
+
+          expect(options.subnetGroupNameTag).toEqual(undefined);
+        },
+      );
+
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        isDefault: true,
+      });
+
+      let subnet = vpc.publicSubnets[0];
+
+      expect(subnet.availabilityZone).toEqual("us-east-1a");
+      expect(subnet.subnetId).toEqual("pub-sub-in-us-east-1a");
+      expect(subnet.routeTable.routeTableId).toEqual("rt-123");
+      expect(subnet.ipv4CidrBlock).toEqual("10.100.0.0/24");
+
+      restoreContextProvider(previous);
+    });
+    test("passes account and region", () => {
+      const previous = mockVpcContextProviderWith(
+        {
+          vpcId: "vpc-1234",
+          subnetGroups: [],
+        },
+        (options) => {
+          expect(options.region).toEqual("region-1234");
+        },
+      );
+
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        vpcId: "vpc-1234",
+        region: "region-1234",
+      });
+
+      expect(vpc.vpcId).toEqual("vpc-1234");
+
+      restoreContextProvider(previous);
+    });
+
+    test("passes region to LookedUpVpc correctly", () => {
+      const previous = mockVpcContextProviderWith(
+        {
+          vpcId: "vpc-1234",
+          subnetGroups: [],
+          region: "region-1234",
+        },
+        (options) => {
+          expect(options.region).toEqual("region-1234");
+        },
+      );
+
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        vpcId: "vpc-1234",
+        region: "region-1234",
+      });
+
+      expect(vpc.env.region).toEqual("region-1234");
+      restoreContextProvider(previous);
+    });
+
+    test("passes owner account id to LookedUpVpc correctly", () => {
+      const previous = mockVpcContextProviderWith({
+        vpcId: "vpc-1234",
+        subnetGroups: [],
+        region: "region-1234",
+        ownerAccountId: "123456789012",
+      });
+
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        vpcId: "vpc-1234",
+      });
+      expect(vpc.env.account).toEqual("123456789012");
+      restoreContextProvider(previous);
+    });
+
+    test("passes owner account id to context query correctly", () => {
+      const previous = mockVpcContextProviderWith(
+        {
+          vpcId: "vpc-1234",
+          subnetGroups: [],
+          region: "region-1234",
+          ownerAccountId: "123456789012",
+        },
+        (options) => {
+          expect(options.filter["owner-id"]).toEqual("123456789012");
+        },
+      );
+
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        vpcId: "vpc-1234",
+        ownerAccountId: "123456789012",
+      });
+      expect(vpc.env.account).toEqual("123456789012");
+      restoreContextProvider(previous);
+    });
+
+    test("a looked up VPC in a different region shared from an account has correct VPC", () => {
+      const previous = mockVpcContextProviderWith({
+        vpcId: "vpc-1234",
+        subnetGroups: [],
+        region: "region-1234",
+        ownerAccountId: "123456789012",
+      });
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        vpcId: "vpc-1234",
+      });
+      expect(stack.resolve(vpc.vpcArn)).toEqual(
+        "arn:${data.aws_partition.Partitition.partition}:ec2:region-1234:123456789012:vpc/vpc-1234",
+      );
+      restoreContextProvider(previous);
+    });
+
+    test("a looked up VPC falls back to the parent stack's account and region", () => {
+      const previous = mockVpcContextProviderWith({
+        vpcId: "vpc-1234",
+        subnetGroups: [],
+      });
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        vpcId: "vpc-1234",
+      });
+      expect(stack.resolve(vpc.vpcArn)).toEqual(
+        "arn:${data.aws_partition.Partitition.partition}:ec2:${data.aws_region.Region.name}:${data.aws_caller_identity.CallerIdentity.account_id}:vpc/vpc-1234",
+      );
+      restoreContextProvider(previous);
+    });
+
+    test("can have looked up vpc and lookep up subnet", () => {
+      // GIVEN
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        vpcName: "vpc-name",
+      });
+
+      // WHEN
+      PublicSubnet.fromSubnetAttributes(vpc, "PublicSubnet", {
+        subnetName: "public-subnet",
+      });
+
+      const t = new Template(stack);
+      t.expect.toHaveDataSourceWithProperties(dataAwsVpc.DataAwsVpc, {
+        filter: [
+          {
+            name: "tag:Name",
+            values: ["vpc-name"],
+          },
+        ],
+      });
+      t.expect.toHaveDataSourceWithProperties(dataAwsSubnet.DataAwsSubnet, {
+        filter: [
+          {
+            name: "tag:Name",
+            values: ["public-subnet"],
+          },
+        ],
+      });
+    });
+
+    test("cross-region fromLookup passes region to the DataAwsVpc data source", () => {
+      // GIVEN
+      const stack = new AwsStack(undefined, undefined, {
+        providerConfig: { region: "us-east-1" },
+      });
+
+      // WHEN
+      Vpc.fromLookup(stack, "Vpc", {
+        vpcName: "remote-vpc",
+        region: "us-west-2",
+      });
+
+      // THEN - the synthesized DataAwsVpc data source includes region
+      const t = new Template(stack);
+      t.expect.toHaveDataSourceWithProperties(dataAwsVpc.DataAwsVpc, {
+        region: "us-west-2",
+        filter: [
+          {
+            name: "tag:Name",
+            values: ["remote-vpc"],
+          },
+        ],
+      });
+    });
+
+    test("fallback lookup VPC preserves availabilityZones from stack when no subnet groups", () => {
+      // GIVEN - a stack with a known region so availabilityZones() returns token references
+      const stack = new AwsStack(undefined, undefined, {
+        providerConfig: { region: "us-east-1" },
+      });
+
+      // WHEN - fromLookup with isDefault triggers the fallback (no context provider response)
+      const vpc = Vpc.fromLookup(stack, "DefaultVpc", {
+        isDefault: true,
+      });
+
+      // THEN - availabilityZones is not empty (it uses the stack's AZ data source references)
+      expect(vpc.availabilityZones).not.toEqual([]);
+      expect(vpc.availabilityZones.length).toBeGreaterThan(0);
+    });
+
+    test("looked up VPC with subnet groups still derives AZs from subnets", () => {
+      const previous = mockVpcContextProviderWith({
+        vpcId: "vpc-1234",
+        availabilityZones: ["us-east-1a", "us-east-1b", "us-east-1c"],
+        subnetGroups: [
+          {
+            name: "Public",
+            type: cxapi.VpcSubnetGroupType.PUBLIC,
+            subnets: [
+              {
+                subnetId: "pub-sub-in-us-east-1a",
+                availabilityZone: "us-east-1a",
+                routeTableId: "rt-123",
+              },
+              {
+                subnetId: "pub-sub-in-us-east-1b",
+                availabilityZone: "us-east-1b",
+                routeTableId: "rt-123",
+              },
+            ],
+          },
+        ],
+      });
+
+      const stack = new AwsStack();
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        isDefault: true,
+      });
+
+      // THEN - AZs come from subnet groups, not from props.availabilityZones
+      expect(vpc.availabilityZones).toEqual(["us-east-1a", "us-east-1b"]);
+
+      restoreContextProvider(previous);
+    });
+  });
+});
+
+interface MockVpcContextResponse {
+  readonly vpcId: string;
+  readonly subnetGroups: cxapi.VpcSubnetGroup[];
+  readonly availabilityZones?: string[];
+  readonly ownerAccountId?: string;
+  readonly region?: string;
+}
+
+function mockVpcContextProviderWith(
+  response: MockVpcContextResponse,
+  paramValidator?: (options: cxschema.VpcContextQuery) => void,
+) {
+  const previous = ContextProvider.getValue;
+  ContextProvider.getValue = (
+    _scope: Construct,
+    options: GetContextValueOptions,
+  ) => {
+    // do some basic sanity checks
+    expect(options.provider).toEqual(cxschema.ContextProvider.VPC_PROVIDER);
+    expect(options.props?.returnAsymmetricSubnets).toEqual(true);
+
+    if (paramValidator) {
+      paramValidator(options.props as any);
+    }
+
+    return {
+      value: {
+        availabilityZones: [],
+        isolatedSubnetIds: undefined,
+        isolatedSubnetNames: undefined,
+        isolatedSubnetRouteTableIds: undefined,
+        privateSubnetIds: undefined,
+        privateSubnetNames: undefined,
+        privateSubnetRouteTableIds: undefined,
+        publicSubnetIds: undefined,
+        publicSubnetNames: undefined,
+        publicSubnetRouteTableIds: undefined,
+        ...response,
+      } as cxapi.VpcContextResponse,
+    };
+  };
+  return previous;
+}
+
+function restoreContextProvider(
+  previous: (
+    scope: Construct,
+    options: GetContextValueOptions,
+  ) => GetContextValueResult,
+): void {
+  ContextProvider.getValue = previous;
+}


### PR DESCRIPTION
This will re-enable the `fromLookup` static method of the Vpc class. The context provider has been prepared following the current AWS CDK approach (through the [@aws-cdk/cloud-assembly-schema library](https://www.npmjs.com/package/@aws-cdk/cloud-assembly-schema)). As we don't have a full implementation of the context provider, we will use the [aws_vpc data source](https://registry.terraform.io/providers/hashicorp/aws/6.25.0/docs/data-sources/vpc) to fetch the imported details. Additionally, the same approach has been taken for Subnet and Security Group resources.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.