### PR TITLE
feat(aws/iam): Add managed policy to role with attachment resource

### DIFF
--- a/test/aws/compute/__snapshots__/function-storage.test.ts.snap
+++ b/test/aws/compute/__snapshots__/function-storage.test.ts.snap
@@ -100,9 +100,6 @@ exports[`Function with Storage Should synth and match SnapShot 1`] = `
     "aws_iam_role": {
       "HelloWorld_ServiceRole_F3F7D8B0": {
         "assume_role_policy": "\${data.aws_iam_policy_document.HelloWorld_ServiceRole_AssumeRolePolicy_BA710C6B.json}",
-        "managed_policy_arns": [
-          "arn:\${data.aws_partition.Partitition.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
         "name_prefix": "123e4567-e89b-12d3-lloWorldServiceRole",
         "tags": {
           "Name": "Test-HelloWorld",
@@ -115,6 +112,12 @@ exports[`Function with Storage Should synth and match SnapShot 1`] = `
       "HelloWorld_ServiceRole_DefaultPolicy_ResourceRoles0_F82A2883": {
         "name": "TestStackHelloWorldServiceRoleDefaultPolicy3B4BE62E",
         "policy": "\${data.aws_iam_policy_document.HelloWorld_ServiceRole_DefaultPolicy_80066894.json}",
+        "role": "\${aws_iam_role.HelloWorld_ServiceRole_F3F7D8B0.name}"
+      }
+    },
+    "aws_iam_role_policy_attachment": {
+      "HelloWorld_AWSLambdaBasicExecutionRole_Roles0_2F3BB36A": {
+        "policy_arn": "arn:\${data.aws_partition.Partitition.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
         "role": "\${aws_iam_role.HelloWorld_ServiceRole_F3F7D8B0.name}"
       }
     },
@@ -285,9 +288,6 @@ exports[`Function with event rules Should handle dependencies on permissions 1`]
     "aws_iam_role": {
       "HelloWorld_ServiceRole_F3F7D8B0": {
         "assume_role_policy": "\${data.aws_iam_policy_document.HelloWorld_ServiceRole_AssumeRolePolicy_BA710C6B.json}",
-        "managed_policy_arns": [
-          "arn:\${data.aws_partition.Partitition.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
         "name_prefix": "123e4567-e89b-12d3-lloWorldServiceRole",
         "tags": {
           "Name": "Test-HelloWorld",
@@ -300,6 +300,12 @@ exports[`Function with event rules Should handle dependencies on permissions 1`]
       "HelloWorld_ServiceRole_DefaultPolicy_ResourceRoles0_F82A2883": {
         "name": "TestStackHelloWorldServiceRoleDefaultPolicy3B4BE62E",
         "policy": "\${data.aws_iam_policy_document.HelloWorld_ServiceRole_DefaultPolicy_80066894.json}",
+        "role": "\${aws_iam_role.HelloWorld_ServiceRole_F3F7D8B0.name}"
+      }
+    },
+    "aws_iam_role_policy_attachment": {
+      "HelloWorld_AWSLambdaBasicExecutionRole_Roles0_2F3BB36A": {
+        "policy_arn": "arn:\${data.aws_partition.Partitition.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
         "role": "\${aws_iam_role.HelloWorld_ServiceRole_F3F7D8B0.name}"
       }
     },

--- a/test/aws/compute/__snapshots__/function.test.ts.snap
+++ b/test/aws/compute/__snapshots__/function.test.ts.snap
@@ -88,9 +88,6 @@ exports[`Function Should synth and match SnapShot 1`] = `
     "aws_iam_role": {
       "HelloWorld_ServiceRole_F3F7D8B0": {
         "assume_role_policy": "\${data.aws_iam_policy_document.HelloWorld_ServiceRole_AssumeRolePolicy_BA710C6B.json}",
-        "managed_policy_arns": [
-          "arn:\${data.aws_partition.Partitition.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
         "name_prefix": "123e4567-e89b-12d3-lloWorldServiceRole",
         "tags": {
           "Name": "Test-HelloWorld",
@@ -103,6 +100,12 @@ exports[`Function Should synth and match SnapShot 1`] = `
       "HelloWorld_ServiceRole_DefaultPolicy_ResourceRoles0_F82A2883": {
         "name": "TestStackHelloWorldServiceRoleDefaultPolicy3B4BE62E",
         "policy": "\${data.aws_iam_policy_document.HelloWorld_ServiceRole_DefaultPolicy_80066894.json}",
+        "role": "\${aws_iam_role.HelloWorld_ServiceRole_F3F7D8B0.name}"
+      }
+    },
+    "aws_iam_role_policy_attachment": {
+      "HelloWorld_AWSLambdaBasicExecutionRole_Roles0_2F3BB36A": {
+        "policy_arn": "arn:\${data.aws_partition.Partitition.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
         "role": "\${aws_iam_role.HelloWorld_ServiceRole_F3F7D8B0.name}"
       }
     },
@@ -253,9 +256,6 @@ exports[`latest Lambda node runtime with region agnostic stack 1`] = `
     "aws_iam_role": {
       "Lambda_ServiceRole_A8ED4D3B": {
         "assume_role_policy": "\${data.aws_iam_policy_document.Lambda_ServiceRole_AssumeRolePolicy_FE762235.json}",
-        "managed_policy_arns": [
-          "arn:\${data.aws_partition.Partitition.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
         "name_prefix": "123e4567-e89b-12d3-ckLambdaServiceRole",
         "tags": {
           "Name": "Test-Lambda",
@@ -268,6 +268,12 @@ exports[`latest Lambda node runtime with region agnostic stack 1`] = `
       "Lambda_ServiceRole_DefaultPolicy_ResourceRoles0_DE66D1AF": {
         "name": "StackLambdaServiceRoleDefaultPolicyB03C1F73",
         "policy": "\${data.aws_iam_policy_document.Lambda_ServiceRole_DefaultPolicy_E1FFF11A.json}",
+        "role": "\${aws_iam_role.Lambda_ServiceRole_A8ED4D3B.name}"
+      }
+    },
+    "aws_iam_role_policy_attachment": {
+      "Lambda_AWSLambdaBasicExecutionRole_Roles0_F1493B3C": {
+        "policy_arn": "arn:\${data.aws_partition.Partitition.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
         "role": "\${aws_iam_role.Lambda_ServiceRole_A8ED4D3B.name}"
       }
     },

--- a/test/aws/compute/function.test.ts
+++ b/test/aws/compute/function.test.ts
@@ -73,10 +73,17 @@ describe("Function", () => {
         tfResourceType: "aws_iam_role",
       },
       {
-        managed_policy_arns: [
-          "arn:${data.aws_partition.Partitition.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        name_prefix: "123e4567-e89b-12d3-lloWorldServiceRole",
+      },
+    );
+    template.toHaveResourceWithProperties(
+      {
+        tfResourceType: "aws_iam_role_policy_attachment",
+      },
+      {
+        policy_arn:
           "arn:${data.aws_partition.Partitition.partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole",
-        ],
+        role: "${aws_iam_role.HelloWorld_ServiceRole_F3F7D8B0.name}",
       },
     );
     template.toHaveResourceWithProperties(

--- a/test/aws/compute/instance.test.ts
+++ b/test/aws/compute/instance.test.ts
@@ -8,6 +8,7 @@ import {
   dataAwsIamPolicyDocument,
   iamInstanceProfile,
   iamRole,
+  iamRolePolicyAttachment,
 } from "@cdktf/provider-aws";
 import { App, Testing } from "cdktf";
 import "cdktf/lib/testing/adapters/jest";
@@ -987,11 +988,14 @@ test("ssm permissions adds right managed policy", () => {
     ssmSessionPermissions: true,
   });
 
-  Template.synth(stack).toHaveResourceWithProperties(iamRole.IamRole, {
-    managed_policy_arns: [
-      "arn:${data.aws_partition.Partitition.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore",
-    ],
-  });
+  Template.synth(stack).toHaveResourceWithProperties(
+    iamRolePolicyAttachment.IamRolePolicyAttachment,
+    {
+      policy_arn:
+        "arn:${data.aws_partition.Partitition.partition}:iam::aws:policy/AmazonSSMManagedInstanceCore",
+      role: "${aws_iam_role.InstanceOne_InstanceRole_FAC7C1D7.name}",
+    },
+  );
 });
 
 test("sameInstanceClassAs compares identical InstanceTypes correctly", () => {

--- a/test/aws/compute/restapi.test.ts
+++ b/test/aws/compute/restapi.test.ts
@@ -153,13 +153,17 @@ describe("restapi", () => {
           "my-api_CloudWatchRole_095452E5": {
             assume_role_policy:
               "${data.aws_iam_policy_document.my-api_CloudWatchRole_AssumeRolePolicy_428BCDBB.json}",
-            managed_policy_arns: [
-              "arn:${data.aws_partition.Partitition.partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
-            ],
             name_prefix: "123e4567-e89b-12d3-y-apiCloudWatchRole",
             tags: {
               Name: "test-env-my-api",
             },
+          },
+        },
+        aws_iam_role_policy_attachment: {
+          "my-api_AmazonAPIGatewayPushToCloudWatchLogs_Roles0_044E734E": {
+            policy_arn:
+              "arn:${data.aws_partition.Partitition.partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs",
+            role: "${aws_iam_role.my-api_CloudWatchRole_095452E5.name}",
           },
         },
       },
@@ -660,6 +664,7 @@ ${stack.resolve(api.restApiId)}/stage/method/path`.replace(/\n/g, ""),
       {
         depends_on: [
           "aws_api_gateway_rest_api.myapi_162F20B8",
+          "aws_iam_role_policy_attachment.myapi_AmazonAPIGatewayPushToCloudWatchLogs_Roles0_A656E4F8",
           "data.aws_iam_policy_document.myapi_CloudWatchRole_AssumeRolePolicy_D01A67E8",
           "aws_iam_role.myapi_CloudWatchRole_EB425128",
           "aws_api_gateway_account.myapi_Account_C3A4750C",

--- a/test/aws/iam/managed-policy.test.ts
+++ b/test/aws/iam/managed-policy.test.ts
@@ -126,10 +126,13 @@ describe("managed policy", () => {
           MyRole_F48FFE04: {
             assume_role_policy:
               "${data.aws_iam_policy_document.MyRole_AssumeRolePolicy_4BED951C.json}",
-            managed_policy_arns: [
-              "${aws_iam_policy.MyManagedPolicy_9F3720AE.arn}",
-            ],
             name_prefix: "123e4567-e89b-12d3-MyStackMyRole",
+          },
+        },
+        aws_iam_role_policy_attachment: {
+          MyManagedPolicy_Roles0_8B8C8B56: {
+            policy_arn: "${aws_iam_policy.MyManagedPolicy_9F3720AE.arn}",
+            role: "${aws_iam_role.MyRole_F48FFE04.name}",
           },
         },
       },
@@ -282,9 +285,13 @@ describe("managed policy", () => {
         },
         aws_iam_role: {
           MyRole_F48FFE04: {
-            managed_policy_arns: [
-              "${aws_iam_policy.MyManagedPolicy_9F3720AE.arn}",
-            ],
+            name_prefix: "123e4567-e89b-12d3-MyStackMyRole",
+          },
+        },
+        aws_iam_role_policy_attachment: {
+          MyManagedPolicy_Roles0_8B8C8B56: {
+            policy_arn: "${aws_iam_policy.MyManagedPolicy_9F3720AE.arn}",
+            role: "${aws_iam_role.MyRole_F48FFE04.name}",
           },
         },
       },
@@ -617,10 +624,13 @@ describe("managed policy", () => {
           MyRole_F48FFE04: {
             assume_role_policy:
               "${data.aws_iam_policy_document.MyRole_AssumeRolePolicy_4BED951C.json}",
-            managed_policy_arns: [
-              "${aws_iam_policy.MyManagedPolicy_9F3720AE.arn}",
-            ],
             name_prefix: "123e4567-e89b-12d3-MyStackMyRole",
+          },
+        },
+        aws_iam_role_policy_attachment: {
+          MyManagedPolicy_Roles0_8B8C8B56: {
+            policy_arn: "${aws_iam_policy.MyManagedPolicy_9F3720AE.arn}",
+            role: "${aws_iam_role.MyRole_F48FFE04.name}",
           },
         },
       },
@@ -653,10 +663,14 @@ describe("managed policy", () => {
           MyRole_F48FFE04: {
             assume_role_policy:
               "${data.aws_iam_policy_document.MyRole_AssumeRolePolicy_4BED951C.json}",
-            managed_policy_arns: [
-              "arn:${data.aws_partition.Partitition.partition}:iam::aws:policy/AnAWSManagedPolicy",
-            ],
             name_prefix: "123e4567-e89b-12d3-MyStackMyRole",
+          },
+        },
+        aws_iam_role_policy_attachment: {
+          polRef_Roles0_EAE7DD30: {
+            policy_arn:
+              "arn:${data.aws_partition.Partitition.partition}:iam::aws:policy/AnAWSManagedPolicy",
+            role: "${aws_iam_role.MyRole_F48FFE04.name}",
           },
         },
       },
@@ -689,10 +703,14 @@ describe("managed policy", () => {
           MyRole_F48FFE04: {
             assume_role_policy:
               "${data.aws_iam_policy_document.MyRole_AssumeRolePolicy_4BED951C.json}",
-            managed_policy_arns: [
-              "arn:${data.aws_partition.Partitition.partition}:iam::${data.aws_caller_identity.CallerIdentity.account_id}:policy/ACustomerManagedPolicyName",
-            ],
             name_prefix: "123e4567-e89b-12d3-MyStackMyRole",
+          },
+        },
+        aws_iam_role_policy_attachment: {
+          MyManagedPolicy_Roles0_8B8C8B56: {
+            policy_arn:
+              "arn:${data.aws_partition.Partitition.partition}:iam::${data.aws_caller_identity.CallerIdentity.account_id}:policy/ACustomerManagedPolicyName",
+            role: "${aws_iam_role.MyRole_F48FFE04.name}",
           },
         },
       },
@@ -729,10 +747,13 @@ describe("managed policy", () => {
           MyRole_F48FFE04: {
             assume_role_policy:
               "${data.aws_iam_policy_document.MyRole_AssumeRolePolicy_4BED951C.json}",
-            managed_policy_arns: [
-              "${data.aws_iam_policy.MyManagedPolicy_9F3720AE.arn}",
-            ],
             name_prefix: "123e4567-e89b-12d3-MyStackMyRole",
+          },
+        },
+        aws_iam_role_policy_attachment: {
+          MyManagedPolicy_Roles0_8B8C8B56: {
+            policy_arn: "${data.aws_iam_policy.MyManagedPolicy_9F3720AE.arn}",
+            role: "${aws_iam_role.MyRole_F48FFE04.name}",
           },
         },
       },


### PR DESCRIPTION
As the `managed_policy_arns` property has been deprecated from `aws_iam_role` resource (more details [here](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/design-decisions/exclusive-relationship-management-resources.md)), we will create a separate [aws_iam_role_policy_attachment](https://registry.terraform.io/providers/hashicorp/aws/6.25.0/docs/resources/iam_role_policy_attachment) for each managed policy that is added to the role.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.