### PR TITLE
chore(integ): regression tests for EventBridge Rule

### DIFF
--- a/integ/aws/notify/apps/eventbridge-rule-lambda.ts
+++ b/integ/aws/notify/apps/eventbridge-rule-lambda.ts
@@ -1,0 +1,112 @@
+// Integration test for EventBridge Rule with custom event bus and Lambda target
+// Regression test for: https://github.com/TerraConstructs/base/pull/89
+
+import { App, LocalBackend } from "cdktf";
+import { aws } from "../../../../src";
+
+/**
+ * The standard nodejs runtime used for integration tests.
+ */
+export const STANDARD_NODEJS_RUNTIME = aws.compute.Runtime.NODEJS_18_X;
+
+const environmentName = process.env.ENVIRONMENT_NAME ?? "test";
+const region = process.env.AWS_REGION ?? "us-east-1";
+const outdir = process.env.OUT_DIR ?? "cdktf.out";
+const stackName = process.env.STACK_NAME ?? "eventbridge-rule-lambda";
+
+class EventBridgeRuleLambdaStack extends aws.AwsStack {
+  constructor(scope: App, id: string, props: aws.AwsStackProps) {
+    super(scope, id, props);
+
+    // Create a custom event bus (not default)
+    const eventBus = new aws.notify.EventBus(this, "CustomEventBus", {
+      eventBusName: "custom-event-bus",
+      registerOutputs: true,
+      outputName: "event_bus",
+    });
+
+    // Create a Lambda function that will be triggered by the rule
+    const targetFunction = new aws.compute.LambdaFunction(
+      this,
+      "TargetFunction",
+      {
+        handler: "index.handler",
+        runtime: STANDARD_NODEJS_RUNTIME,
+        code: aws.compute.Code.fromInline(
+          `exports.handler = ${handler.toString()}`,
+        ),
+        registerOutputs: true,
+        outputName: "target_function",
+      },
+    );
+
+    // Create a rule on the custom event bus with a Lambda target
+    // This tests the bug where the event bus name was not set on the target
+    const rule = new aws.notify.Rule(this, "TestRule", {
+      eventBus: eventBus,
+      eventPattern: {
+        source: ["custom.source"],
+        detailType: ["Custom Event"],
+      },
+      targets: [new aws.notify.targets.LambdaFunction(targetFunction)],
+      registerOutputs: true,
+      outputName: "rule",
+    });
+
+    // Also test with fromEventBusName pattern (another common use case)
+    const importedEventBus = aws.notify.EventBus.fromEventBusName(
+      this,
+      "ImportedEventBus",
+      eventBus.eventBusName,
+    );
+
+    const importedBusFunction = new aws.compute.LambdaFunction(
+      this,
+      "ImportedBusFunction",
+      {
+        handler: "index.handler",
+        runtime: STANDARD_NODEJS_RUNTIME,
+        code: aws.compute.Code.fromInline(
+          `exports.handler = ${handler.toString()}`,
+        ),
+        registerOutputs: true,
+        outputName: "imported_bus_function",
+      },
+    );
+
+    const importedBusRule = new aws.notify.Rule(this, "ImportedBusRule", {
+      eventBus: importedEventBus,
+      eventPattern: {
+        source: ["imported.source"],
+        detailType: ["Imported Event"],
+      },
+      targets: [new aws.notify.targets.LambdaFunction(importedBusFunction)],
+      registerOutputs: true,
+      outputName: "imported_bus_rule",
+    });
+  }
+}
+
+const app = new App({
+  outdir,
+});
+const stack = new EventBridgeRuleLambdaStack(app, stackName, {
+  gridUUID: "12345678-1234",
+  environmentName,
+  providerConfig: {
+    region,
+  },
+});
+new LocalBackend(stack, {
+  path: `${stackName}.tfstate`,
+});
+app.synth();
+
+function handler(event: any, _context: any, callback: any) {
+  /* eslint-disable no-console */
+  console.log("====================================================");
+  console.log("EventBridge event received:");
+  console.log(JSON.stringify(event, undefined, 2));
+  console.log("====================================================");
+  return callback(undefined, event);
+}


### PR DESCRIPTION
Add comprehensive integration tests to prevent regression of the bug fixed in #89 where EventBridge Rule targets were missing the event_bus_name property when using a custom event bus (not default).

Changes:
- Add eventbridge-rule-lambda integration test app that creates:
  * A custom EventBus (not default)
  * A Rule on that custom event bus with Lambda target
  * A second rule using fromEventBusName pattern

- Add helper functions to integ/aws/eventbridge.go:
  * DescribeEventBridgeRule - get rule details with event bus support
  * ListEventBridgeTargets - list targets for a rule on a specific event bus

- Add validateEventBridgeRuleLambda test validation that:
  * Verifies rules are created on the correct event bus
  * Verifies targets can be listed (proving event_bus_name is set correctly)
  * Tests end-to-end functionality by sending events and verifying Lambda invocation
  * Tests both direct EventBus creation and fromEventBusName import patterns

This test ensures that the event_bus_name property is correctly set on EventBridge targets when using a custom event bus, preventing the error: "Rule <rule-name> does not exist on EventBus default"

Regression test for: https://github.com/TerraConstructs/base/pull/89

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.