### PR TITLE
feat(aws): make stack AZ helper region-aware for cross-region lookups

### DIFF
--- a/src/aws/aws-stack.ts
+++ b/src/aws/aws-stack.ts
@@ -37,6 +37,12 @@ import { SKIP_DEPENDENCY_PROPAGATION } from "../private/terraform-dependables-as
 
 const AWS_STACK_SYMBOL = Symbol.for("terraconstructs/lib/aws.AwsStack");
 
+/**
+ * Cache key used for region-scoped lookups that target the stack's own
+ * provider region (i.e. no explicit region was requested).
+ */
+const DEFAULT_REGION_KEY = "default_region";
+
 export interface AwsStackProps extends StackBaseProps {
   /**
    * The AWS Provider configuration (without the alias field)
@@ -103,7 +109,12 @@ interface AwsLookup {
   dataAwsRegion?: dataAwsRegion.DataAwsRegion;
   dataAwsCallerIdentity?: dataAwsCallerIdentity.DataAwsCallerIdentity;
   dataAwsPartition?: dataAwsPartition.DataAwsPartition;
-  dataAwsAvailabilityZones?: dataAwsAvailabilityZones.DataAwsAvailabilityZones;
+  // AWS Availability Zones data sources keyed by region (DEFAULT_REGION_KEY for
+  // the stack's own provider region).
+  dataAwsAvailabilityZones: Record<
+    string,
+    dataAwsAvailabilityZones.DataAwsAvailabilityZones
+  >;
   // AWS Service Principals by region and by service
   dataAwsServicePrincipals: Record<
     string,
@@ -204,6 +215,7 @@ export class AwsStack extends StackBase implements IAwsStack {
         // defaultTags: this.cdkTagManager.renderedTags,
         ...(this._providerConfig ?? {}),
       }),
+      dataAwsAvailabilityZones: {},
       dataAwsServicePrincipals: {},
     };
     return this._lookup;
@@ -264,20 +276,36 @@ export class AwsStack extends StackBase implements IAwsStack {
     return this.lookup.dataAwsCallerIdentity;
   }
 
-  private get dataAwsAvailabilityZones(): dataAwsAvailabilityZones.DataAwsAvailabilityZones {
-    if (!this.lookup.dataAwsAvailabilityZones) {
+  /**
+   * Get (or lazily create) the `aws_availability_zones` data source for a
+   * region.
+   *
+   * When `region` is omitted the data source resolves against the stack's
+   * default provider region. When `region` is provided the AWS provider v6
+   * per-resource `region` argument is used to query that region directly,
+   * without requiring a separate provider alias.
+   */
+  private getDataAwsAvailabilityZones(
+    region?: string,
+  ): dataAwsAvailabilityZones.DataAwsAvailabilityZones {
+    const key = region ?? DEFAULT_REGION_KEY;
+    if (!this.lookup.dataAwsAvailabilityZones[key]) {
       const azs = new dataAwsAvailabilityZones.DataAwsAvailabilityZones(
         this,
-        "AvailabilityZones",
+        region
+          ? `AvailabilityZones_${toTerraformIdentifier(region)}`
+          : "AvailabilityZones",
         {
           provider: this.lookup.awsProvider,
+          // undefined for the default region -> omitted from synthesized output
+          region,
         },
       );
       // these should never depend on anything (HACK to avoid cycles)
       Object.defineProperty(azs, SKIP_DEPENDENCY_PROPAGATION, { value: true });
-      this.lookup.dataAwsAvailabilityZones = azs;
+      this.lookup.dataAwsAvailabilityZones[key] = azs;
     }
-    return this.lookup.dataAwsAvailabilityZones;
+    return this.lookup.dataAwsAvailabilityZones[key];
   }
 
   private get dataAwsPartition(): dataAwsPartition.DataAwsPartition {
@@ -363,7 +391,6 @@ export class AwsStack extends StackBase implements IAwsStack {
    * @param region The region to get the service principal ID for
    */
   public servicePrincipalName(service: string, region?: string): string {
-    const DEFAULT_REGION_KEY = "default_region";
     if (!region) {
       region = DEFAULT_REGION_KEY;
     }
@@ -498,7 +525,7 @@ export class AwsStack extends StackBase implements IAwsStack {
    * To specify a different strategy for selecting availability zones override this method.
    */
   public get availabilityZoneIterator(): ResourceTerraformIterator {
-    const azs = this.dataAwsAvailabilityZones;
+    const azs = this.getDataAwsAvailabilityZones();
     return TerraformIterator.fromDataSources(azs);
   }
 
@@ -508,11 +535,17 @@ export class AwsStack extends StackBase implements IAwsStack {
    *
    * The list length is `maxCount` which defaults to 2.
    *
+   * When `region` is provided, the AZs are resolved for that region using the
+   * AWS provider v6 per-resource `region` argument (no provider alias is
+   * required). This is primarily useful for cross-region lookups such as
+   * `Vpc.fromLookup({ region })`.
+   *
    * @param maxCount the maximum number of AZs to return
+   * @param region the region to resolve AZs for (defaults to the stack region)
    */
-  public availabilityZones(maxCount: number = 2): string[] {
+  public availabilityZones(maxCount: number = 2, region?: string): string[] {
     // TODO: Implement ContextProvider
-    const azs = this.dataAwsAvailabilityZones;
+    const azs = this.getDataAwsAvailabilityZones(region);
     const azLookups: any[] = [];
     for (let i = 0; i < maxCount; i++) {
       azLookups.push(Fn.element(azs.names, i));

--- a/src/aws/compute/vpc.ts
+++ b/src/aws/compute/vpc.ts
@@ -1682,7 +1682,9 @@ export class Vpc extends VpcBase {
       attributes = {
         vpcId: data.id,
         vpcCidrBlock: data.cidrBlock,
-        availabilityZones: stack.availabilityZones(),
+        // Resolve AZs for the looked-up region so cross-region lookups do not
+        // mix the enclosing stack region's AZs (see issue #102).
+        availabilityZones: stack.availabilityZones(2, options.region),
         region: options.region,
       };
     }

--- a/test/aws/compute/vpc.from-lookup.test.ts
+++ b/test/aws/compute/vpc.from-lookup.test.ts
@@ -1,7 +1,11 @@
 // https://github.com/aws/aws-cdk/blob/v2.233.0/packages/aws-cdk-lib/aws-ec2/test/vpc.from-lookup.test.ts
 
 import * as cxschema from "@aws-cdk/cloud-assembly-schema";
-import { dataAwsSubnet, dataAwsVpc } from "@cdktn/provider-aws";
+import {
+  dataAwsAvailabilityZones,
+  dataAwsSubnet,
+  dataAwsVpc,
+} from "@cdktn/provider-aws";
 import { Lazy } from "cdktn";
 import "cdktn/lib/testing/adapters/jest";
 import { Construct } from "constructs";
@@ -444,6 +448,35 @@ describe("vpc from lookup", () => {
           },
         ],
       });
+    });
+
+    test("cross-region fallback resolves availabilityZones for the lookup region", () => {
+      // GIVEN - a stack in us-east-1 looking up a VPC in us-west-2
+      const stack = new AwsStack(undefined, undefined, {
+        providerConfig: { region: "us-east-1" },
+      });
+
+      // WHEN - fromLookup with a different region triggers the data-source fallback
+      const vpc = Vpc.fromLookup(stack, "Vpc", {
+        vpcId: "vpc-1234",
+        region: "us-west-2",
+      });
+
+      // THEN - the fallback AZs reference a region-scoped data source, not the
+      // stack's default-region one (issue #102)
+      expect(stack.resolve(vpc.availabilityZones)).toEqual([
+        "${element(data.aws_availability_zones.AvailabilityZones_us_west_2.names, 0)}",
+        "${element(data.aws_availability_zones.AvailabilityZones_us_west_2.names, 1)}",
+      ]);
+
+      // AND - that data source carries the per-resource region argument
+      const t = new Template(stack);
+      t.expect.toHaveDataSourceWithProperties(
+        dataAwsAvailabilityZones.DataAwsAvailabilityZones,
+        {
+          region: "us-west-2",
+        },
+      );
     });
 
     test("fallback lookup VPC preserves availabilityZones from stack when no subnet groups", () => {

--- a/test/aws/stack.test.ts
+++ b/test/aws/stack.test.ts
@@ -89,6 +89,47 @@ describe("stack", () => {
       "${element(data.aws_availability_zones.AvailabilityZones.names, 1)}",
     ]);
   });
+
+  test("stack.availabilityZones(region) returns references to a region-scoped data source", () => {
+    // GIVEN
+    const app = new App();
+    const stack = new AwsStack(app, "MyStack", {
+      providerConfig: {
+        region: "us-east-1",
+      },
+    });
+    // WHEN
+    const azs = stack.availabilityZones(2, "us-west-2");
+    // THEN - resolves against a region-suffixed data source, not the default one
+    expect(stack.resolve(azs)).toEqual([
+      "${element(data.aws_availability_zones.AvailabilityZones_us_west_2.names, 0)}",
+      "${element(data.aws_availability_zones.AvailabilityZones_us_west_2.names, 1)}",
+    ]);
+    // AND - the region-scoped data source carries the per-resource region arg
+    const synthesized = JSON.parse(JSON.stringify(stack.toTerraform()));
+    expect(
+      synthesized.data.aws_availability_zones.AvailabilityZones_us_west_2
+        .region,
+    ).toEqual("us-west-2");
+  });
+
+  test("stack.availabilityZones(region) caches per region", () => {
+    // GIVEN
+    const app = new App();
+    const stack = new AwsStack(app, "MyStack", {
+      providerConfig: {
+        region: "us-east-1",
+      },
+    });
+    // WHEN - two calls for the same region
+    stack.availabilityZones(2, "us-west-2");
+    stack.availabilityZones(3, "us-west-2");
+    // THEN - only a single region-scoped data source is created
+    const synthesized = JSON.parse(JSON.stringify(stack.toTerraform()));
+    expect(Object.keys(synthesized.data.aws_availability_zones)).toEqual([
+      "AvailabilityZones_us_west_2",
+    ]);
+  });
 });
 
 describe("regionalFact", () => {


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

---

Fixes #102

## Narrow focus

This PR is intentionally scoped to the **availability-zone helper** and **`Vpc.fromLookup`**, so the diff stays small and reviewable.

`Vpc.fromLookup({ region })` already queried the correct region for the VPC data source (#91), but its fallback `availabilityZones` were still sourced from the enclosing stack's provider region — so cross-region lookups mixed regions. This fixes that.

The key enabler is **AWS provider v6** (`@cdktn/provider-aws@24.8.0`): data sources now expose a first-class per-resource `region` argument (confirmed `DataAwsAvailabilityZones.region?: string`). Cross-region AZ lookups therefore no longer need a separate provider alias — the data source targets the region directly on the default provider.

## Changes

**`src/aws/aws-stack.ts`**
- `AwsStack.availabilityZones(maxCount?, region?)` — new optional `region` parameter. When supplied, provisions a region-scoped `aws_availability_zones` data source (construct id `AvailabilityZones_<region>`) carrying the v6 `region` argument.
- Replaced the single cached AZ getter with `getDataAwsAvailabilityZones(region?)`, caching **one data source per region** (keyed by region; `DEFAULT_REGION_KEY` for the stack's own region).
- Hoisted the duplicated `DEFAULT_REGION_KEY` to a module constant (also used by `servicePrincipalName`).
- **Backward compatible**: the no-region path keeps the same construct id (`AvailabilityZones`), emits no `region` in output, and behaves exactly as before. `availabilityZoneIterator` remains a getter (no API break).

**`src/aws/compute/vpc.ts`**
- `Vpc.fromLookup` fallback now calls `stack.availabilityZones(2, options.region)` so all region-sensitive fallback metadata corresponds to the lookup region.

## Tests

- `test/aws/stack.test.ts` — region-scoped references + per-region caching.
- `test/aws/compute/vpc.from-lookup.test.ts` — cross-region fallback resolves AZs against `AvailabilityZones_us_west_2` with the `region` argument set.

Verification: stack + vpc.from-lookup tests (31) and the full vpc suite (130) pass; `tsc` reports no new errors in changed files; eslint clean.

## Follow-up work — IAM / provider aliases (#103)

This PR deliberately does **not** touch the older provider-alias path. `AwsStack.servicePrincipalName()` still uses `getRegionalAwsProvider(region)` to create an aliased provider per region. That should migrate to the same v6 per-resource `region` argument, after which `getRegionalAwsProvider()` and the `regionalAwsProviders` cache can be removed. Because that touches IAM/ARN code paths and changes more snapshots, it's tracked separately in **#103** for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01WArWt85um7GUcM1st9fLvL)_