### PR TITLE
chore(integ): add cross-region VPC lookup validation

### DIFF
--- a/integ/aws/compute/Makefile
+++ b/integ/aws/compute/Makefile
@@ -48,6 +48,10 @@ machine-image: ## Test Machine Image
 	go test -v -count 1 -timeout 15m ./... -run ^TestMachineImage$
 .PHONY: machine-image
 
+vpc-lookup: ## Test VPC lookup
+	go test -v -count 1 -timeout 15m ./... -run ^TestVpcLookup$
+.PHONY: vpc-lookup
+
 apigw-authorizer: ## Test All API Gateway Authorizer tests (sequential)
 	go test -v -count 1 -p 1 -parallel 1 -timeout 15m ./... -run '^TestApigw.*Authorizer.*$$'
 .PHONY: apigw-authorizer

--- a/integ/aws/compute/apps/package.json
+++ b/integ/aws/compute/apps/package.json
@@ -12,6 +12,7 @@
     "launch-template": "bun run ./launch-template.ts",
     "instance-public": "bun run ./instance-public.ts",
     "machine-image": "bun run ./machine-image.ts",
+    "vpc-lookup": "bun run ./vpc-lookup.ts",
     "apigw.request-authorizer": "bun run ./apigw.request-authorizer.ts",
     "apigw.token-authorizer": "bun run ./apigw.token-authorizer.ts",
     "apigw.token-authorizer-iam-role": "bun run ./apigw.token-authorizer-iam-role.ts"

--- a/integ/aws/compute/apps/vpc-lookup.ts
+++ b/integ/aws/compute/apps/vpc-lookup.ts
@@ -1,0 +1,47 @@
+// https://github.com/aws/aws-cdk/blob/main/packages/@aws-cdk-testing/framework-integ/test/aws-ec2/test/integ.vpc-lookup.ts
+
+import { App, LocalBackend, TerraformOutput } from "cdktn";
+import { aws } from "../../../../src";
+
+const environmentName = process.env.ENVIRONMENT_NAME ?? "test";
+const region = process.env.AWS_REGION ?? "us-east-1";
+const lookupRegion = process.env.LOOKUP_REGION ?? region;
+const outdir = process.env.OUT_DIR ?? "cdktf.out";
+const stackName = process.env.STACK_NAME ?? "vpc-lookup";
+
+const app = new App({
+  outdir,
+});
+
+const stack = new aws.AwsStack(app, stackName, {
+  gridUUID: "12345678-1234",
+  environmentName,
+  providerConfig: {
+    region,
+  },
+});
+new LocalBackend(stack, {
+  path: `${stackName}.tfstate`,
+});
+
+const vpcFromLookup = aws.compute.Vpc.fromLookup(stack, "VpcFromLookup", {
+  isDefault: true,
+  region: lookupRegion,
+});
+
+new TerraformOutput(stack, "OutputFromLookup", {
+  value: `Region fromLookup: ${vpcFromLookup.env.region}`,
+  staticId: true,
+});
+
+new TerraformOutput(stack, "AvailabilityZonesFromLookup", {
+  value: vpcFromLookup.availabilityZones.join(","),
+  staticId: true,
+});
+
+new TerraformOutput(stack, "VpcIdFromLookup", {
+  value: vpcFromLookup.vpcId,
+  staticId: true,
+});
+
+app.synth();

--- a/integ/aws/compute/ec2_test.go
+++ b/integ/aws/compute/ec2_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"testing"
 	"time"
 
@@ -145,6 +146,48 @@ func TestInstancePublic(t *testing.T) {
 	})
 }
 
+func TestVpcLookup(t *testing.T) {
+	envVars := executors.EnvMap(os.Environ())
+
+	testApp := "vpc-lookup"
+	awsRegion := "us-east-1"
+	lookupRegion := "us-west-2"
+	t.Parallel()
+	tfWorkingDir := filepath.Join("tf", testApp)
+	envVars["AWS_REGION"] = awsRegion
+	envVars["LOOKUP_REGION"] = lookupRegion
+	envVars["ENVIRONMENT_NAME"] = "test"
+	envVars["STACK_NAME"] = testApp
+
+	defer test_structure.RunTestStage(t, "cleanup_terraform", func() {
+		util.UndeployUsingTerraform(t, tfWorkingDir)
+	})
+
+	test_structure.RunTestStage(t, "synth_app", func() {
+		util.SynthApp(t, testApp, tfWorkingDir, envVars)
+	})
+	test_structure.RunTestStage(t, "deploy_terraform", func() {
+		util.DeployUsingTerraform(t, tfWorkingDir, nil)
+	})
+	test_structure.RunTestStage(t, "validate", func() {
+		validateVpcLookup(t, tfWorkingDir, lookupRegion)
+	})
+}
+
+func validateVpcLookup(t *testing.T, tfWorkingDir string, lookupRegion string) {
+	terraformOptions := test_structure.LoadTerraformOptions(t, tfWorkingDir)
+	outputs := terraform.OutputAll(t, terraformOptions)
+
+	assert.Equal(t, "Region fromLookup: "+lookupRegion, outputs["OutputFromLookup"].(string))
+	assert.NotEmpty(t, outputs["VpcIdFromLookup"].(string))
+
+	availabilityZones := outputs["AvailabilityZonesFromLookup"].(string)
+	require.NotEmpty(t, availabilityZones)
+	for _, availabilityZone := range strings.Split(availabilityZones, ",") {
+		assert.Truef(t, strings.HasPrefix(availabilityZone, lookupRegion), "availability zone %q should be in lookup region %q", availabilityZone, lookupRegion)
+	}
+}
+
 // Test the machine-image app
 func TestMachineImage(t *testing.T) {
 	envVars := executors.EnvMap(os.Environ())
@@ -239,29 +282,29 @@ func validateInstancePublic(t *testing.T, tfWorkingDir, awsRegion string) {
 
 	// Wait for instance to be running before validation
 	util.WaitForEc2InstanceRunning(t, awsRegion, instanceID, 10, 10*time.Second)
-	
+
 	// Fetch instance details
 	instance := util.GetEc2InstanceDetails(t, awsRegion, instanceID)
 
 	// Validate basic instance properties
 	assert.Equal(t, "t3.nano", string(instance.InstanceType))
 	assert.Equal(t, vpcID, *instance.VpcId)
-	
+
 	// Validate instance has public IP
 	require.NotNil(t, instance.PublicIpAddress, "instance should have a public IP address")
 	assert.Equal(t, instancePublicIP, *instance.PublicIpAddress)
-	
+
 	// Validate associate_public_ip_address was set correctly
-	assert.True(t, instance.PublicIpAddress != nil && *instance.PublicIpAddress != "", 
+	assert.True(t, instance.PublicIpAddress != nil && *instance.PublicIpAddress != "",
 		"instance should have associate_public_ip_address=true resulting in a public IP")
-	
+
 	// Validate instance has private IP
 	require.NotNil(t, instance.PrivateIpAddress, "instance should have a private IP address")
 	assert.NotEmpty(t, *instance.PrivateIpAddress)
-	
+
 	// Validate security groups (should have at least one)
 	require.True(t, len(instance.SecurityGroups) > 0, "instance should have at least one security group")
-	
+
 	// Test network connectivity - ping the public IP
 	// This validates that ICMP is allowed and the instance is reachable
 	util.PingHost(t, instancePublicIP, 5*time.Second)


### PR DESCRIPTION
## Summary
- Adds a CDKTN-style compute integ app based on AWS CDK's `integ.vpc-lookup.ts`.
- Validates `Vpc.fromLookup(..., { region: LOOKUP_REGION })` from a stack in `us-east-1` against the default VPC in `us-west-2`.
- Asserts the looked-up VPC ID is non-empty and fallback availability zones are scoped to the lookup region.

## Validation
- `pnpm compile`
- `pnpm eslint`
- `cd integ/aws/compute && AWS_PROFILE=tcons-hermes AWS_REGION=us-east-1 LOOKUP_REGION=us-west-2 make vpc-lookup-synth-only`
- `cd integ/aws/compute && AWS_PROFILE=tcons-hermes AWS_REGION=us-east-1 LOOKUP_REGION=us-west-2 make vpc-lookup`

Runtime validation observed:
- `OutputFromLookup = "Region fromLookup: us-west-2"`
- `AvailabilityZonesFromLookup = "us-west-2a,us-west-2b"`
- `VpcIdFromLookup = "vpc-f8ff6d80"`
- OpenTofu apply/destroy completed with `0` resources added/destroyed; data sources only.

## Relationship to #104
This branch is intentionally stacked on top of PR #104's commits so it can validate the region-aware availability-zone helper change directly. The PR target is still `main` and is left as a draft.
