### PR TITLE
feat(aws): SecretsManager L2 — combined landing (supersedes #117) [stacked]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/kms v1.49.4
 	github.com/aws/aws-sdk-go-v2/service/lambda v1.87.0
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.93.2
+	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.6
 	github.com/aws/aws-sdk-go-v2/service/servicediscovery v1.42.0
 	github.com/aws/aws-sdk-go-v2/service/sfn v1.40.5
 	github.com/aws/aws-sdk-go-v2/service/sns v1.39.10
@@ -66,7 +67,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.16 // indirect
 	github.com/aws/aws-sdk-go-v2/service/rds v1.91.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/route53 v1.46.2 // indirect
-	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.34.6 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.56.0 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.7 // indirect

--- a/integ/aws/encryption/Makefile
+++ b/integ/aws/encryption/Makefile
@@ -11,3 +11,11 @@ key: ## Test AWS KMS Customer Master Key creation
 key-alias: ## Test AWS KMS CMK + alias creation
 	go test -v -count 1 -timeout 15m ./... -run ^TestKeyAlias$
 .PHONY: key-alias
+
+secret-attach: ## Test SecretsManager Secret.attach() against an RDS DbInstance
+	go test -v -count 1 -timeout 30m ./... -run ^TestSecretAttach$
+.PHONY: secret-attach
+
+secret.replica: ## Test AWS Secrets Manager Secret + replica region
+	go test -v -count 1 -timeout 15m ./... -run ^TestSecretReplica$
+.PHONY: secret.replica

--- a/integ/aws/encryption/README.md
+++ b/integ/aws/encryption/README.md
@@ -13,6 +13,8 @@ Test Targets:
   all                        Test all Stepfunctions
   key                        Test AWS KMS Customer Master Key creation
   key-alias                  Test AWS KMS CMK + alias creation
+  secret-attach              Test SecretsManager Secret.attach() against an RDS DbInstance
+  secret.replica             Test AWS Secrets Manager Secret + replica region
 
 Other Targets:
   help                       Print out every target with a description

--- a/integ/aws/encryption/apps/package.json
+++ b/integ/aws/encryption/apps/package.json
@@ -3,7 +3,9 @@
   "type": "module",
   "scripts": {
     "key-alias": "bun run ./key-alias.ts",
-    "key": "bun run ./key.ts"
+    "key": "bun run ./key.ts",
+    "secret-attach": "bun run ./secret-attach.ts",
+    "secret.replica": "bun run ./secret.replica.ts"
   },
   "dependencies": {
     "cdktn": "^0.23.0",

--- a/integ/aws/encryption/apps/secret-attach.ts
+++ b/integ/aws/encryption/apps/secret-attach.ts
@@ -1,0 +1,139 @@
+// Demonstrates `encryption.Secret.attach()` against a real target (an RDS
+// `aws_db_instance`), composing the provider-aws RDS L1 the same way an
+// upstream aws-rds `DatabaseInstance` would (see AGREED DESIGN in
+// src/aws/encryption/secret.ts).
+//
+// IMPORTANT: `RdsDbInstanceAttachmentTarget` below is a TEST-ONLY adapter.
+// TerraConstructs does not ship any concrete `ISecretAttachmentTarget`
+// implementation in `src/` -- consumers of the library must provide their
+// own (e.g. once aws-rds is ported) or copy a pattern like this one.
+//
+// Because the Terraform AWS provider has no equivalent of CloudFormation's
+// `AWS::SecretsManager::SecretTargetAttachment` (no server-side merge of
+// connection details into the secret value -- see the class doc on
+// `SecretTargetAttachment`), the TARGET supplies the connection details via
+// `asSecretAttachmentTarget().connectionFields`, and `attach()` merges them
+// into the secret's single version. The `ConnectionsSecret` below is created
+// with ONLY the base credentials (username + password); `attach()` folds in
+// the DbInstance's engine/host/port/dbname -- so the deployed secret ends up
+// with the full connection details WITHOUT this app pre-building the merge.
+import {
+  dataAwsSecretsmanagerRandomPassword,
+  dbInstance,
+} from "@cdktn/provider-aws";
+import { App, Fn, LocalBackend, TerraformOutput } from "cdktn";
+import { aws, Duration } from "../../../../src";
+
+const environmentName = process.env.ENVIRONMENT_NAME ?? "test";
+const region = process.env.AWS_REGION ?? "us-east-1";
+const outdir = process.env.OUT_DIR ?? "cdktf.out";
+const stackName = process.env.STACK_NAME ?? "secret-attach";
+
+const app = new App({
+  outdir,
+});
+
+const stack = new aws.AwsStack(app, stackName, {
+  gridUUID: "g12345678-1234",
+  environmentName,
+  providerConfig: {
+    region,
+  },
+});
+new LocalBackend(stack, {
+  path: `${stackName}.tfstate`,
+});
+
+const masterUsername = "dbadmin";
+
+// Generate the RDS master password out-of-band (no server-side merge is
+// available in Terraform, so the DB's own credentials are not sourced from
+// the "connections" secret below -- see module doc comment above).
+const masterPassword =
+  new dataAwsSecretsmanagerRandomPassword.DataAwsSecretsmanagerRandomPassword(
+    stack,
+    "MasterPassword",
+    {
+      passwordLength: 20,
+      excludePunctuation: true,
+    },
+  );
+
+const database = new dbInstance.DbInstance(stack, "Database", {
+  identifier: `db-${stack.gridUUID}`,
+  engine: "postgres",
+  instanceClass: "db.t3.micro",
+  allocatedStorage: 20,
+  dbName: "appdb",
+  username: masterUsername,
+  password: masterPassword.randomPassword,
+  skipFinalSnapshot: true,
+  applyImmediately: true,
+  publiclyAccessible: false,
+  backupRetentionPeriod: 0,
+});
+
+/**
+ * TEST-ONLY adapter demonstrating how a concrete `ISecretAttachmentTarget`
+ * would be implemented on top of the RDS L1 (`dbInstance.DbInstance`). This
+ * pattern intentionally lives in the integ app, not in `src/` -- see the
+ * "HARD CONSTRAINT" note on `ISecretAttachmentTarget` in
+ * src/aws/encryption/secret.ts.
+ */
+class RdsDbInstanceAttachmentTarget
+  implements aws.encryption.ISecretAttachmentTarget
+{
+  constructor(private readonly instance: dbInstance.DbInstance) {}
+
+  public asSecretAttachmentTarget(): aws.encryption.SecretAttachmentTargetProps {
+    return {
+      targetId: this.instance.id,
+      targetType: aws.encryption.AttachmentTargetType.RDS_DB_INSTANCE,
+      // Terraform has no server-side merge, so the target supplies the
+      // connection details that attach() folds into the secret value.
+      connectionFields: {
+        engine: this.instance.engine,
+        host: this.instance.address,
+        // `port` is a number attribute; force a Terraform `tostring()` so the
+        // merged JSON value is a string (connectionFields is a string map).
+        port: Fn.tostring(this.instance.port),
+        dbname: this.instance.dbName,
+      },
+    };
+  }
+}
+
+// Created with ONLY the base credentials (username + password); attach() below
+// folds in the target's engine/host/port/dbname -- this app does NOT pre-build
+// the merged connection value.
+const connectionsSecret = new aws.encryption.Secret(stack, "Connections", {
+  registerOutputs: true,
+  outputName: "secret",
+  description: "RDS connection details for the attached database instance",
+  // Force immediate deletion on destroy (no 7-30 day recovery window) so the
+  // deterministic secret name can be re-used across repeated integ runs.
+  recoveryWindow: Duration.days(0),
+  secretObjectValue: {
+    username: masterUsername,
+    password: masterPassword.randomPassword,
+  },
+});
+
+// attach() links the secret to the target, merges the target's connectionFields
+// into the secret's single version, and forwards addToResourcePolicy() calls so
+// only a single aws_secretsmanager_secret_policy is ever created.
+const attachment = connectionsSecret.attach(
+  new RdsDbInstanceAttachmentTarget(database),
+);
+
+new TerraformOutput(stack, "attachment_secret_arn", {
+  value: attachment.secretArn,
+  staticId: true,
+});
+
+new TerraformOutput(stack, "db_instance_identifier", {
+  value: database.identifier,
+  staticId: true,
+});
+
+app.synth();

--- a/integ/aws/encryption/apps/secret.replica.ts
+++ b/integ/aws/encryption/apps/secret.replica.ts
@@ -1,0 +1,32 @@
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/@aws-cdk-testing/framework-integ/test/aws-secretsmanager/test/integ.replica.ts
+
+import { App, LocalBackend } from "cdktn";
+import { aws } from "../../../../src";
+
+const environmentName = process.env.ENVIRONMENT_NAME ?? "test";
+const region = process.env.AWS_REGION ?? "us-east-1";
+const outdir = process.env.OUT_DIR ?? "cdktf.out";
+const stackName = process.env.STACK_NAME ?? "secret.replica";
+
+const app = new App({
+  outdir,
+});
+
+const stack = new aws.AwsStack(app, stackName, {
+  gridUUID: "g12345678-1234",
+  environmentName,
+  providerConfig: {
+    region,
+  },
+});
+new LocalBackend(stack, {
+  path: `${stackName}.tfstate`,
+});
+
+const secret = new aws.encryption.Secret(stack, "Secret", {
+  registerOutputs: true,
+  outputName: "secret",
+});
+secret.addReplicaRegion("eu-central-1");
+
+app.synth();

--- a/integ/aws/encryption/encryption_test.go
+++ b/integ/aws/encryption/encryption_test.go
@@ -2,9 +2,11 @@ package test
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gruntwork-io/terratest/modules/aws"
 	loggers "github.com/gruntwork-io/terratest/modules/logger"
@@ -73,6 +75,67 @@ func TestKeyAlias(t *testing.T) {
 			keyArn := aws.GetCmkArn(t, awsRegion, aliasName)
 			require.Equal(t, targetKeyArn, keyArn)
 		})
+}
+
+// Run the apps/secret-attach.ts integration test
+//
+// Validates that Secret.attach() produced a deployable, "complete" secret:
+// the merged connection secret's value must contain the real RDS connection
+// details (host/port) of the attached DbInstance -- see the module doc
+// comment on apps/secret-attach.ts for how the merge is achieved without a
+// CloudFormation-style server-side merge.
+func TestSecretAttach(t *testing.T) {
+	runEncryptionIntegrationTest(t, "secret-attach", "us-east-1",
+		func(t *testing.T, tfWorkingDir string, awsRegion string) {
+			terraformOptions := test_structure.LoadTerraformOptions(t, tfWorkingDir)
+
+			secretArn := util.LoadOutputAttribute(t, terraformOptions, "secret", "secretArn")
+			attachmentSecretArn := terraform.Output(t, terraformOptions, "attachment_secret_arn")
+			require.Equal(t, secretArn, attachmentSecretArn, "attached secret has no separate ARN in Terraform")
+
+			dbInstanceID := terraform.Output(t, terraformOptions, "db_instance_identifier")
+			dbInstanceDetails, err := aws.GetRdsInstanceDetailsE(t, dbInstanceID, awsRegion)
+			require.NoError(t, err)
+			require.NotNil(t, dbInstanceDetails.Endpoint)
+
+			expectedHost := *dbInstanceDetails.Endpoint.Address
+			expectedPort := fmt.Sprintf("%d", *dbInstanceDetails.Endpoint.Port)
+
+			secretValue := aws.GetSecretValue(t, awsRegion, secretArn)
+			var connection map[string]string
+			err = json.Unmarshal([]byte(secretValue), &connection)
+			require.NoError(t, err)
+
+			require.Equal(t, expectedHost, connection["host"])
+			require.Equal(t, expectedPort, connection["port"])
+			require.Equal(t, "postgres", connection["engine"])
+			require.NotEmpty(t, connection["username"])
+			require.NotEmpty(t, connection["password"])
+		})
+}
+
+// Run the apps/secret.replica.ts integration test
+func TestSecretReplica(t *testing.T) {
+	runEncryptionIntegrationTest(t, "secret.replica", "us-east-1", validateSecretReplica)
+}
+
+// validateSecretReplica validates the apps/secret.replica.ts integration test: a default Secret
+// with a single replica region (the app's literal "eu-central-1") reaches "InSync" replication
+// status, per the upstream integ's intent of exercising `secret.addReplicaRegion('eu-central-1')`.
+func validateSecretReplica(t *testing.T, tfWorkingDir string, awsRegion string) {
+	// mirrors apps/secret.replica.ts: secret.addReplicaRegion("eu-central-1")
+	const replicaRegion = "eu-central-1"
+
+	// Load the Terraform Options saved by the earlier deploy_terraform stage
+	terraformOptions := test_structure.LoadTerraformOptions(t, tfWorkingDir)
+	secretArn := util.LoadOutputAttribute(t, terraformOptions, "secret", "secretArn")
+
+	// Replication is asynchronous - wait for AWS to report the replica as InSync.
+	util.WaitForSecretReplicationInSync(t, awsRegion, secretArn, replicaRegion, 20, 15*time.Second)
+
+	description := util.DescribeSecret(t, awsRegion, secretArn)
+	require.Len(t, description.ReplicationStatus, 1, "expected exactly one replica region")
+	require.Equal(t, replicaRegion, *description.ReplicationStatus[0].Region)
 }
 
 // run encryption integration test

--- a/integ/aws/secretsmanager.go
+++ b/integ/aws/secretsmanager.go
@@ -1,0 +1,79 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager"
+	"github.com/aws/aws-sdk-go-v2/service/secretsmanager/types"
+	"github.com/stretchr/testify/require"
+
+	terratestaws "github.com/gruntwork-io/terratest/modules/aws"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/gruntwork-io/terratest/modules/testing"
+)
+
+// DescribeSecret describes a Secrets Manager secret or panics if not found.
+func DescribeSecret(t testing.TestingT, region, secretID string) *secretsmanager.DescribeSecretOutput {
+	output, err := DescribeSecretE(t, region, secretID)
+	require.NoError(t, err)
+	return output
+}
+
+// DescribeSecretE describes a Secrets Manager secret in the given region.
+func DescribeSecretE(t testing.TestingT, region, secretID string) (*secretsmanager.DescribeSecretOutput, error) {
+	client := terratestaws.NewSecretsManagerClient(t, region)
+
+	return client.DescribeSecret(context.Background(), &secretsmanager.DescribeSecretInput{
+		SecretId: &secretID,
+	})
+}
+
+// GetSecretReplicationStatus returns the replication status entry for the given replica region, or
+// an error if the secret has not (yet) been replicated to that region.
+func GetSecretReplicationStatusE(t testing.TestingT, region, secretID, replicaRegion string) (*types.ReplicationStatusType, error) {
+	output, err := DescribeSecretE(t, region, secretID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, status := range output.ReplicationStatus {
+		if status.Region != nil && *status.Region == replicaRegion {
+			return &status, nil
+		}
+	}
+
+	return nil, fmt.Errorf("secret %s has no replication status for region %s", secretID, replicaRegion)
+}
+
+// WaitForSecretReplicationInSync waits until the given secret's replica in replicaRegion reaches the
+// "InSync" status, or fails the test if it does not within maxRetries.
+func WaitForSecretReplicationInSync(t testing.TestingT, region, secretID, replicaRegion string, maxRetries int, sleepBetweenRetries time.Duration) {
+	err := WaitForSecretReplicationInSyncE(t, region, secretID, replicaRegion, maxRetries, sleepBetweenRetries)
+	require.NoError(t, err)
+}
+
+// WaitForSecretReplicationInSyncE waits until the given secret's replica in replicaRegion reaches the
+// "InSync" status.
+func WaitForSecretReplicationInSyncE(t testing.TestingT, region, secretID, replicaRegion string, maxRetries int, sleepBetweenRetries time.Duration) error {
+	msg, err := retry.DoWithRetryE(
+		t,
+		fmt.Sprintf("Waiting for secret %s replica in %s to be %s.", secretID, replicaRegion, types.StatusTypeInSync),
+		maxRetries,
+		sleepBetweenRetries,
+		func() (string, error) {
+			status, err := GetSecretReplicationStatusE(t, region, secretID, replicaRegion)
+			if err != nil {
+				return "", err
+			}
+			if status.Status != types.StatusTypeInSync {
+				return "", fmt.Errorf("replica of secret %s in %s has status %s, want %s", secretID, replicaRegion, status.Status, types.StatusTypeInSync)
+			}
+			return fmt.Sprintf("Replica of secret %s in %s is now %s", secretID, replicaRegion, types.StatusTypeInSync), nil
+		},
+	)
+	logger.Log(t, msg)
+	return err
+}

--- a/src/aws/encryption/index.ts
+++ b/src/aws/encryption/index.ts
@@ -2,3 +2,7 @@ export * from "./key";
 export * from "./key-lookup";
 export * from "./alias";
 export * from "./via-service-principal";
+export * from "./secret";
+export * from "./rotation-schedule";
+export * from "./policy";
+export * from "./secret-rotation";

--- a/src/aws/encryption/policy.ts
+++ b/src/aws/encryption/policy.ts
@@ -1,0 +1,77 @@
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/aws-cdk-lib/aws-secretsmanager/lib/policy.ts
+
+import { secretsmanagerSecretPolicy } from "@cdktn/provider-aws";
+import { Construct } from "constructs";
+import { ISecret } from "./secret";
+import { AwsConstructBase, AwsConstructProps } from "../aws-construct";
+import { PolicyDocument } from "../iam";
+
+/**
+ * Construction properties for a ResourcePolicy
+ */
+export interface ResourcePolicyProps extends AwsConstructProps {
+  /**
+   * The secret to attach a resource-based permissions policy
+   */
+  readonly secret: ISecret;
+}
+
+/**
+ * Resource Policy for SecretsManager Secrets
+ *
+ * Policies define the operations that are allowed on this resource.
+ *
+ * You almost never need to define this construct directly.
+ *
+ * All AWS resources that support resource policies have a method called
+ * `addToResourcePolicy()`, which will automatically create a new resource
+ * policy if one doesn't exist yet, otherwise it will add to the existing
+ * policy.
+ *
+ * Prefer to use `addToResourcePolicy()` instead.
+ */
+export class ResourcePolicy extends AwsConstructBase {
+  /** Uniquely identifies this class. */
+  public static readonly PROPERTY_INJECTION_ID: string =
+    "terraconstructs.aws.encryption.ResourcePolicy";
+
+  /**
+   * The underlying `aws_secretsmanager_secret_policy` resource.
+   */
+  public readonly resource: secretsmanagerSecretPolicy.SecretsmanagerSecretPolicy;
+
+  /**
+   * The IAM policy document for this policy.
+   *
+   * NOTE (TerraConstructs deviation): upstream's `iam.PolicyDocument` is a plain (non-Construct)
+   * IResolvable that CloudFormation serializes inline on `CfnResourcePolicy.resourcePolicy`. This
+   * repo's `PolicyDocument` synthesizes to its own `data.aws_iam_policy_document` data source and
+   * therefore is itself a Construct requiring `(scope, id)` -- see `iam/policy-document.ts`.
+   */
+  public readonly document: PolicyDocument;
+
+  public get outputs(): Record<string, any> {
+    /**
+     * This resource exports no additional attributes.
+     *
+     * NOTE: upstream's `CfnResourcePolicy.attrId` ('Id') doc-defines it as "The Arn of the
+     * secret". Downstream code should reference `props.secret.secretArn` directly instead.
+     */
+    return {};
+  }
+
+  constructor(scope: Construct, id: string, props: ResourcePolicyProps) {
+    super(scope, id, props);
+
+    this.document = new PolicyDocument(this, "Policy");
+
+    this.resource = new secretsmanagerSecretPolicy.SecretsmanagerSecretPolicy(
+      this,
+      "Resource",
+      {
+        secretArn: props.secret.secretArn,
+        policy: this.document.json,
+      },
+    );
+  }
+}

--- a/src/aws/encryption/rotation-schedule.ts
+++ b/src/aws/encryption/rotation-schedule.ts
@@ -1,0 +1,572 @@
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/aws-cdk-lib/aws-secretsmanager/lib/rotation-schedule.ts
+
+import { secretsmanagerSecretRotation } from "@cdktn/provider-aws";
+import { Construct } from "constructs";
+import { ISecret } from "./secret";
+import { ViaServicePrincipal } from "./via-service-principal";
+import { Duration } from "../../duration";
+import { ValidationError, UnscopedValidationError } from "../../errors";
+import { AwsConstructBase } from "../aws-construct";
+import * as compute from "../compute";
+import * as iam from "../iam";
+import { Schedule } from "../notify";
+
+/**
+ * Options to add a rotation schedule to a secret.
+ */
+export interface RotationScheduleOptions {
+  /**
+   * A Lambda function that can rotate the secret.
+   *
+   * @default - either `rotationLambda` or `hostedRotation` must be specified
+   */
+  readonly rotationLambda?: compute.IFunction;
+
+  /**
+   * Hosted rotation
+   *
+   * @default - either `rotationLambda` or `hostedRotation` must be specified
+   */
+  readonly hostedRotation?: HostedRotation;
+
+  /**
+   * Specifies the number of days after the previous rotation before
+   * Secrets Manager triggers the next automatic rotation.
+   *
+   * The minimum value is 4 hours.
+   * The maximum value is 1000 days.
+   *
+   * TERRACONSTRUCTS DEVIATION: upstream allows a value of zero (`Duration.days(0)`) to mean "do not
+   * create RotationRules" -- CloudFormation's `AWS::SecretsManager::RotationSchedule.RotationRules`
+   * is entirely optional. Terraform's `aws_secretsmanager_secret_rotation` resource requires a
+   * populated `rotation_rules` block (verified against `SecretsmanagerSecretRotationConfig`: the
+   * block itself is a required field, even though its sub-fields are optional) -- an empty block
+   * fails `tofu validate`. Passing `Duration.days(0)` therefore throws a `ValidationError` here
+   * instead of silently synthesizing invalid Terraform.
+   *
+   * @default Duration.days(30)
+   */
+  readonly automaticallyAfter?: Duration;
+
+  /**
+   * Specifies whether to rotate the secret immediately or wait until the next
+   * scheduled rotation window.
+   *
+   * @default true
+   */
+  readonly rotateImmediatelyOnUpdate?: boolean;
+}
+
+/**
+ * Construction properties for a RotationSchedule.
+ */
+export interface RotationScheduleProps extends RotationScheduleOptions {
+  /**
+   * The secret to rotate.
+   *
+   * If hosted rotation is used, this must be a JSON string with the following format:
+   *
+   * ```
+   * {
+   *   "engine": <required: database engine>,
+   *   "host": <required: instance host name>,
+   *   "username": <required: username>,
+   *   "password": <required: password>,
+   *   "dbname": <optional: database name>,
+   *   "port": <optional: if not specified, default port will be used>,
+   *   "masterarn": <required for multi user rotation: the arn of the master secret which will be used to create users/change passwords>
+   * }
+   * ```
+   *
+   * This is typically the case for a secret referenced from an `ISecretTargetAttachment`, i.e. the
+   * `ISecret` returned by the `attach()` method of `Secret`.
+   */
+  readonly secret: ISecret;
+}
+
+/**
+ * Outputs which may be registered for output via the Grid.
+ */
+export interface RotationScheduleOutputs {
+  /**
+   * The ARN or name of the secret this rotation schedule is attached to.
+   *
+   * @attribute
+   */
+  readonly secretId: string;
+}
+
+/**
+ * A rotation schedule.
+ *
+ * @resource aws_secretsmanager_secret_rotation
+ */
+export class RotationSchedule extends AwsConstructBase {
+  /** Uniquely identifies this class. */
+  public static readonly PROPERTY_INJECTION_ID: string =
+    "terraconstructs.aws.encryption.RotationSchedule";
+
+  /**
+   * The underlying `aws_secretsmanager_secret_rotation` resource.
+   */
+  public readonly resource: secretsmanagerSecretRotation.SecretsmanagerSecretRotation;
+
+  public readonly rotationScheduleOutputs: RotationScheduleOutputs;
+  public get outputs(): Record<string, any> {
+    return this.rotationScheduleOutputs;
+  }
+
+  constructor(scope: Construct, id: string, props: RotationScheduleProps) {
+    super(scope, id);
+
+    if (
+      (!props.rotationLambda && !props.hostedRotation) ||
+      (props.rotationLambda && props.hostedRotation)
+    ) {
+      throw new ValidationError(
+        "One of `rotationLambda` or `hostedRotation` must be specified.",
+        this,
+      );
+    }
+
+    if (props.rotationLambda?.permissionsNode.defaultChild) {
+      if (props.secret.encryptionKey) {
+        props.secret.encryptionKey.grantEncryptDecrypt(
+          new ViaServicePrincipal(
+            `secretsmanager.${this.stack.region}.amazonaws.com`,
+            props.rotationLambda.grantPrincipal,
+          ),
+        );
+      }
+
+      const grant = props.rotationLambda.grantInvoke(
+        new iam.ServicePrincipal("secretsmanager.amazonaws.com"),
+      );
+      grant.applyBefore(this);
+
+      props.rotationLambda.addToRolePolicy(
+        new iam.PolicyStatement({
+          actions: [
+            "secretsmanager:DescribeSecret",
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:PutSecretValue",
+            "secretsmanager:UpdateSecretVersionStage",
+          ],
+          resources: [
+            props.secret.secretFullArn
+              ? props.secret.secretFullArn
+              : `${props.secret.secretArn}-??????`,
+          ],
+        }),
+      );
+      props.rotationLambda.addToRolePolicy(
+        new iam.PolicyStatement({
+          actions: ["secretsmanager:GetRandomPassword"],
+          resources: ["*"],
+        }),
+      );
+    }
+
+    let scheduleExpression: string;
+    if (props.automaticallyAfter) {
+      const automaticallyAfterMillis =
+        props.automaticallyAfter.toMilliseconds();
+      if (automaticallyAfterMillis === 0) {
+        // See the "Never synthesize provider-invalid config for CFN sentinel semantics" rule
+        // (conventions.md): CFN's `Duration.days(0)` sentinel ("do not create RotationRules") has no
+        // Terraform representation -- `rotation_rules` is a required block on
+        // `aws_secretsmanager_secret_rotation`, and an empty block fails `tofu validate`.
+        throw new ValidationError(
+          "`automaticallyAfter` cannot be `Duration.days(0)`: CloudFormation treats a zero duration as " +
+            '"do not create RotationRules", but Terraform\'s `aws_secretsmanager_secret_rotation` ' +
+            "resource requires a populated `rotation_rules` block (an empty block fails `tofu validate`). " +
+            "Omit `automaticallyAfter` to use the default 30-day schedule.",
+          this,
+        );
+      }
+      if (automaticallyAfterMillis < Duration.hours(4).toMilliseconds()) {
+        throw new ValidationError(
+          `automaticallyAfter must not be smaller than 4 hours, got ${props.automaticallyAfter.toHours()} hours`,
+          this,
+        );
+      }
+      if (automaticallyAfterMillis > Duration.days(1000).toMilliseconds()) {
+        throw new ValidationError(
+          `automaticallyAfter must not be greater than 1000 days, got ${props.automaticallyAfter.toDays()} days`,
+          this,
+        );
+      }
+      scheduleExpression = Schedule.rate(
+        props.automaticallyAfter,
+      ).expressionString;
+    } else {
+      scheduleExpression = Schedule.rate(Duration.days(30)).expressionString;
+    }
+
+    // TERRACONSTRUCTS DEVIATION: upstream passes `props.hostedRotation?.bind(props.secret, this)` into
+    // `hostedRotationLambda` on the underlying Cfn resource. `aws_secretsmanager_secret_rotation` has no
+    // equivalent field (verified: absent from `SecretsmanagerSecretRotationConfig`) -- CFN's
+    // `HostedRotationLambda` relies on the `AWS::SecretsManager-2024-09-16` transform to auto-provision a
+    // fully managed rotation Lambda from an AWS-published SAR template, which Terraform cannot do. Calling
+    // `bind()` always throws (see `HostedRotation.bind` below); it is invoked here -- before the L1 resource
+    // is created -- purely to preserve upstream's construction-time failure for this unsupported feature.
+    props.hostedRotation?.bind(props.secret, this);
+
+    this.resource =
+      new secretsmanagerSecretRotation.SecretsmanagerSecretRotation(
+        this,
+        "Resource",
+        {
+          secretId: props.secret.secretArn,
+          rotationLambdaArn: props.rotationLambda?.functionArn,
+          rotationRules: {
+            scheduleExpression,
+          },
+          rotateImmediately: props.rotateImmediatelyOnUpdate,
+        },
+      );
+
+    this.rotationScheduleOutputs = {
+      secretId: this.resource.secretId,
+    };
+
+    // Prevent secrets deletions when rotation is in place
+    props.secret.denyAccountRootDelete();
+  }
+}
+
+/**
+ * Single user hosted rotation options
+ */
+export interface SingleUserHostedRotationOptions {
+  /**
+   * A name for the Lambda created to rotate the secret
+   *
+   * @default - a Terraform generated name
+   */
+  readonly functionName?: string;
+
+  /**
+   * A list of security groups for the Lambda created to rotate the secret
+   *
+   * @default - a new security group is created
+   */
+  readonly securityGroups?: compute.ISecurityGroup[];
+
+  /**
+   * The VPC where the Lambda rotation function will run.
+   *
+   * @default - the Lambda is not deployed in a VPC
+   */
+  readonly vpc?: compute.IVpc;
+
+  /**
+   * The type of subnets in the VPC where the Lambda rotation function will run.
+   *
+   * @default - the Vpc default strategy if not specified.
+   */
+  readonly vpcSubnets?: compute.SubnetSelection;
+
+  /**
+   * A string of the characters that you don't want in the password
+   *
+   * @default the same exclude characters as the ones used for the
+   * secret or " %+~`#$&*()|[]{}:;<>?!'/@\"\\"
+   */
+  readonly excludeCharacters?: string;
+}
+
+/**
+ * Multi user hosted rotation options
+ */
+export interface MultiUserHostedRotationOptions
+  extends SingleUserHostedRotationOptions {
+  /**
+   * The master secret for a multi user rotation scheme
+   */
+  readonly masterSecret: ISecret;
+}
+
+/**
+ * A hosted rotation
+ *
+ * TERRACONSTRUCTS DEVIATION: upstream's `bind()` renders a `CfnRotationSchedule.HostedRotationLambdaProperty`
+ * consumed by CloudFormation's `AWS::SecretsManager-2024-09-16` transform, which auto-provisions a fully
+ * managed rotation Lambda from an AWS-published SAR template. Terraform's `aws_secretsmanager_secret_rotation`
+ * resource has no equivalent (verified against `SecretsmanagerSecretRotationConfig` -- no `hostedRotationLambda`
+ * / SAR-backed field exists anywhere in the AWS Terraform provider). `HostedRotation` and `HostedRotationType`
+ * are preserved here for API compatibility (so callers can still construct e.g.
+ * `HostedRotation.mysqlSingleUser()`), but `bind()` always throws -- "Not supported by Terraform Provider".
+ * To rotate a secret with Terraform, deploy a real rotation Lambda (`aws_lambda_function`, e.g. from one of
+ * the AWS Secrets Manager rotation templates) and pass it as `RotationScheduleOptions.rotationLambda` instead.
+ */
+export class HostedRotation implements compute.IConnectable {
+  /** MySQL Single User */
+  public static mysqlSingleUser(options: SingleUserHostedRotationOptions = {}) {
+    return new HostedRotation(HostedRotationType.MYSQL_SINGLE_USER, options);
+  }
+
+  /** MySQL Multi User */
+  public static mysqlMultiUser(options: MultiUserHostedRotationOptions) {
+    return new HostedRotation(
+      HostedRotationType.MYSQL_MULTI_USER,
+      options,
+      options.masterSecret,
+    );
+  }
+
+  /** PostgreSQL Single User */
+  public static postgreSqlSingleUser(
+    options: SingleUserHostedRotationOptions = {},
+  ) {
+    return new HostedRotation(
+      HostedRotationType.POSTGRESQL_SINGLE_USER,
+      options,
+    );
+  }
+
+  /** PostgreSQL Multi User */
+  public static postgreSqlMultiUser(options: MultiUserHostedRotationOptions) {
+    return new HostedRotation(
+      HostedRotationType.POSTGRESQL_MULTI_USER,
+      options,
+      options.masterSecret,
+    );
+  }
+
+  /** Oracle Single User */
+  public static oracleSingleUser(
+    options: SingleUserHostedRotationOptions = {},
+  ) {
+    return new HostedRotation(HostedRotationType.ORACLE_SINGLE_USER, options);
+  }
+
+  /** Oracle Multi User */
+  public static oracleMultiUser(options: MultiUserHostedRotationOptions) {
+    return new HostedRotation(
+      HostedRotationType.ORACLE_MULTI_USER,
+      options,
+      options.masterSecret,
+    );
+  }
+
+  /** MariaDB Single User */
+  public static mariaDbSingleUser(
+    options: SingleUserHostedRotationOptions = {},
+  ) {
+    return new HostedRotation(HostedRotationType.MARIADB_SINGLE_USER, options);
+  }
+
+  /** MariaDB Multi User */
+  public static mariaDbMultiUser(options: MultiUserHostedRotationOptions) {
+    return new HostedRotation(
+      HostedRotationType.MARIADB_MULTI_USER,
+      options,
+      options.masterSecret,
+    );
+  }
+
+  /** SQL Server Single User */
+  public static sqlServerSingleUser(
+    options: SingleUserHostedRotationOptions = {},
+  ) {
+    return new HostedRotation(
+      HostedRotationType.SQLSERVER_SINGLE_USER,
+      options,
+    );
+  }
+
+  /** SQL Server Multi User */
+  public static sqlServerMultiUser(options: MultiUserHostedRotationOptions) {
+    return new HostedRotation(
+      HostedRotationType.SQLSERVER_MULTI_USER,
+      options,
+      options.masterSecret,
+    );
+  }
+
+  /** Redshift Single User */
+  public static redshiftSingleUser(
+    options: SingleUserHostedRotationOptions = {},
+  ) {
+    return new HostedRotation(HostedRotationType.REDSHIFT_SINGLE_USER, options);
+  }
+
+  /** Redshift Multi User */
+  public static redshiftMultiUser(options: MultiUserHostedRotationOptions) {
+    return new HostedRotation(
+      HostedRotationType.REDSHIFT_MULTI_USER,
+      options,
+      options.masterSecret,
+    );
+  }
+
+  /** MongoDB Single User */
+  public static mongoDbSingleUser(
+    options: SingleUserHostedRotationOptions = {},
+  ) {
+    return new HostedRotation(HostedRotationType.MONGODB_SINGLE_USER, options);
+  }
+
+  /** MongoDB Multi User */
+  public static mongoDbMultiUser(options: MultiUserHostedRotationOptions) {
+    return new HostedRotation(
+      HostedRotationType.MONGODB_MULTI_USER,
+      options,
+      options.masterSecret,
+    );
+  }
+
+  private _connections?: compute.Connections;
+
+  private constructor(
+    private readonly type: HostedRotationType,
+    private readonly props:
+      | SingleUserHostedRotationOptions
+      | MultiUserHostedRotationOptions,
+    // NOTE: not stored as a property -- `bind()` below always throws (Terraform has no
+    // equivalent of CloudFormation's HostedRotationLambda transform), so upstream's
+    // masterSecret-driven ARN/KMS wiring in `bind()` has no Terraform counterpart to port.
+    // Retained as a constructor-only parameter purely to preserve the multi-user validation
+    // check below and the public static factory signatures.
+    masterSecret?: ISecret,
+  ) {
+    if (type.isMultiUser && !masterSecret) {
+      throw new UnscopedValidationError(
+        "The `masterSecret` must be specified when using the multi user scheme.",
+      );
+    }
+  }
+
+  /**
+   * Binds this hosted rotation to a secret.
+   *
+   * Always throws: Terraform's `aws_secretsmanager_secret_rotation` resource has no equivalent of
+   * CloudFormation's `HostedRotationLambda`. See the `HostedRotation` class doc comment above.
+   *
+   * NOTE: return type is `void`, not `never` -- jsii rejects `never` as unrepresentable in target
+   * languages (JSII1007). Callers only invoke this for its side effect (it always throws before
+   * returning), so the narrower TS type isn't otherwise load-bearing here.
+   */
+  public bind(_secret: ISecret, scope: Construct): void {
+    throw new ValidationError(
+      "HostedRotation is not supported by the Terraform AWS provider: `aws_secretsmanager_secret_rotation` " +
+        "has no equivalent of CloudFormation's `HostedRotationLambda` (which relies on the " +
+        `"${this.type.name}" AWS::SecretsManager-2024-09-16 transform to auto-provision a fully managed ` +
+        "rotation Lambda from an AWS-published SAR template -- Terraform cannot do this). Deploy a real " +
+        "rotation Lambda and provide it as `RotationScheduleOptions.rotationLambda` instead.",
+      scope,
+    );
+  }
+
+  /**
+   * Security group connections for this hosted rotation
+   */
+  public get connections() {
+    if (!this.props.vpc) {
+      throw new UnscopedValidationError(
+        "Cannot use connections for a hosted rotation that is not deployed in a VPC",
+      );
+    }
+
+    // If we are in a vpc and bind() has been called _connections should be defined
+    if (!this._connections) {
+      throw new UnscopedValidationError(
+        "Cannot use connections for a hosted rotation that has not been bound to a secret",
+      );
+    }
+
+    return this._connections;
+  }
+}
+
+/**
+ * Hosted rotation type
+ */
+export class HostedRotationType {
+  /** MySQL Single User */
+  public static readonly MYSQL_SINGLE_USER = new HostedRotationType(
+    "MySQLSingleUser",
+  );
+
+  /** MySQL Multi User */
+  public static readonly MYSQL_MULTI_USER = new HostedRotationType(
+    "MySQLMultiUser",
+    true,
+  );
+
+  /** PostgreSQL Single User */
+  public static readonly POSTGRESQL_SINGLE_USER = new HostedRotationType(
+    "PostgreSQLSingleUser",
+  );
+
+  /** PostgreSQL Multi User */
+  public static readonly POSTGRESQL_MULTI_USER = new HostedRotationType(
+    "PostgreSQLMultiUser",
+    true,
+  );
+
+  /** Oracle Single User */
+  public static readonly ORACLE_SINGLE_USER = new HostedRotationType(
+    "OracleSingleUser",
+  );
+
+  /** Oracle Multi User */
+  public static readonly ORACLE_MULTI_USER = new HostedRotationType(
+    "OracleMultiUser",
+    true,
+  );
+
+  /** MariaDB Single User */
+  public static readonly MARIADB_SINGLE_USER = new HostedRotationType(
+    "MariaDBSingleUser",
+  );
+
+  /** MariaDB Multi User */
+  public static readonly MARIADB_MULTI_USER = new HostedRotationType(
+    "MariaDBMultiUser",
+    true,
+  );
+
+  /** SQL Server Single User */
+  public static readonly SQLSERVER_SINGLE_USER = new HostedRotationType(
+    "SQLServerSingleUser",
+  );
+
+  /** SQL Server Multi User */
+  public static readonly SQLSERVER_MULTI_USER = new HostedRotationType(
+    "SQLServerMultiUser",
+    true,
+  );
+
+  /** Redshift Single User */
+  public static readonly REDSHIFT_SINGLE_USER = new HostedRotationType(
+    "RedshiftSingleUser",
+  );
+
+  /** Redshift Multi User */
+  public static readonly REDSHIFT_MULTI_USER = new HostedRotationType(
+    "RedshiftMultiUser",
+    true,
+  );
+
+  /** MongoDB Single User */
+  public static readonly MONGODB_SINGLE_USER = new HostedRotationType(
+    "MongoDBSingleUser",
+  );
+
+  /** MongoDB Multi User */
+  public static readonly MONGODB_MULTI_USER = new HostedRotationType(
+    "MongoDBMultiUser",
+    true,
+  );
+
+  /**
+   * @param name The type of rotation
+   * @param isMultiUser Whether the rotation uses the mutli user scheme
+   */
+  private constructor(
+    public readonly name: string,
+    public readonly isMultiUser?: boolean,
+  ) {}
+}

--- a/src/aws/encryption/secret-rotation.ts
+++ b/src/aws/encryption/secret-rotation.ts
@@ -1,0 +1,386 @@
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/aws-cdk-lib/aws-secretsmanager/lib/secret-rotation.ts
+
+import { Construct } from "constructs";
+import { ISecret } from "./secret";
+import { Duration } from "../../duration";
+import { ValidationError, UnscopedValidationError } from "../../errors";
+import * as ec2 from "../compute";
+
+/**
+ * Options for a SecretRotationApplication
+ */
+export interface SecretRotationApplicationOptions {
+  /**
+   * Whether the rotation application uses the mutli user scheme
+   *
+   * @default false
+   */
+  readonly isMultiUser?: boolean;
+}
+
+/**
+ * A secret rotation serverless application.
+ */
+export class SecretRotationApplication {
+  /**
+   * Conducts an AWS SecretsManager secret rotation for RDS MariaDB using the single user rotation scheme
+   */
+  public static readonly MARIADB_ROTATION_SINGLE_USER =
+    new SecretRotationApplication(
+      "SecretsManagerRDSMariaDBRotationSingleUser",
+      "1.1.618",
+    );
+
+  /**
+   * Conducts an AWS SecretsManager secret rotation for RDS MariaDB using the multi user rotation scheme
+   */
+  public static readonly MARIADB_ROTATION_MULTI_USER =
+    new SecretRotationApplication(
+      "SecretsManagerRDSMariaDBRotationMultiUser",
+      "1.1.618",
+      {
+        isMultiUser: true,
+      },
+    );
+
+  /**
+   * Conducts an AWS SecretsManager secret rotation for RDS MySQL using the single user rotation scheme
+   */
+  public static readonly MYSQL_ROTATION_SINGLE_USER =
+    new SecretRotationApplication(
+      "SecretsManagerRDSMySQLRotationSingleUser",
+      "1.1.618",
+    );
+
+  /**
+   * Conducts an AWS SecretsManager secret rotation for RDS MySQL using the multi user rotation scheme
+   */
+  public static readonly MYSQL_ROTATION_MULTI_USER =
+    new SecretRotationApplication(
+      "SecretsManagerRDSMySQLRotationMultiUser",
+      "1.1.618",
+      {
+        isMultiUser: true,
+      },
+    );
+
+  /**
+   * Conducts an AWS SecretsManager secret rotation for RDS Oracle using the single user rotation scheme
+   */
+  public static readonly ORACLE_ROTATION_SINGLE_USER =
+    new SecretRotationApplication(
+      "SecretsManagerRDSOracleRotationSingleUser",
+      "1.1.618",
+    );
+
+  /**
+   * Conducts an AWS SecretsManager secret rotation for RDS Oracle using the multi user rotation scheme
+   */
+  public static readonly ORACLE_ROTATION_MULTI_USER =
+    new SecretRotationApplication(
+      "SecretsManagerRDSOracleRotationMultiUser",
+      "1.1.618",
+      {
+        isMultiUser: true,
+      },
+    );
+
+  /**
+   * Conducts an AWS SecretsManager secret rotation for RDS PostgreSQL using the single user rotation scheme
+   */
+  public static readonly POSTGRES_ROTATION_SINGLE_USER =
+    new SecretRotationApplication(
+      "SecretsManagerRDSPostgreSQLRotationSingleUser",
+      "1.1.618",
+    );
+
+  /**
+   * Conducts an AWS SecretsManager secret rotation for RDS PostgreSQL using the multi user rotation scheme
+   */
+  public static readonly POSTGRES_ROTATION_MULTI_USER =
+    new SecretRotationApplication(
+      "SecretsManagerRDSPostgreSQLRotationMultiUser",
+      "1.1.618",
+      {
+        isMultiUser: true,
+      },
+    );
+
+  /**
+   * Conducts an AWS SecretsManager secret rotation for RDS SQL Server using the single user rotation scheme
+   */
+  public static readonly SQLSERVER_ROTATION_SINGLE_USER =
+    new SecretRotationApplication(
+      "SecretsManagerRDSSQLServerRotationSingleUser",
+      "1.1.618",
+    );
+
+  /**
+   * Conducts an AWS SecretsManager secret rotation for RDS SQL Server using the multi user rotation scheme
+   */
+  public static readonly SQLSERVER_ROTATION_MULTI_USER =
+    new SecretRotationApplication(
+      "SecretsManagerRDSSQLServerRotationMultiUser",
+      "1.1.618",
+      {
+        isMultiUser: true,
+      },
+    );
+
+  /**
+   * Conducts an AWS SecretsManager secret rotation for Amazon Redshift using the single user rotation scheme
+   */
+  public static readonly REDSHIFT_ROTATION_SINGLE_USER =
+    new SecretRotationApplication(
+      "SecretsManagerRedshiftRotationSingleUser",
+      "1.1.618",
+    );
+
+  /**
+   * Conducts an AWS SecretsManager secret rotation for Amazon Redshift using the multi user rotation scheme
+   */
+  public static readonly REDSHIFT_ROTATION_MULTI_USER =
+    new SecretRotationApplication(
+      "SecretsManagerRedshiftRotationMultiUser",
+      "1.1.618",
+      {
+        isMultiUser: true,
+      },
+    );
+
+  /**
+   * Conducts an AWS SecretsManager secret rotation for MongoDB using the single user rotation scheme
+   */
+  public static readonly MONGODB_ROTATION_SINGLE_USER =
+    new SecretRotationApplication(
+      "SecretsManagerMongoDBRotationSingleUser",
+      "1.1.618",
+    );
+
+  /**
+   * Conducts an AWS SecretsManager secret rotation for MongoDB using the multi user rotation scheme
+   */
+  public static readonly MONGODB_ROTATION_MULTI_USER =
+    new SecretRotationApplication(
+      "SecretsManagerMongoDBRotationMultiUser",
+      "1.1.618",
+      {
+        isMultiUser: true,
+      },
+    );
+
+  /**
+   * The application identifier of the rotation application
+   *
+   * @deprecated only valid when deploying to the 'aws' partition. Use `applicationArnForPartition` instead.
+   */
+  public readonly applicationId: string;
+
+  /**
+   * The semantic version of the rotation application
+   *
+   * @deprecated only valid when deploying to the 'aws' partition. Use `semanticVersionForPartition` instead.
+   */
+  public readonly semanticVersion: string;
+
+  /**
+   * Whether the rotation application uses the mutli user scheme
+   */
+  public readonly isMultiUser?: boolean;
+
+  /**
+   * The application name of the rotation application
+   */
+  private readonly applicationName: string;
+
+  constructor(
+    applicationId: string,
+    semanticVersion: string,
+    options?: SecretRotationApplicationOptions,
+  ) {
+    // partitions are handled explicitly via applicationArnForPartition()
+    this.applicationId = `arn:aws:serverlessrepo:us-east-1:297356227824:applications/${applicationId}`;
+    this.semanticVersion = semanticVersion;
+    this.applicationName = applicationId;
+    this.isMultiUser = options && options.isMultiUser;
+  }
+
+  /**
+   * Returns the application ARN for the current partition.
+   * Can be used in combination with a `CfnMapping` to automatically select the correct ARN based on the current partition.
+   */
+  public applicationArnForPartition(partition: string) {
+    if (partition === "aws") {
+      return this.applicationId;
+    } else if (partition === "aws-cn") {
+      return `arn:aws-cn:serverlessrepo:cn-north-1:193023089310:applications/${this.applicationName}`;
+    } else if (partition === "aws-us-gov") {
+      return `arn:aws-us-gov:serverlessrepo:us-gov-west-1:023102451235:applications/${this.applicationName}`;
+    } else {
+      throw new UnscopedValidationError(`unsupported partition: ${partition}`);
+    }
+  }
+
+  /**
+   * The semantic version of the app for the current partition.
+   * Can be used in combination with a `CfnMapping` to automatically select the correct version based on the current partition.
+   */
+  public semanticVersionForPartition(partition: string) {
+    if (partition === "aws") {
+      return this.semanticVersion;
+    } else if (partition === "aws-cn") {
+      return "1.1.237";
+    } else if (partition === "aws-us-gov") {
+      return "1.1.213";
+    } else {
+      throw new UnscopedValidationError(`unsupported partition: ${partition}`);
+    }
+  }
+}
+
+/**
+ * Construction properties for a SecretRotation.
+ */
+export interface SecretRotationProps {
+  /**
+   * The secret to rotate. It must be a JSON string with the following format:
+   *
+   * ```
+   * {
+   *   "engine": <required: database engine>,
+   *   "host": <required: instance host name>,
+   *   "username": <required: username>,
+   *   "password": <required: password>,
+   *   "dbname": <optional: database name>,
+   *   "port": <optional: if not specified, default port will be used>,
+   *   "masterarn": <required for multi user rotation: the arn of the master secret which will be used to create users/change passwords>
+   * }
+   * ```
+   *
+   * This is typically the case for a secret referenced from an `ISecretTargetAttachment`, i.e. the
+   * `ISecret` returned by the `attach()` method of `Secret`.
+   *
+   * @see https://docs.aws.amazon.com/secretsmanager/latest/userguide/reference_secret_json_structure.html
+   */
+  readonly secret: ISecret;
+
+  /**
+   * The master secret for a multi user rotation scheme
+   *
+   * @default - single user rotation scheme
+   */
+  readonly masterSecret?: ISecret;
+
+  /**
+   * Specifies the number of days after the previous rotation before
+   * Secrets Manager triggers the next automatic rotation.
+   *
+   * @default Duration.days(30)
+   */
+  readonly automaticallyAfter?: Duration;
+
+  /**
+   * The serverless application for the rotation.
+   */
+  readonly application: SecretRotationApplication;
+
+  /**
+   * The VPC where the Lambda rotation function will run.
+   */
+  readonly vpc: ec2.IVpc;
+
+  /**
+   * The type of subnets in the VPC where the Lambda rotation function will run.
+   *
+   * @default - the Vpc default strategy if not specified.
+   */
+  readonly vpcSubnets?: ec2.SubnetSelection;
+
+  /**
+   * The target service or database
+   */
+  readonly target: ec2.IConnectable;
+
+  /**
+   * The security group for the Lambda rotation function
+   *
+   * @default - a new security group is created
+   */
+  readonly securityGroup?: ec2.ISecurityGroup;
+
+  /**
+   * Characters which should not appear in the generated password
+   *
+   * @default - no additional characters are explicitly excluded
+   */
+  readonly excludeCharacters?: string;
+
+  /**
+   * The VPC interface endpoint to use for the Secrets Manager API
+   *
+   * If you enable private DNS hostnames for your VPC private endpoint (the default), you don't
+   * need to specify an endpoint. The standard Secrets Manager DNS hostname the Secrets Manager
+   * CLI and SDKs use by default (https://secretsmanager.<region>.amazonaws.com) automatically
+   * resolves to your VPC endpoint.
+   *
+   * @default https://secretsmanager.<region>.amazonaws.com
+   */
+  readonly endpoint?: ec2.IInterfaceVpcEndpoint;
+
+  /**
+   * Specifies whether to rotate the secret immediately or wait until the next
+   * scheduled rotation window.
+   *
+   * @default true
+   */
+  readonly rotateImmediatelyOnUpdate?: boolean;
+}
+
+/**
+ * Secret rotation for a service or database
+ *
+ * TERRACONSTRUCTS DEVIATION (HARD BLOCKER, see conventions.md "Cfn resources with NO terraform-provider-aws
+ * equivalent"): upstream deploys the rotation Lambda by instantiating an AWS-published Serverless
+ * Application Repository (SAR) app via `aws-sam`'s `serverless.CfnApplication`
+ * (`AWS::Serverless::Application`, backed by a `CfnMapping` selecting `application.applicationArnForPartition`
+ * per-partition). There is no `terraform-provider-aws` resource for `serverlessrepo` -- the provider
+ * maintainers decline to add one when there is no matching service API -- so this construct cannot be
+ * represented in Terraform. `SecretRotationApplication` (the pure ARN/version catalog, portable as-is)
+ * is preserved above so callers can still reference e.g. `SecretRotationApplication.MYSQL_ROTATION_SINGLE_USER`,
+ * but this construct always throws a `ValidationError` at construction time -- never synthesize a
+ * half/invalid resource. To rotate a secret with Terraform, deploy a real rotation Lambda by hand (e.g.
+ * from one of the AWS Secrets Manager rotation templates published for the SAR apps above) and attach it
+ * with `secret.addRotationSchedule(id, { rotationLambda, automaticallyAfter, rotateImmediatelyOnUpdate })`
+ * from `./rotation-schedule` instead.
+ */
+export class SecretRotation extends Construct {
+  constructor(scope: Construct, id: string, props: SecretRotationProps) {
+    super(scope, id);
+
+    if (!props.target.connections.defaultPort) {
+      throw new ValidationError(
+        "The `target` connections must have a default port range.",
+        this,
+      );
+    }
+
+    if (props.application.isMultiUser && !props.masterSecret) {
+      throw new ValidationError(
+        "The `masterSecret` must be specified for application using the multi user scheme.",
+        this,
+      );
+    }
+
+    // TODO: AWS::Serverless::Application (SAR) has no Terraform equivalent -- see the class doc
+    // comment above. There is no `terraform-provider-aws` resource for `serverlessrepo`, so the
+    // rotation Lambda this construct deploys via a SAR app cannot be synthesized. Deploy a real
+    // rotation Lambda by hand and use `ISecret.addRotationSchedule` / `RotationSchedule` from
+    // `./rotation-schedule` instead.
+    throw new ValidationError(
+      "SecretRotation is not supported: it deploys its rotation Lambda via an AWS Serverless Application " +
+        "Repository (SAR) app (`AWS::Serverless::Application`), and Terraform has no `serverlessrepo` " +
+        "resource. Deploy a rotation Lambda yourself and call `secret.addRotationSchedule(id, { rotationLambda, ... })` instead.",
+      this,
+    );
+  }
+}

--- a/src/aws/encryption/secret.ts
+++ b/src/aws/encryption/secret.ts
@@ -1,0 +1,1369 @@
+// https://github.com/aws/aws-cdk/blob/v2.186.0/packages/aws-cdk-lib/aws-secretsmanager/lib/secret.ts
+//
+// COMBINED (PR#117 core + run-3 v2.233 breadth): the attach()/lazy-single-version machinery,
+// recoveryWindow support, and explicit generateSecretString defaults below are v2.186 core design
+// (PR#117); `fromSecretName`, `addTargetAttachment`, `AttachmentTargetType.INSTANCE`/`CLUSTER`, and
+// `SecretAttributes.secretArn` are v2.233 currency additions layered on top. The header tag is left
+// at v2.186 -- the retained core design's tag -- pending a future full v2.233 refresh.
+
+import {
+  secretsmanagerSecret,
+  secretsmanagerSecretVersion,
+  dataAwsSecretsmanagerRandomPassword,
+} from "@cdktn/provider-aws";
+import { Lazy, Token } from "cdktn";
+import { IConstruct, Construct } from "constructs";
+import { IKey } from "./key";
+import { ResourcePolicy } from "./policy";
+import { RotationSchedule, RotationScheduleOptions } from "./rotation-schedule";
+import { ViaServicePrincipal } from "./via-service-principal";
+import { Duration } from "../../duration";
+import { ValidationError } from "../../errors";
+import { Fn } from "../../terra-func";
+import { TokenComparison, tokenCompareStrings } from "../../token";
+import { ArnFormat } from "../arn";
+import {
+  IAwsConstruct,
+  AwsConstructBase,
+  AwsConstructProps,
+} from "../aws-construct";
+import { AwsStack } from "../aws-stack";
+import * as iam from "../iam";
+
+const SECRET_SYMBOL = Symbol.for("terraconstructs/aws/encryption.Secret");
+
+/**
+ * Outputs which may be registered for output via the Grid.
+ */
+export interface SecretOutputs {
+  /**
+   * The ARN of the secret in AWS Secrets Manager.
+   *
+   * @attribute
+   */
+  readonly secretArn: string;
+
+  /**
+   * The name of the secret.
+   *
+   * @attribute
+   */
+  readonly secretName: string;
+}
+
+/**
+ * A secret in AWS Secrets Manager.
+ */
+export interface ISecret extends iam.IAwsConstructWithPolicy, IAwsConstruct {
+  /** Strongly typed outputs */
+  readonly secretOutputs: SecretOutputs;
+
+  /**
+   * The customer-managed encryption key that is used to encrypt this secret, if any. When not specified, the default
+   * KMS key for the account and region is being used.
+   */
+  readonly encryptionKey?: IKey;
+
+  /**
+   * The ARN of the secret in AWS Secrets Manager. Will return the full ARN if available, otherwise a partial arn.
+   * For secrets imported by the deprecated `fromSecretName`, it will return the `secretName`.
+   * @attribute
+   */
+  readonly secretArn: string;
+
+  /**
+   * The full ARN of the secret in AWS Secrets Manager, which is the ARN including the Secrets Manager-supplied 6-character suffix.
+   * This is equal to `secretArn` in most cases, but is undefined when a full ARN is not available (e.g., secrets imported by name).
+   */
+  readonly secretFullArn?: string;
+
+  /**
+   * The name of the secret.
+   *
+   * For "owned" secrets, this will be the full resource name (secret name + suffix), unless the
+   * '@aws-cdk/aws-secretsmanager:parseOwnedSecretName' feature flag is set.
+   */
+  readonly secretName: string;
+
+  /**
+   * Grants reading the secret value to some role.
+   *
+   * @param grantee       the principal being granted permission.
+   * @param versionStages the version stages the grant is limited to. If not specified, no restriction on the version
+   *                      stages is applied.
+   */
+  grantRead(grantee: iam.IGrantable, versionStages?: string[]): iam.Grant;
+
+  /**
+   * Grants writing and updating the secret value to some role.
+   *
+   * @param grantee       the principal being granted permission.
+   */
+  grantWrite(grantee: iam.IGrantable): iam.Grant;
+
+  /**
+   * Adds a rotation schedule to the secret.
+   */
+  addRotationSchedule(
+    id: string,
+    options: RotationScheduleOptions,
+  ): RotationSchedule;
+
+  // NOTE (TerraConstructs deviation): `addToResourcePolicy` is inherited from
+  // `iam.IAwsConstructWithPolicy` above -- jsii rejects an interface redeclaring a member
+  // already declared on a base interface (JSII5015 "invalid C#"), even with an identical
+  // signature. Upstream CDK's `ISecret` (which doesn't share that base interface) declares it
+  // directly; here it's picked up via inheritance instead. See `IQueue` in
+  // `src/aws/notify/queue-base.ts` for the same pattern.
+
+  /**
+   * Denies the `DeleteSecret` action to all principals within the current
+   * account.
+   */
+  denyAccountRootDelete(): void;
+
+  /**
+   * Attach a target to this secret.
+   *
+   * NOTE: TerraConstructs does not yet ship any concrete
+   * `ISecretAttachmentTarget` implementations (the aws-rds/docdb/redshift
+   * modules that provide them upstream have not been ported). Consumers
+   * must supply their own implementation of `ISecretAttachmentTarget`
+   * until those modules exist. See `ISecretAttachmentTarget` for details.
+   *
+   * NOTE: merging the target's `connectionFields` into the secret's JSON
+   * value is only supported when this secret is an owned `Secret` construct
+   * whose value is a JSON object (`secretObjectValue`, or
+   * `generateSecretString` with a `secretStringTemplate`). Calling `attach()`
+   * with `connectionFields` on an imported secret, or on a `Secret` whose
+   * value is a scalar, throws a `ValidationError` at synthesis time.
+   *
+   * @param target The target to attach.
+   * @returns An attached secret
+   */
+  attach(target: ISecretAttachmentTarget): ISecret;
+
+  // NOTE (TerraConstructs deviation): upstream also declares `secretValue`, `secretValueFromJson`,
+  // and `cfnDynamicReferenceKey` here. `core.SecretValue` / CloudFormation dynamic references are
+  // not ported in this repo (see `src/aws/storage/parameter.ts` / `src/aws/compute/vpn.ts` for the
+  // same TODO). Use `SecretProps.secretStringValue` / `secretObjectValue` (plain strings, possibly
+  // Tokens) to seed a concrete value via `aws_secretsmanager_secret_version.secret_string` instead.
+}
+
+/**
+ * The properties required to create a new secret in AWS Secrets Manager.
+ */
+export interface SecretProps extends AwsConstructProps {
+  /**
+   * An optional, human-friendly description of the secret.
+   *
+   * @default - No description.
+   */
+  readonly description?: string;
+
+  /**
+   * The customer-managed encryption key to use for encrypting the secret value.
+   *
+   * @default - A default KMS key for the account and region is used.
+   */
+  readonly encryptionKey?: IKey;
+
+  /**
+   * Configuration for how to generate a secret value.
+   *
+   * Only one of `secretStringValue`, `secretObjectValue`, and `generateSecretString` can be provided.
+   *
+   * @default - 32 characters with upper-case letters, lower-case letters, punctuation and numbers (at least one from each
+   * category), per the default values of ``SecretStringGenerator``.
+   */
+  readonly generateSecretString?: SecretStringGenerator;
+
+  /**
+   * A name for the secret. Note that deleting secrets from SecretsManager does not happen immediately, but after a 7 to
+   * 30 days blackout period. During that period, it is not possible to create another secret that shares the same name.
+   *
+   * @default - GridUUID + Stack Unique Name
+   */
+  readonly secretName?: string;
+
+  /**
+   * Initial value for the secret
+   *
+   * **NOTE:** *It is **highly** encouraged to leave this field undefined and allow SecretsManager to create the secret value.
+   * The secret string -- if provided -- will be included in the output of the cdk as part of synthesis,
+   * and will appear in the generated Terraform configuration/state. This can be secure(-ish) if that value is merely a
+   * reference to another resource (or one of its attributes), but if the value is a plaintext string, it will be visible
+   * to anyone with access to the Terraform state or configuration.
+   *
+   * Specifies text data that you want to encrypt and store in this new version of the secret.
+   * May be a simple string value. To provide a string representation of JSON structure, use `SecretProps.secretObjectValue` instead.
+   *
+   * Only one of `secretStringValue`, `secretObjectValue`, and `generateSecretString` can be provided.
+   *
+   * TERRACONSTRUCTS DEVIATION: upstream types this as `core.SecretValue`, which is not ported in
+   * this repo. Pass a plain `string` (which may itself be an unresolved Token / reference to
+   * another resource's attribute) instead.
+   *
+   * @default - SecretsManager generates a new secret value.
+   */
+  readonly secretStringValue?: string;
+
+  /**
+   * Initial value for a JSON secret
+   *
+   * **NOTE:** *It is **highly** encouraged to leave this field undefined and allow SecretsManager to create the secret value.
+   * The secret object -- if provided -- will be included in the output of the cdk as part of synthesis,
+   * and will appear in the generated Terraform configuration/state. This can be secure(-ish) if that value is merely a
+   * reference to another resource (or one of its attributes), but if the value is a plaintext string, it will be visible
+   * to anyone with access to the Terraform state or configuration.
+   *
+   * Specifies a JSON object that you want to encrypt and store in this new version of the secret.
+   * To specify a simple string value instead, use `SecretProps.secretStringValue`
+   *
+   * Only one of `secretStringValue`, `secretObjectValue`, and `generateSecretString` can be provided.
+   *
+   * TERRACONSTRUCTS DEVIATION: upstream types the values as `core.SecretValue`, which is not ported
+   * in this repo. Each field is a plain `string` instead (which may itself be an unresolved Token).
+   *
+   * @default - SecretsManager generates a new secret value.
+   */
+  readonly secretObjectValue?: { [key: string]: string };
+
+  // NOTE (TerraConstructs deviation): upstream also exposes `removalPolicy` here. `core.RemovalPolicy`
+  // is not ported in this repo (see `notify/queue.ts` for the same omission), so it is dropped.
+  // readonly removalPolicy?: RemovalPolicy;
+
+  /**
+   * (Optional) Number of days that AWS Secrets Manager waits before it can
+   * delete the secret.
+   *
+   * This value can be 0 to force deletion without recovery or range
+   * from 7 to 30 days. The default value is 30
+   *
+   * @default - 30 days.
+   */
+  readonly recoveryWindow?: Duration;
+
+  /**
+   * A list of regions where to replicate this secret.
+   *
+   * @default - Secret is not replicated
+   */
+  readonly replicaRegions?: ReplicaRegion[];
+}
+
+/**
+ * Secret replica region
+ */
+export interface ReplicaRegion {
+  /**
+   * The name of the region
+   */
+  readonly region: string;
+
+  /**
+   * The customer-managed encryption key to use for encrypting the secret value.
+   *
+   * @default - A default KMS key for the account and region is used.
+   */
+  readonly encryptionKey?: IKey;
+}
+
+/**
+ * Attributes required to import an existing secret into the Stack.
+ * One ARN format (`secretArn`, `secretCompleteArn`, `secretPartialArn`) must be provided.
+ */
+export interface SecretAttributes {
+  /**
+   * The encryption key that is used to encrypt the secret, unless the default SecretsManager key is used.
+   */
+  readonly encryptionKey?: IKey;
+
+  /**
+   * The ARN of the secret in SecretsManager.
+   * Cannot be used with `secretCompleteArn` or `secretPartialArn`.
+   * @deprecated use `secretCompleteArn` or `secretPartialArn` instead.
+   */
+  readonly secretArn?: string;
+
+  /**
+   * The complete ARN of the secret in SecretsManager. This is the ARN including the Secrets Manager 6-character suffix.
+   * Cannot be used with `secretArn` or `secretPartialArn`.
+   */
+  readonly secretCompleteArn?: string;
+
+  /**
+   * The partial ARN of the secret in SecretsManager. This is the ARN without the Secrets Manager 6-character suffix.
+   * Cannot be used with `secretArn` or `secretCompleteArn`.
+   */
+  readonly secretPartialArn?: string;
+}
+
+/**
+ * The common behavior of Secrets. Users should not use this class directly, and instead use ``Secret``.
+ */
+abstract class SecretBase extends AwsConstructBase implements ISecret {
+  public get secretOutputs(): SecretOutputs {
+    return {
+      secretArn: this.secretArn,
+      secretName: this.secretName,
+    };
+  }
+  public get outputs(): Record<string, any> {
+    return this.secretOutputs;
+  }
+
+  public abstract readonly encryptionKey?: IKey;
+  public abstract readonly secretArn: string;
+  public abstract readonly secretName: string;
+
+  protected abstract readonly autoCreatePolicy: boolean;
+
+  private policy?: ResourcePolicy;
+
+  constructor(scope: Construct, id: string, props: AwsConstructProps = {}) {
+    super(scope, id, props);
+
+    this.node.addValidation({
+      validate: () => this.policy?.document.validateForResourcePolicy() ?? [],
+    });
+  }
+
+  public get secretFullArn(): string | undefined {
+    return this.secretArn;
+  }
+
+  public grantRead(
+    grantee: iam.IGrantable,
+    versionStages?: string[],
+  ): iam.Grant {
+    // @see https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_identity-based-policies.html
+
+    const result = iam.Grant.addToPrincipalOrResource({
+      grantee,
+      actions: [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret",
+      ],
+      resourceArns: [this.arnForPolicies],
+      resource: this,
+    });
+
+    const statement = result.principalStatement || result.resourceStatement;
+    if (versionStages != null && statement) {
+      statement.addCondition({
+        test: "ForAnyValue:StringEquals",
+        variable: "secretsmanager:VersionStage",
+        values: versionStages,
+      });
+    }
+
+    if (this.encryptionKey) {
+      // @see https://docs.aws.amazon.com/kms/latest/developerguide/services-secrets-manager.html
+      this.encryptionKey.grantDecrypt(
+        new ViaServicePrincipal(
+          `secretsmanager.${this.stack.region}.amazonaws.com`,
+          grantee.grantPrincipal,
+        ),
+      );
+    }
+
+    const crossAccount = tokenCompareStrings(
+      this.stack.account,
+      grantee.grantPrincipal.principalAccount || "",
+    );
+
+    // Throw if secret is not imported and it's shared cross account and no KMS key is provided
+    if (
+      this instanceof Secret &&
+      result.resourceStatement &&
+      !this.encryptionKey &&
+      crossAccount === TokenComparison.DIFFERENT
+    ) {
+      throw new ValidationError(
+        "KMS Key must be provided for cross account access to Secret",
+        this,
+      );
+    }
+
+    return result;
+  }
+
+  public grantWrite(grantee: iam.IGrantable): iam.Grant {
+    // See https://docs.aws.amazon.com/secretsmanager/latest/userguide/auth-and-access_identity-based-policies.html
+    const result = iam.Grant.addToPrincipalOrResource({
+      grantee,
+      actions: [
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:UpdateSecret",
+        "secretsmanager:UpdateSecretVersionStage",
+      ],
+      resourceArns: [this.arnForPolicies],
+      resource: this,
+    });
+
+    if (this.encryptionKey) {
+      // See https://docs.aws.amazon.com/kms/latest/developerguide/services-secrets-manager.html
+      this.encryptionKey.grantEncrypt(
+        new ViaServicePrincipal(
+          `secretsmanager.${this.stack.region}.amazonaws.com`,
+          grantee.grantPrincipal,
+        ),
+      );
+    }
+
+    // Throw if secret is not imported and it's shared cross account and no KMS key is provided
+    if (
+      this instanceof Secret &&
+      result.resourceStatement &&
+      !this.encryptionKey
+    ) {
+      throw new ValidationError(
+        "KMS Key must be provided for cross account access to Secret",
+        this,
+      );
+    }
+
+    return result;
+  }
+
+  public addRotationSchedule(
+    id: string,
+    options: RotationScheduleOptions,
+  ): RotationSchedule {
+    return new RotationSchedule(this, id, {
+      secret: this,
+      ...options,
+    });
+  }
+
+  public addToResourcePolicy(
+    statement: iam.PolicyStatement,
+  ): iam.AddToResourcePolicyResult {
+    if (!this.policy && this.autoCreatePolicy) {
+      this.policy = new ResourcePolicy(this, "Policy", { secret: this });
+    }
+
+    if (this.policy) {
+      this.policy.document.addStatements(statement);
+      return { statementAdded: true, policyDependable: this.policy };
+    }
+    return { statementAdded: false };
+  }
+
+  public denyAccountRootDelete() {
+    this.addToResourcePolicy(
+      new iam.PolicyStatement({
+        actions: ["secretsmanager:DeleteSecret"],
+        effect: iam.Effect.DENY,
+        resources: ["*"],
+        principals: [new iam.AccountRootPrincipal()],
+      }),
+    );
+  }
+
+  /**
+   * Provides an identifier for this secret for use in IAM policies.
+   * If there is a full ARN, this is just the ARN;
+   * if we have a partial ARN -- due to either importing by secret name or partial ARN --
+   * then we need to add a suffix to capture the full ARN's format.
+   *
+   * NOTE (TerraConstructs deviation): upstream lazily re-derives this per consuming Stack to
+   * detect cross-account/cross-region references (`Stack._crossRegionReferences`), a concept not
+   * ported in this repo. It is computed eagerly here instead.
+   */
+  protected get arnForPolicies(): string {
+    return this.secretFullArn ?? `${this.secretArn}-??????`;
+  }
+
+  /**
+   * Attach a target to this secret
+   *
+   * @param target The target to attach
+   * @returns An attached secret
+   */
+  public attach(target: ISecretAttachmentTarget): ISecret {
+    const id = "Attachment";
+    const existing = this.node.tryFindChild(id);
+
+    if (existing) {
+      throw new ValidationError(
+        "Secret is already attached to a target.",
+        this,
+      );
+    }
+
+    return new SecretTargetAttachment(this, id, {
+      secret: this,
+      target,
+    });
+  }
+}
+
+/**
+ * Creates a new secret in AWS SecretsManager.
+ *
+ * @resource aws_secretsmanager_secret
+ */
+export class Secret extends SecretBase {
+  /**
+   * Uniquely identifies this class.
+   */
+  public static readonly PROPERTY_INJECTION_ID: string =
+    "terraconstructs.aws.encryption.Secret";
+
+  /**
+   * Return whether the given object is a Secret.
+   */
+  public static isSecret(x: any): x is Secret {
+    return x !== null && typeof x === "object" && SECRET_SYMBOL in x;
+  }
+
+  /** Imports a secret by complete ARN. The complete ARN is the ARN with the Secrets Manager-supplied suffix. */
+  public static fromSecretCompleteArn(
+    scope: Construct,
+    id: string,
+    secretCompleteArn: string,
+  ): ISecret {
+    return Secret.fromSecretAttributes(scope, id, { secretCompleteArn });
+  }
+
+  /** Imports a secret by partial ARN. The partial ARN is the ARN without the Secrets Manager-supplied suffix. */
+  public static fromSecretPartialArn(
+    scope: Construct,
+    id: string,
+    secretPartialArn: string,
+  ): ISecret {
+    return Secret.fromSecretAttributes(scope, id, { secretPartialArn });
+  }
+
+  /**
+   * Imports a secret by secret name; the ARN of the Secret will be set to the secret name.
+   * A secret with this name must exist in the same account & region.
+   * @deprecated use `fromSecretNameV2`
+   */
+  public static fromSecretName(
+    scope: Construct,
+    id: string,
+    secretName: string,
+  ): ISecret {
+    return new (class extends SecretBase {
+      public readonly encryptionKey = undefined;
+      public readonly secretArn = secretName;
+      public readonly secretName = secretName;
+      protected readonly autoCreatePolicy = false;
+      public get secretFullArn() {
+        return undefined;
+      }
+      // Overrides the secretArn for grant* methods, where the secretArn must be in ARN format.
+      // Also adds a wildcard to the resource name to support the SecretsManager-provided suffix.
+      protected get arnForPolicies() {
+        return this.stack.formatArn({
+          service: "secretsmanager",
+          resource: "secret",
+          resourceName: this.secretName + "*",
+          arnFormat: ArnFormat.COLON_RESOURCE_NAME,
+        });
+      }
+    })(scope, id);
+  }
+
+  /**
+   * Imports a secret by secret name.
+   * A secret with this name must exist in the same account & region.
+   * Please note this method returns ISecret that only contains partial ARN and could lead to AccessDeniedException
+   * when you pass the partial ARN to CLI or SDK to get the secret value. If your secret name ends with a hyphen and
+   * 6 characters, you should always use fromSecretCompleteArn() to avoid potential AccessDeniedException.
+   * @see https://docs.aws.amazon.com/secretsmanager/latest/userguide/troubleshoot.html#ARN_secretnamehyphen
+   */
+  public static fromSecretNameV2(
+    scope: Construct,
+    id: string,
+    secretName: string,
+  ): ISecret {
+    return new (class extends SecretBase {
+      public readonly encryptionKey = undefined;
+      public readonly secretName = secretName;
+      public readonly secretArn = this.partialArn;
+      protected readonly autoCreatePolicy = false;
+      public get secretFullArn() {
+        return undefined;
+      }
+      // Creates a "partial" ARN from the secret name. The "full" ARN would include the SecretsManager-provided suffix.
+      private get partialArn(): string {
+        return this.stack.formatArn({
+          service: "secretsmanager",
+          resource: "secret",
+          resourceName: secretName,
+          arnFormat: ArnFormat.COLON_RESOURCE_NAME,
+        });
+      }
+    })(scope, id);
+  }
+
+  /**
+   * Import an existing secret into the Stack.
+   *
+   * @param scope the scope of the import.
+   * @param id    the ID of the imported Secret in the construct tree.
+   * @param attrs the attributes of the imported secret.
+   */
+  public static fromSecretAttributes(
+    scope: Construct,
+    id: string,
+    attrs: SecretAttributes,
+  ): ISecret {
+    let secretArn: string;
+    let secretArnIsPartial: boolean;
+
+    if (attrs.secretArn) {
+      if (attrs.secretCompleteArn || attrs.secretPartialArn) {
+        throw new ValidationError(
+          "cannot use `secretArn` with `secretCompleteArn` or `secretPartialArn`",
+          scope,
+        );
+      }
+      secretArn = attrs.secretArn;
+      secretArnIsPartial = false;
+    } else {
+      if (
+        (attrs.secretCompleteArn && attrs.secretPartialArn) ||
+        (!attrs.secretCompleteArn && !attrs.secretPartialArn)
+      ) {
+        throw new ValidationError(
+          "must use only one of `secretCompleteArn` or `secretPartialArn`",
+          scope,
+        );
+      }
+      if (attrs.secretCompleteArn && !arnIsComplete(attrs.secretCompleteArn)) {
+        throw new ValidationError(
+          "`secretCompleteArn` does not appear to be complete; missing 6-character suffix",
+          scope,
+        );
+      }
+      [secretArn, secretArnIsPartial] = attrs.secretCompleteArn
+        ? [attrs.secretCompleteArn, false]
+        : [attrs.secretPartialArn!, true];
+    }
+
+    return new (class extends SecretBase {
+      public readonly encryptionKey = attrs.encryptionKey;
+      public readonly secretArn = secretArn;
+      public readonly secretName = parseSecretName(
+        scope,
+        secretArn,
+        secretArnIsPartial,
+      );
+      protected readonly autoCreatePolicy = false;
+      public get secretFullArn() {
+        return secretArnIsPartial ? undefined : secretArn;
+      }
+      protected get arnForPolicies() {
+        return secretArnIsPartial ? `${secretArn}-??????` : secretArn;
+      }
+    })(scope, id, { environmentFromArn: secretArn });
+  }
+
+  public readonly encryptionKey?: IKey;
+  public readonly secretArn: string;
+  public readonly secretName: string;
+  public readonly secretVersionArn: string;
+
+  /**
+   * The string of the characters that are excluded in this secret
+   * when it is generated.
+   */
+  public readonly excludeCharacters?: string;
+
+  /**
+   * The underlying `aws_secretsmanager_secret` resource.
+   */
+  public readonly resource: secretsmanagerSecret.SecretsmanagerSecret;
+
+  private replicaRegions: secretsmanagerSecret.SecretsmanagerSecretReplica[] =
+    [];
+  /**
+   * The base secret value configured at construction (from
+   * `generateSecretString`/`secretStringValue`/`secretObjectValue`), before
+   * any attachment connection details are merged in. Rendered into the sole
+   * `secretsmanagerSecretVersion` during `toTerraform()`.
+   */
+  private readonly baseSecretString?: string;
+  /**
+   * Whether `baseSecretString` renders a JSON object (as opposed to a scalar
+   * string). Only `secretObjectValue`, or `generateSecretString` combined with
+   * a `secretStringTemplate`, produce a JSON object; a bare
+   * `generateSecretString` (scalar generated password), `secretStringValue`,
+   * or the default (SecretsManager-generated random password) are all
+   * scalars. `attach()`'s `connectionFields` can only be merged (via
+   * `jsonencode(merge(jsondecode(base), fields))`) when the base is a JSON
+   * object -- `jsondecode()` of a scalar string fails at plan/apply time.
+   */
+  private readonly baseValueIsObject: boolean;
+  /**
+   * Connection details contributed by `attach()` to be merged into the secret
+   * value. Registered (after construction) via `_attachConnectionFields()`.
+   */
+  private attachmentConnectionFields?: { [key: string]: string };
+  /**
+   * The sole secret version resource. Created lazily during `toTerraform()`
+   * (the first `prepareStack()` pass) so connection details registered by a
+   * later `attach()` are merged into the same version rather than creating a
+   * conflicting second `AWSCURRENT` version for the same secret.
+   */
+  private secretVersion?: secretsmanagerSecretVersion.SecretsmanagerSecretVersion;
+
+  protected readonly autoCreatePolicy = true;
+  // TODO: Use Ephemeral Resources as soon as Hashicorp decides to update CDKTF T_T
+  private readonly randomPassword?: dataAwsSecretsmanagerRandomPassword.DataAwsSecretsmanagerRandomPassword;
+
+  constructor(scope: Construct, id: string, props: SecretProps = {}) {
+    super(scope, id, props);
+
+    const secretName = props.secretName ?? this.stack.uniqueResourceName(this);
+
+    if (
+      props.generateSecretString &&
+      (props.generateSecretString.secretStringTemplate ||
+        props.generateSecretString.generateStringKey) &&
+      !(
+        props.generateSecretString.secretStringTemplate &&
+        props.generateSecretString.generateStringKey
+      )
+    ) {
+      throw new ValidationError(
+        "`secretStringTemplate` and `generateStringKey` must be specified together.",
+        this,
+      );
+    }
+
+    if (
+      (props.generateSecretString ? 1 : 0) +
+        (props.secretStringValue ? 1 : 0) +
+        (props.secretObjectValue ? 1 : 0) >
+      1
+    ) {
+      throw new ValidationError(
+        "Cannot specify more than one of `generateSecretString`, `secretStringValue`, and `secretObjectValue`.",
+        this,
+      );
+    }
+
+    let secretString = props.secretObjectValue
+      ? this.resolveSecretObjectValue(props.secretObjectValue)
+      : props.secretStringValue?.toString();
+    // `secretObjectValue` is the only construction path (so far) that
+    // produces a JSON object; refined below once `generateSecretString` is
+    // resolved (a `secretStringTemplate` also produces a JSON object).
+    let baseValueIsObject = !!props.secretObjectValue;
+
+    // Mirrors upstream aws-cdk: when neither a secret string nor
+    // generateSecretString options are provided, default to generating a
+    // random password (equivalent to CFN's `GenerateSecretString: {}`).
+    const generateSecretString: SecretStringGenerator | undefined =
+      props.generateSecretString ?? (secretString ? undefined : {});
+
+    if (generateSecretString) {
+      this.randomPassword =
+        new dataAwsSecretsmanagerRandomPassword.DataAwsSecretsmanagerRandomPassword(
+          this,
+          "RandomPassword",
+          {
+            // note Defaults
+            // https://github.com/hashicorp/terraform-provider-aws/blob/v5.100.0/internal/service/secretsmanager/random_password_data_source.go#L22-L59
+            passwordLength: generateSecretString.passwordLength ?? 32,
+            excludeUppercase: generateSecretString.excludeUppercase ?? false,
+            excludeLowercase: generateSecretString.excludeLowercase ?? false,
+            excludeNumbers: generateSecretString.excludeNumbers ?? false,
+            excludePunctuation:
+              generateSecretString.excludePunctuation ?? false,
+            includeSpace: generateSecretString.includeSpace ?? false,
+            requireEachIncludedType:
+              generateSecretString.requireEachIncludedType ?? true,
+            excludeCharacters: generateSecretString.excludeCharacters,
+          },
+        );
+
+      if (generateSecretString.secretStringTemplate) {
+        // If a secretStringTemplate is provided, we need to merge the generated password into it.
+        const secretStringTemplate = JSON.parse(
+          generateSecretString.secretStringTemplate,
+        );
+        secretStringTemplate[generateSecretString.generateStringKey!] =
+          this.randomPassword.randomPassword;
+        secretString = Fn.jsonencode(secretStringTemplate);
+        baseValueIsObject = true;
+      } else {
+        secretString = this.randomPassword.randomPassword;
+      }
+    }
+
+    // // TODO: If we implement removalPolicy logic, set recoveryWindowInDays
+    // // based on that.
+    // const recoveryWindowInDays =
+    //   props.removalPolicy === RemovalPolicy.DESTROY ? 0 : undefined;
+    const recoveryWindowInDays = props.recoveryWindow?.toDays();
+    // validate recovery window between 7 and 30 days
+    if (
+      recoveryWindowInDays !== undefined &&
+      recoveryWindowInDays !== 0 &&
+      (recoveryWindowInDays < 7 || recoveryWindowInDays > 30)
+    ) {
+      throw new ValidationError(
+        "recoveryWindow must be between 7 and 30 days, or 0 to force deletion without recovery.",
+        this,
+      );
+    }
+
+    this.resource = new secretsmanagerSecret.SecretsmanagerSecret(
+      this,
+      "Resource",
+      {
+        name: secretName,
+        description: props.description,
+        kmsKeyId: props.encryptionKey?.keyArn,
+        recoveryWindowInDays,
+        replica: Lazy.anyValue(
+          { produce: () => this.replicaRegions },
+          { omitEmptyArray: true },
+        ),
+      },
+    );
+
+    // Store the base value; the SOLE `secretsmanagerSecretVersion` resource is
+    // created lazily in `toTerraform()` (the first prepareStack pass) so that
+    // connection details registered by a later `attach()` can be merged into
+    // the same version, instead of creating a conflicting second AWSCURRENT
+    // version for the same secret.
+    // TODO: Use Ephemeral Resources as soon as Hashicorp decides to update CDKTF T_T
+    this.baseSecretString = secretString;
+    this.baseValueIsObject = baseValueIsObject;
+
+    this.secretArn = this.resource.arn;
+    this.secretVersionArn = Lazy.stringValue({
+      produce: () => this.getOrCreateSecretVersion().arn,
+    });
+    this.secretName = this.resource.name;
+    this.encryptionKey = props.encryptionKey;
+
+    // @see https://docs.aws.amazon.com/kms/latest/developerguide/services-secrets-manager.html#asm-authz
+    const principal = new ViaServicePrincipal(
+      `secretsmanager.${this.stack.region}.amazonaws.com`,
+      new iam.AccountPrincipal(this.stack.account),
+    );
+    this.encryptionKey?.grantEncryptDecrypt(principal);
+    this.encryptionKey?.grant(principal, "kms:CreateGrant", "kms:DescribeKey");
+
+    for (const replica of props.replicaRegions ?? []) {
+      this.addReplicaRegion(replica.region, replica.encryptionKey);
+    }
+
+    this.excludeCharacters = props.generateSecretString?.excludeCharacters;
+  }
+
+  private resolveSecretObjectValue(secretObject: {
+    [key: string]: string;
+  }): string {
+    // We are not using SecretValue, so can just stringify the object.
+    return Fn.jsonencode(secretObject);
+  }
+
+  /**
+   * Adds a target attachment to the secret.
+   *
+   * @returns an AttachedSecret
+   *
+   * @deprecated use `attach()` instead
+   */
+  public addTargetAttachment(
+    id: string,
+    options: AttachedSecretOptions,
+  ): SecretTargetAttachment {
+    return new SecretTargetAttachment(this, id, {
+      secret: this,
+      ...options,
+    });
+  }
+
+  /**
+   * Adds a replica region for the secret
+   *
+   * @param region The name of the region
+   * @param encryptionKey The customer-managed encryption key to use for encrypting the secret value.
+   */
+  public addReplicaRegion(region: string, encryptionKey?: IKey): void {
+    if (
+      !Token.isUnresolved(this.stack.region) &&
+      !Token.isUnresolved(region) &&
+      region === this.stack.region
+    ) {
+      throw new ValidationError(
+        "Cannot add the region where this stack is deployed as a replica region.",
+        this,
+      );
+    }
+
+    this.replicaRegions.push({
+      region,
+      kmsKeyId: encryptionKey?.keyArn,
+    });
+  }
+
+  /**
+   * Renders the secret string for the sole version resource, merging any
+   * connection details contributed by `attach()` over the base value. Terraform
+   * has no server-side merge (unlike CloudFormation's SecretTargetAttachment),
+   * so the merge is expressed as `jsonencode(merge(jsondecode(base), fields))`.
+   */
+  private renderSecretString(): string | undefined {
+    if (!this.attachmentConnectionFields) {
+      return this.baseSecretString;
+    }
+    return Fn.jsonencode(
+      Fn.merge([
+        Fn.jsondecode(this.baseSecretString ?? "{}"),
+        this.attachmentConnectionFields,
+      ]),
+    );
+  }
+
+  private getOrCreateSecretVersion(): secretsmanagerSecretVersion.SecretsmanagerSecretVersion {
+    const id = "SecretVersion";
+    const existing = this.node.tryFindChild(id) as
+      | secretsmanagerSecretVersion.SecretsmanagerSecretVersion
+      | undefined;
+    if (existing) {
+      return existing;
+    }
+    // TODO: Use Ephemeral Resources as soon as Hashicorp decides to update CDKTF T_T
+    this.secretVersion =
+      new secretsmanagerSecretVersion.SecretsmanagerSecretVersion(this, id, {
+        secretId: this.resource.arn,
+        secretString: this.renderSecretString(),
+      });
+    return this.secretVersion;
+  }
+
+  /**
+   * Creates the sole secret version during the first `prepareStack()` pass,
+   * after any `attach()` calls have registered their connection details.
+   * Mirrors the idempotent `toTerraform()` pattern used by `iam/policy.ts`.
+   */
+  public toTerraform(): any {
+    this.getOrCreateSecretVersion();
+    return {};
+  }
+
+  /**
+   * Registers connection details contributed by an attached target so they are
+   * merged into this secret's sole version. Called by `SecretTargetAttachment`.
+   * @internal
+   */
+  public _attachConnectionFields(fields?: { [key: string]: string }): void {
+    if (!fields || Object.keys(fields).length === 0) {
+      return;
+    }
+    if (!this.baseValueIsObject) {
+      throw new ValidationError(
+        "Cannot merge attachment connectionFields into this Secret because its value is not a JSON object. Use secretObjectValue, or generateSecretString with a secretStringTemplate.",
+        this,
+      );
+    }
+    this.attachmentConnectionFields = {
+      ...(this.attachmentConnectionFields ?? {}),
+      ...fields,
+    };
+  }
+}
+
+/**
+ * A secret attachment target.
+ *
+ * NOTE: TerraConstructs does not yet ship any concrete implementations of
+ * this interface. In upstream aws-cdk, `ISecretAttachmentTarget` is
+ * implemented by `DatabaseInstance`, `DatabaseCluster`, and `DatabaseProxy`
+ * (aws-rds), and by the DocDB/Redshift equivalents -- none of which have
+ * been ported to TerraConstructs yet. Until they are, consumers who want to
+ * attach a secret to a database (or other supported target) must implement
+ * this interface themselves. See `integ/aws/encryption/apps/*.ts` for a
+ * worked (test-only) example.
+ */
+export interface ISecretAttachmentTarget {
+  /**
+   * Renders the target specifications.
+   */
+  asSecretAttachmentTarget(): SecretAttachmentTargetProps;
+}
+
+/**
+ * The type of service or database that's being associated with the secret.
+ */
+export enum AttachmentTargetType {
+  /**
+   * AWS::RDS::DBInstance
+   */
+  RDS_DB_INSTANCE = "AWS::RDS::DBInstance",
+
+  /**
+   * A database instance
+   *
+   * @deprecated use RDS_DB_INSTANCE instead
+   */
+  INSTANCE = "deprecated_AWS::RDS::DBInstance",
+
+  /**
+   * AWS::RDS::DBCluster
+   */
+  RDS_DB_CLUSTER = "AWS::RDS::DBCluster",
+
+  /**
+   * A database cluster
+   *
+   * @deprecated use RDS_DB_CLUSTER instead
+   */
+  CLUSTER = "deprecated_AWS::RDS::DBCluster",
+
+  /**
+   * AWS::RDS::DBProxy
+   */
+  RDS_DB_PROXY = "AWS::RDS::DBProxy",
+
+  /**
+   * AWS::Redshift::Cluster
+   */
+  REDSHIFT_CLUSTER = "AWS::Redshift::Cluster",
+
+  /**
+   * AWS::DocDB::DBInstance
+   */
+  DOCDB_DB_INSTANCE = "AWS::DocDB::DBInstance",
+
+  /**
+   * AWS::DocDB::DBCluster
+   */
+  DOCDB_DB_CLUSTER = "AWS::DocDB::DBCluster",
+}
+
+/**
+ * Attachment target specifications.
+ */
+export interface SecretAttachmentTargetProps {
+  /**
+   * The id of the target to attach the secret to.
+   */
+  readonly targetId: string;
+
+  /**
+   * The type of the target to attach the secret to.
+   */
+  readonly targetType: AttachmentTargetType;
+
+  /**
+   * Connection details to merge into the attached secret's JSON value.
+   *
+   * CloudFormation's `AWS::SecretsManager::SecretTargetAttachment` resolves
+   * these from `targetId`/`targetType` **server-side**; the Terraform AWS
+   * provider has no such server-side merge, so a target must supply the
+   * connection attributes it wants folded into the secret (typically
+   * `engine`, `host`, `port`, `dbname`). They are merged over the secret's
+   * existing JSON value at synthesis via
+   * `jsonencode(merge(jsondecode(existing), connectionFields))`.
+   *
+   * This field is a TerraConstructs-specific superset of the upstream aws-cdk
+   * `SecretAttachmentTargetProps` (which carries only `targetId`/`targetType`).
+   *
+   * @default - no additional fields are merged (API-parity-only attachment)
+   */
+  readonly connectionFields?: { [key: string]: string };
+}
+
+/**
+ * Options to add a secret attachment to a secret.
+ */
+export interface AttachedSecretOptions {
+  /**
+   * The target to attach the secret to.
+   */
+  readonly target: ISecretAttachmentTarget;
+}
+
+/**
+ * Construction properties for an AttachedSecret.
+ */
+export interface SecretTargetAttachmentProps extends AttachedSecretOptions {
+  /**
+   * The secret to attach to the target.
+   */
+  readonly secret: ISecret;
+}
+
+export interface ISecretTargetAttachment extends ISecret {
+  /**
+   * Same as `secretArn`
+   *
+   * @attribute
+   */
+  readonly secretTargetAttachmentSecretArn: string;
+}
+
+/**
+ * An attached secret.
+ *
+ * CloudFormation's `AWS::SecretsManager::SecretTargetAttachment` is an opaque
+ * AWS orchestration call that merges a target's connection details (host,
+ * port, engine, dbname, ...) into the secret's JSON value **server-side**. The
+ * Terraform AWS provider has no equivalent -- there is no SecretsManager API
+ * behind it -- so the maintainers recommend building that merged value
+ * yourself with a single `aws_secretsmanager_secret_version`. See HashiCorp's
+ * design decision (also referenced from `HostedRotation` in
+ * rotation-schedule.ts):
+ * https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/design-decisions/secretsmanager-secret-target-attachment.md
+ *
+ * TerraConstructs mirrors that recommended shape: `attach()` does NOT create a
+ * second version resource (two versions managing the same secret's
+ * `AWSCURRENT` would conflict). Instead it registers the target's
+ * `connectionFields` (from `asSecretAttachmentTarget()`) onto the owned
+ * `Secret`, which merges them into its SOLE version -- created lazily in
+ * `Secret.toTerraform()` -- via `jsonencode(merge(jsondecode(base), fields))`.
+ * The result is exactly one `aws_secretsmanager_secret_version` containing the
+ * base credentials plus the target's connection details.
+ *
+ * Concrete `ISecretAttachmentTarget` implementers (`DatabaseInstance`,
+ * `DatabaseCluster`, ... in aws-rds/docdb/redshift) are not yet ported to
+ * TerraConstructs; until they are, consumers implement the interface
+ * themselves. See `integ/aws/encryption/apps/*.ts` for a worked (test-only)
+ * example of a target that supplies real connection details.
+ *
+ * `addToResourcePolicy` calls are forwarded to the original secret so that
+ * only a single resource policy is ever created for the secret (AWS allows
+ * only one `aws_secretsmanager_secret_policy` per secret ARN).
+ *
+ * `secretArn`/`secretName` mirror the attached secret since there is no
+ * separate attachment ARN in Terraform.
+ */
+export class SecretTargetAttachment
+  extends SecretBase
+  implements ISecretTargetAttachment
+{
+  /** Uniquely identifies this class. */
+  public static readonly PROPERTY_INJECTION_ID: string =
+    "terraconstructs.aws.encryption.SecretTargetAttachment";
+
+  public static fromSecretTargetAttachmentSecretArn(
+    scope: Construct,
+    id: string,
+    secretTargetAttachmentSecretArn: string,
+  ): ISecretTargetAttachment {
+    class Import extends SecretBase implements ISecretTargetAttachment {
+      public readonly encryptionKey: IKey | undefined = undefined;
+      public readonly secretArn: string = secretTargetAttachmentSecretArn;
+      public readonly secretTargetAttachmentSecretArn: string =
+        secretTargetAttachmentSecretArn;
+      public readonly secretName: string = parseSecretName(
+        scope,
+        secretTargetAttachmentSecretArn,
+      );
+      protected readonly autoCreatePolicy = false;
+    }
+
+    return new Import(scope, id);
+  }
+
+  public readonly encryptionKey?: IKey;
+  public readonly secretArn: string;
+  public readonly secretName: string;
+
+  /**
+   * @attribute
+   */
+  public readonly secretTargetAttachmentSecretArn: string;
+
+  protected readonly autoCreatePolicy = true;
+
+  private readonly attachedSecret: ISecret;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    props: SecretTargetAttachmentProps,
+  ) {
+    super(scope, id);
+    this.attachedSecret = props.secret;
+
+    // Terraform has no server-side merge, so fold the target's connection
+    // details into the attached secret's SOLE version (created lazily in
+    // `Secret.toTerraform()`). No separate/duplicate version is created here.
+    const targetProps = props.target.asSecretAttachmentTarget();
+    if (Secret.isSecret(this.attachedSecret)) {
+      (this.attachedSecret as Secret)._attachConnectionFields(
+        targetProps.connectionFields,
+      );
+    } else if (
+      targetProps.connectionFields &&
+      Object.keys(targetProps.connectionFields).length > 0
+    ) {
+      throw new ValidationError(
+        "Cannot merge attachment connectionFields into an imported secret; attach() with connectionFields is only supported for owned Secret constructs.",
+        this,
+      );
+    }
+
+    this.encryptionKey = this.attachedSecret.encryptionKey;
+    this.secretName = this.attachedSecret.secretName;
+
+    // No separate attachment ARN exists in Terraform, so the attached
+    // secret's own ARN is the correct reference.
+    this.secretArn = this.attachedSecret.secretArn;
+    this.secretTargetAttachmentSecretArn = this.attachedSecret.secretArn;
+  }
+
+  /**
+   * Forward any additions to the resource policy to the original secret.
+   * This is required because a secret can only have a single resource policy.
+   * If we do not forward policy additions, a new policy resource would be
+   * created using the secret attachment ARN, which AWS APIs would reject.
+   */
+  public addToResourcePolicy(
+    statement: iam.PolicyStatement,
+  ): iam.AddToResourcePolicyResult {
+    return this.attachedSecret.addToResourcePolicy(statement);
+  }
+}
+
+/**
+ * Configuration to generate secrets such as passwords automatically.
+ */
+export interface SecretStringGenerator {
+  /**
+   * Specifies that the generated password shouldn't include uppercase letters.
+   *
+   * @default false
+   */
+  readonly excludeUppercase?: boolean;
+
+  /**
+   * Specifies whether the generated password must include at least one of every allowed character type.
+   *
+   * @default true
+   */
+  readonly requireEachIncludedType?: boolean;
+
+  /**
+   * Specifies that the generated password can include the space character.
+   *
+   * @default false
+   */
+  readonly includeSpace?: boolean;
+
+  /**
+   * A string that includes characters that shouldn't be included in the generated password. The string can be a minimum
+   * of ``0`` and a maximum of ``4096`` characters long.
+   *
+   * @default no exclusions
+   */
+  readonly excludeCharacters?: string;
+
+  /**
+   * The desired length of the generated password.
+   *
+   * @default 32
+   */
+  readonly passwordLength?: number;
+
+  /**
+   * Specifies that the generated password shouldn't include punctuation characters.
+   *
+   * @default false
+   */
+  readonly excludePunctuation?: boolean;
+
+  /**
+   * Specifies that the generated password shouldn't include lowercase letters.
+   *
+   * @default false
+   */
+  readonly excludeLowercase?: boolean;
+
+  /**
+   * Specifies that the generated password shouldn't include digits.
+   *
+   * @default false
+   */
+  readonly excludeNumbers?: boolean;
+
+  /**
+   * A properly structured JSON string that the generated password can be added to. The ``generateStringKey`` is
+   * combined with the generated random string and inserted into the JSON structure that's specified by this parameter.
+   * The merged JSON string is returned as the completed SecretString of the secret. If you specify ``secretStringTemplate``
+   * then ``generateStringKey`` must be also be specified.
+   */
+  readonly secretStringTemplate?: string;
+
+  /**
+   * The JSON key name that's used to add the generated password to the JSON structure specified by the
+   * ``secretStringTemplate`` parameter. If you specify ``generateStringKey`` then ``secretStringTemplate``
+   * must be also be specified.
+   */
+  readonly generateStringKey?: string;
+}
+
+/**
+ * Parses the secret name from the ARN.
+ *
+ * @param isPartialArn Whether `secretArn` is a partial ARN (i.e. one without
+ * the Secrets Manager-supplied 6-character suffix, per definition). A partial
+ * ARN's resource name is never followed by that suffix, so it must be
+ * returned in full -- a trailing `-XXXXXX` segment on a partial ARN is part
+ * of the actual secret name, not a suffix to strip.
+ */
+function parseSecretName(
+  construct: IConstruct,
+  secretArn: string,
+  isPartialArn = false,
+) {
+  const resourceName = AwsStack.ofAwsConstruct(construct).splitArn(
+    secretArn,
+    ArnFormat.COLON_RESOURCE_NAME,
+  ).resourceName;
+  if (resourceName) {
+    // Can't operate on the token to remove the SecretsManager suffix, so just return the full secret name
+    if (Token.isUnresolved(resourceName)) {
+      return resourceName;
+    }
+
+    if (isPartialArn) {
+      // A partial ARN by definition carries no AWS-supplied suffix, so the
+      // full resource name IS the secret name -- even if its trailing
+      // hyphen-separated segment happens to be 6 characters long.
+      return resourceName;
+    }
+
+    // Secret resource names are in the format `${secretName}-${6-character SecretsManager suffix}`
+    // If there is no hyphen (or 6-character suffix) assume no suffix was provided, and return the whole name.
+    const lastHyphenIndex = resourceName.lastIndexOf("-");
+    const hasSecretsSuffix =
+      lastHyphenIndex !== -1 &&
+      resourceName.slice(lastHyphenIndex + 1).length === 6;
+    return hasSecretsSuffix
+      ? resourceName.slice(0, lastHyphenIndex)
+      : resourceName;
+  }
+  throw new ValidationError(
+    "invalid ARN format; no secret name provided",
+    construct,
+  );
+}
+
+/** Performs a best guess if an ARN is complete, based on if it ends with a 6-character suffix. */
+function arnIsComplete(secretArn: string): boolean {
+  return Token.isUnresolved(secretArn) || /-[a-z0-9]{6}$/i.test(secretArn);
+}
+
+/**
+ * Mark all instances of 'Secret'.
+ */
+Object.defineProperty(Secret.prototype, SECRET_SYMBOL, {
+  value: true,
+  enumerable: false,
+  writable: false,
+});

--- a/test/aws/encryption/__snapshots__/policy.test.ts.snap
+++ b/test/aws/encryption/__snapshots__/policy.test.ts.snap
@@ -1,0 +1,83 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ResourcePolicy Should synth and match SnapShot 1`] = `
+"{
+  "data": {
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_iam_policy_document": {
+      "Policy_C96C8195": {
+        "statement": [
+        ]
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_region": {
+      "Region": {
+        "provider": "aws"
+      }
+    },
+    "aws_secretsmanager_random_password": {
+      "Secret_RandomPassword_01FCD53F": {
+        "exclude_lowercase": false,
+        "exclude_numbers": false,
+        "exclude_punctuation": false,
+        "exclude_uppercase": false,
+        "include_space": false,
+        "password_length": 32,
+        "require_each_included_type": true
+      }
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+      }
+    ]
+  },
+  "resource": {
+    "aws_secretsmanager_secret": {
+      "Secret_A720EF05": {
+        "name": "Secret",
+        "tags": {
+          "Name": "Default-Secret",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "g"
+        }
+      }
+    },
+    "aws_secretsmanager_secret_policy": {
+      "Policy_23B91518": {
+        "policy": "\${data.aws_iam_policy_document.Policy_C96C8195.json}",
+        "secret_arn": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}"
+      }
+    },
+    "aws_secretsmanager_secret_version": {
+      "Secret_SecretVersion_1CCEE6BD": {
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}",
+        "secret_string": "\${data.aws_secretsmanager_random_password.Secret_RandomPassword_01FCD53F.random_password}"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "local": {
+        "path": "/Users/vincentsmet/tcons/base-secretsmanager-combined/terraform.Default.tfstate"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;

--- a/test/aws/encryption/__snapshots__/policy.test.ts.snap
+++ b/test/aws/encryption/__snapshots__/policy.test.ts.snap
@@ -68,8 +68,8 @@ exports[`ResourcePolicy Should synth and match SnapShot 1`] = `
   },
   "terraform": {
     "backend": {
-      "local": {
-        "path": "/Users/vincentsmet/tcons/base-secretsmanager-combined/terraform.Default.tfstate"
+      "http": {
+        "address": "http://localhost:3000"
       }
     },
     "required_providers": {

--- a/test/aws/encryption/__snapshots__/rotation-schedule.test.ts.snap
+++ b/test/aws/encryption/__snapshots__/rotation-schedule.test.ts.snap
@@ -244,8 +244,8 @@ exports[`RotationSchedule Should synth and match SnapShot 1`] = `
   },
   "terraform": {
     "backend": {
-      "local": {
-        "path": "/Users/vincentsmet/tcons/base-secretsmanager-combined/terraform.Default.tfstate"
+      "http": {
+        "address": "http://localhost:3000"
       }
     },
     "required_providers": {

--- a/test/aws/encryption/__snapshots__/rotation-schedule.test.ts.snap
+++ b/test/aws/encryption/__snapshots__/rotation-schedule.test.ts.snap
@@ -1,0 +1,263 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RotationSchedule Should synth and match SnapShot 1`] = `
+"{
+  "data": {
+    "archive_file": {
+      "Lambda_Lambda977ac4c4b02ffbf33727a2b3dfd94f40A3E2D98D_FA6D0A46": {
+        "output_path": "\${path.root}/.archive_files/Lambda977ac4c4b02ffbf33727a2b3dfd94f40A3E2D98D.zip",
+        "provider": "archive",
+        "source_content": "export.handler = event => event;",
+        "source_content_filename": "index.js",
+        "type": "zip"
+      }
+    },
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_iam_policy_document": {
+      "Lambda_ServiceRole_AssumeRolePolicy_FE762235": {
+        "statement": [
+          {
+            "actions": [
+              "sts:AssumeRole"
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "\${data.aws_service_principal.aws_svcp_default_region_lambda.name}"
+                ],
+                "type": "Service"
+              }
+            ]
+          }
+        ]
+      },
+      "Lambda_ServiceRole_DefaultPolicy_E1FFF11A": {
+        "statement": [
+          {
+            "actions": [
+              "xray:PutTraceSegments",
+              "xray:PutTelemetryRecords"
+            ],
+            "effect": "Allow",
+            "resources": [
+              "*"
+            ]
+          },
+          {
+            "actions": [
+              "secretsmanager:DescribeSecret",
+              "secretsmanager:GetSecretValue",
+              "secretsmanager:PutSecretValue",
+              "secretsmanager:UpdateSecretVersionStage"
+            ],
+            "effect": "Allow",
+            "resources": [
+              "\${aws_secretsmanager_secret.Secret_A720EF05.arn}"
+            ]
+          },
+          {
+            "actions": [
+              "secretsmanager:GetRandomPassword"
+            ],
+            "effect": "Allow",
+            "resources": [
+              "*"
+            ]
+          }
+        ]
+      },
+      "Secret_Policy_13544DA0": {
+        "statement": [
+          {
+            "actions": [
+              "secretsmanager:DeleteSecret"
+            ],
+            "effect": "Deny",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_region": {
+      "Region": {
+        "provider": "aws"
+      }
+    },
+    "aws_secretsmanager_random_password": {
+      "Secret_RandomPassword_01FCD53F": {
+        "exclude_lowercase": false,
+        "exclude_numbers": false,
+        "exclude_punctuation": false,
+        "exclude_uppercase": false,
+        "include_space": false,
+        "password_length": 32,
+        "require_each_included_type": true
+      }
+    },
+    "aws_service_principal": {
+      "aws_svcp_default_region_lambda": {
+        "service_name": "lambda"
+      }
+    }
+  },
+  "provider": {
+    "archive": [
+      {
+      }
+    ],
+    "aws": [
+      {
+      }
+    ]
+  },
+  "resource": {
+    "aws_cloudwatch_log_group": {
+      "Lambda_LogGroup_966346B4": {
+        "name": "/aws/lambda/g-Lambda",
+        "retention_in_days": 7,
+        "tags": {
+          "Name": "Default-Lambda",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "g"
+        }
+      }
+    },
+    "aws_iam_role": {
+      "Lambda_ServiceRole_A8ED4D3B": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.Lambda_ServiceRole_AssumeRolePolicy_FE762235.json}",
+        "name_prefix": "g-LambdaServiceRole",
+        "tags": {
+          "Name": "Default-Lambda",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "g"
+        }
+      }
+    },
+    "aws_iam_role_policy": {
+      "Lambda_ServiceRole_DefaultPolicy_ResourceRoles0_DE66D1AF": {
+        "name": "LambdaServiceRoleDefaultPolicy375CD4A7",
+        "policy": "\${data.aws_iam_policy_document.Lambda_ServiceRole_DefaultPolicy_E1FFF11A.json}",
+        "role": "\${aws_iam_role.Lambda_ServiceRole_A8ED4D3B.name}"
+      }
+    },
+    "aws_iam_role_policy_attachment": {
+      "Lambda_AWSLambdaBasicExecutionRole_Roles0_F1493B3C": {
+        "policy_arn": "arn:\${data.aws_partition.Partitition.partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+        "role": "\${aws_iam_role.Lambda_ServiceRole_A8ED4D3B.name}"
+      }
+    },
+    "aws_lambda_function": {
+      "Lambda_D247545B": {
+        "architectures": [
+          "x86_64"
+        ],
+        "depends_on": [
+          "aws_cloudwatch_log_group.Lambda_LogGroup_966346B4",
+          "data.aws_iam_policy_document.Lambda_ServiceRole_AssumeRolePolicy_FE762235",
+          "aws_iam_role.Lambda_ServiceRole_A8ED4D3B",
+          "data.aws_iam_policy_document.Lambda_ServiceRole_DefaultPolicy_E1FFF11A",
+          "aws_iam_role_policy.Lambda_ServiceRole_DefaultPolicy_ResourceRoles0_DE66D1AF"
+        ],
+        "environment": {
+          "variables": {
+          }
+        },
+        "filename": "\${data.archive_file.Lambda_Lambda977ac4c4b02ffbf33727a2b3dfd94f40A3E2D98D_FA6D0A46.output_path}",
+        "function_name": "g-Lambda",
+        "handler": "index.handler",
+        "memory_size": 128,
+        "role": "\${aws_iam_role.Lambda_ServiceRole_A8ED4D3B.arn}",
+        "runtime": "nodejs22.x",
+        "source_code_hash": "\${data.archive_file.Lambda_Lambda977ac4c4b02ffbf33727a2b3dfd94f40A3E2D98D_FA6D0A46.output_base64sha256}",
+        "tags": {
+          "Name": "Default-Lambda",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "g"
+        },
+        "timeout": 3,
+        "tracing_config": {
+          "mode": "Active"
+        }
+      }
+    },
+    "aws_lambda_permission": {
+      "Lambda_InvokeWD9X6a9NLlLnGrEs8Z0khbjD6QCSv7PAjlePIac6E_CED4E3B4": {
+        "action": "lambda:InvokeFunction",
+        "function_name": "\${aws_lambda_function.Lambda_D247545B.arn}",
+        "principal": "secretsmanager.amazonaws.com"
+      }
+    },
+    "aws_secretsmanager_secret": {
+      "Secret_A720EF05": {
+        "name": "Secret",
+        "tags": {
+          "Name": "Default-Secret",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "g"
+        }
+      }
+    },
+    "aws_secretsmanager_secret_policy": {
+      "Secret_Policy_06C9821C": {
+        "policy": "\${data.aws_iam_policy_document.Secret_Policy_13544DA0.json}",
+        "secret_arn": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}"
+      }
+    },
+    "aws_secretsmanager_secret_rotation": {
+      "RotationSchedule_2A725270": {
+        "depends_on": [
+          "aws_lambda_permission.Lambda_InvokeWD9X6a9NLlLnGrEs8Z0khbjD6QCSv7PAjlePIac6E_CED4E3B4"
+        ],
+        "rotation_lambda_arn": "\${aws_lambda_function.Lambda_D247545B.arn}",
+        "rotation_rules": {
+          "schedule_expression": "rate(14 days)"
+        },
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}"
+      }
+    },
+    "aws_secretsmanager_secret_version": {
+      "Secret_SecretVersion_1CCEE6BD": {
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}",
+        "secret_string": "\${data.aws_secretsmanager_random_password.Secret_RandomPassword_01FCD53F.random_password}"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "local": {
+        "path": "/Users/vincentsmet/tcons/base-secretsmanager-combined/terraform.Default.tfstate"
+      }
+    },
+    "required_providers": {
+      "archive": {
+        "source": "hashicorp/archive",
+        "version": "2.8.0"
+      },
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;

--- a/test/aws/encryption/__snapshots__/secret.test.ts.snap
+++ b/test/aws/encryption/__snapshots__/secret.test.ts.snap
@@ -1,0 +1,1915 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`default secret 1`] = `
+"{
+  "data": {
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_secretsmanager_random_password": {
+      "Secret_RandomPassword_01FCD53F": {
+        "exclude_lowercase": false,
+        "exclude_numbers": false,
+        "exclude_punctuation": false,
+        "exclude_uppercase": false,
+        "include_space": false,
+        "password_length": 32,
+        "require_each_included_type": true
+      }
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "us-east-1"
+      }
+    ]
+  },
+  "resource": {
+    "aws_secretsmanager_secret": {
+      "Secret_A720EF05": {
+        "name": "MyStackSecret03F6D6E7",
+        "tags": {
+          "Name": "Test-Secret",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret_version": {
+      "Secret_SecretVersion_1CCEE6BD": {
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}",
+        "secret_string": "\${data.aws_secretsmanager_random_password.Secret_RandomPassword_01FCD53F.random_password}"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "http": {
+        "address": "http://localhost:3000"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`grantRead cross account 1`] = `
+"{
+  "data": {
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_iam_policy_document": {
+      "KMS_Policy_BCC43B78": {
+        "statement": [
+          {
+            "actions": [
+              "kms:*"
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          },
+          {
+            "actions": [
+              "kms:Decrypt",
+              "kms:Encrypt",
+              "kms:ReEncrypt*",
+              "kms:GenerateDataKey*"
+            ],
+            "condition": [
+              {
+                "test": "StringEquals",
+                "values": [
+                  "secretsmanager.us-east-1.amazonaws.com"
+                ],
+                "variable": "kms:ViaService"
+              }
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          },
+          {
+            "actions": [
+              "kms:CreateGrant",
+              "kms:DescribeKey"
+            ],
+            "condition": [
+              {
+                "test": "StringEquals",
+                "values": [
+                  "secretsmanager.us-east-1.amazonaws.com"
+                ],
+                "variable": "kms:ViaService"
+              }
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          },
+          {
+            "actions": [
+              "kms:Decrypt"
+            ],
+            "condition": [
+              {
+                "test": "StringEquals",
+                "values": [
+                  "secretsmanager.us-east-1.amazonaws.com"
+                ],
+                "variable": "kms:ViaService"
+              }
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::1234:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          }
+        ]
+      },
+      "Secret_Policy_13544DA0": {
+        "statement": [
+          {
+            "actions": [
+              "secretsmanager:GetSecretValue",
+              "secretsmanager:DescribeSecret"
+            ],
+            "condition": [
+              {
+                "test": "ForAnyValue:StringEquals",
+                "values": [
+                  "FOO",
+                  "bar"
+                ],
+                "variable": "secretsmanager:VersionStage"
+              }
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::1234:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "\${aws_secretsmanager_secret.Secret_A720EF05.arn}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_secretsmanager_random_password": {
+      "Secret_RandomPassword_01FCD53F": {
+        "exclude_lowercase": false,
+        "exclude_numbers": false,
+        "exclude_punctuation": false,
+        "exclude_uppercase": false,
+        "include_space": false,
+        "password_length": 32,
+        "require_each_included_type": true
+      }
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "us-east-1"
+      }
+    ]
+  },
+  "resource": {
+    "aws_kms_key": {
+      "KMS_6B14D45A": {
+        "policy": "\${data.aws_iam_policy_document.KMS_Policy_BCC43B78.json}",
+        "tags": {
+          "Name": "Test-KMS",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret": {
+      "Secret_A720EF05": {
+        "kms_key_id": "\${aws_kms_key.KMS_6B14D45A.arn}",
+        "name": "MyStackSecret03F6D6E7",
+        "tags": {
+          "Name": "Test-Secret",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret_policy": {
+      "Secret_Policy_06C9821C": {
+        "policy": "\${data.aws_iam_policy_document.Secret_Policy_13544DA0.json}",
+        "secret_arn": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}"
+      }
+    },
+    "aws_secretsmanager_secret_version": {
+      "Secret_SecretVersion_1CCEE6BD": {
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}",
+        "secret_string": "\${data.aws_secretsmanager_random_password.Secret_RandomPassword_01FCD53F.random_password}"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "http": {
+        "address": "http://localhost:3000"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`grantRead with KMS Key 1`] = `
+"{
+  "data": {
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_iam_policy_document": {
+      "KMS_Policy_BCC43B78": {
+        "statement": [
+          {
+            "actions": [
+              "kms:*"
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          },
+          {
+            "actions": [
+              "kms:Decrypt",
+              "kms:Encrypt",
+              "kms:ReEncrypt*",
+              "kms:GenerateDataKey*"
+            ],
+            "condition": [
+              {
+                "test": "StringEquals",
+                "values": [
+                  "secretsmanager.us-east-1.amazonaws.com"
+                ],
+                "variable": "kms:ViaService"
+              }
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          },
+          {
+            "actions": [
+              "kms:CreateGrant",
+              "kms:DescribeKey"
+            ],
+            "condition": [
+              {
+                "test": "StringEquals",
+                "values": [
+                  "secretsmanager.us-east-1.amazonaws.com"
+                ],
+                "variable": "kms:ViaService"
+              }
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          },
+          {
+            "actions": [
+              "kms:Decrypt"
+            ],
+            "condition": [
+              {
+                "test": "StringEquals",
+                "values": [
+                  "secretsmanager.us-east-1.amazonaws.com"
+                ],
+                "variable": "kms:ViaService"
+              }
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "\${aws_iam_role.Role_1ABCC5F0.arn}"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          }
+        ]
+      },
+      "Role_AssumeRolePolicy_B27E8126": {
+        "statement": [
+          {
+            "actions": [
+              "sts:AssumeRole"
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ]
+          }
+        ]
+      },
+      "Role_DefaultPolicy_2E5E5E0B": {
+        "statement": [
+          {
+            "actions": [
+              "secretsmanager:GetSecretValue",
+              "secretsmanager:DescribeSecret"
+            ],
+            "effect": "Allow",
+            "resources": [
+              "\${aws_secretsmanager_secret.Secret_A720EF05.arn}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_secretsmanager_random_password": {
+      "Secret_RandomPassword_01FCD53F": {
+        "exclude_lowercase": false,
+        "exclude_numbers": false,
+        "exclude_punctuation": false,
+        "exclude_uppercase": false,
+        "include_space": false,
+        "password_length": 32,
+        "require_each_included_type": true
+      }
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "us-east-1"
+      }
+    ]
+  },
+  "resource": {
+    "aws_iam_role": {
+      "Role_1ABCC5F0": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.Role_AssumeRolePolicy_B27E8126.json}",
+        "name_prefix": "a123e4567-e89b-12d3-MyStackRole",
+        "tags": {
+          "Name": "Test-Role",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_iam_role_policy": {
+      "Role_DefaultPolicy_ResourceRoles0_50D8AFFD": {
+        "name": "MyStackRoleDefaultPolicy86F304AD",
+        "policy": "\${data.aws_iam_policy_document.Role_DefaultPolicy_2E5E5E0B.json}",
+        "role": "\${aws_iam_role.Role_1ABCC5F0.name}"
+      }
+    },
+    "aws_kms_key": {
+      "KMS_6B14D45A": {
+        "policy": "\${data.aws_iam_policy_document.KMS_Policy_BCC43B78.json}",
+        "tags": {
+          "Name": "Test-KMS",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret": {
+      "Secret_A720EF05": {
+        "kms_key_id": "\${aws_kms_key.KMS_6B14D45A.arn}",
+        "name": "MyStackSecret03F6D6E7",
+        "tags": {
+          "Name": "Test-Secret",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret_version": {
+      "Secret_SecretVersion_1CCEE6BD": {
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}",
+        "secret_string": "\${data.aws_secretsmanager_random_password.Secret_RandomPassword_01FCD53F.random_password}"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "http": {
+        "address": "http://localhost:3000"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`grantRead with version label constraint 1`] = `
+"{
+  "data": {
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_iam_policy_document": {
+      "KMS_Policy_BCC43B78": {
+        "statement": [
+          {
+            "actions": [
+              "kms:*"
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          },
+          {
+            "actions": [
+              "kms:Decrypt",
+              "kms:Encrypt",
+              "kms:ReEncrypt*",
+              "kms:GenerateDataKey*"
+            ],
+            "condition": [
+              {
+                "test": "StringEquals",
+                "values": [
+                  "secretsmanager.us-east-1.amazonaws.com"
+                ],
+                "variable": "kms:ViaService"
+              }
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          },
+          {
+            "actions": [
+              "kms:CreateGrant",
+              "kms:DescribeKey"
+            ],
+            "condition": [
+              {
+                "test": "StringEquals",
+                "values": [
+                  "secretsmanager.us-east-1.amazonaws.com"
+                ],
+                "variable": "kms:ViaService"
+              }
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          },
+          {
+            "actions": [
+              "kms:Decrypt"
+            ],
+            "condition": [
+              {
+                "test": "StringEquals",
+                "values": [
+                  "secretsmanager.us-east-1.amazonaws.com"
+                ],
+                "variable": "kms:ViaService"
+              }
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "\${aws_iam_role.Role_1ABCC5F0.arn}"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          }
+        ]
+      },
+      "Role_AssumeRolePolicy_B27E8126": {
+        "statement": [
+          {
+            "actions": [
+              "sts:AssumeRole"
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ]
+          }
+        ]
+      },
+      "Role_DefaultPolicy_2E5E5E0B": {
+        "statement": [
+          {
+            "actions": [
+              "secretsmanager:GetSecretValue",
+              "secretsmanager:DescribeSecret"
+            ],
+            "condition": [
+              {
+                "test": "ForAnyValue:StringEquals",
+                "values": [
+                  "FOO",
+                  "bar"
+                ],
+                "variable": "secretsmanager:VersionStage"
+              }
+            ],
+            "effect": "Allow",
+            "resources": [
+              "\${aws_secretsmanager_secret.Secret_A720EF05.arn}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_secretsmanager_random_password": {
+      "Secret_RandomPassword_01FCD53F": {
+        "exclude_lowercase": false,
+        "exclude_numbers": false,
+        "exclude_punctuation": false,
+        "exclude_uppercase": false,
+        "include_space": false,
+        "password_length": 32,
+        "require_each_included_type": true
+      }
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "us-east-1"
+      }
+    ]
+  },
+  "resource": {
+    "aws_iam_role": {
+      "Role_1ABCC5F0": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.Role_AssumeRolePolicy_B27E8126.json}",
+        "name_prefix": "a123e4567-e89b-12d3-MyStackRole",
+        "tags": {
+          "Name": "Test-Role",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_iam_role_policy": {
+      "Role_DefaultPolicy_ResourceRoles0_50D8AFFD": {
+        "name": "MyStackRoleDefaultPolicy86F304AD",
+        "policy": "\${data.aws_iam_policy_document.Role_DefaultPolicy_2E5E5E0B.json}",
+        "role": "\${aws_iam_role.Role_1ABCC5F0.name}"
+      }
+    },
+    "aws_kms_key": {
+      "KMS_6B14D45A": {
+        "policy": "\${data.aws_iam_policy_document.KMS_Policy_BCC43B78.json}",
+        "tags": {
+          "Name": "Test-KMS",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret": {
+      "Secret_A720EF05": {
+        "kms_key_id": "\${aws_kms_key.KMS_6B14D45A.arn}",
+        "name": "MyStackSecret03F6D6E7",
+        "tags": {
+          "Name": "Test-Secret",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret_version": {
+      "Secret_SecretVersion_1CCEE6BD": {
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}",
+        "secret_string": "\${data.aws_secretsmanager_random_password.Secret_RandomPassword_01FCD53F.random_password}"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "http": {
+        "address": "http://localhost:3000"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`grantWrite with kms 1`] = `
+"{
+  "data": {
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_iam_policy_document": {
+      "KMS_Policy_BCC43B78": {
+        "statement": [
+          {
+            "actions": [
+              "kms:*"
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          },
+          {
+            "actions": [
+              "kms:Decrypt",
+              "kms:Encrypt",
+              "kms:ReEncrypt*",
+              "kms:GenerateDataKey*"
+            ],
+            "condition": [
+              {
+                "test": "StringEquals",
+                "values": [
+                  "secretsmanager.us-east-1.amazonaws.com"
+                ],
+                "variable": "kms:ViaService"
+              }
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          },
+          {
+            "actions": [
+              "kms:CreateGrant",
+              "kms:DescribeKey"
+            ],
+            "condition": [
+              {
+                "test": "StringEquals",
+                "values": [
+                  "secretsmanager.us-east-1.amazonaws.com"
+                ],
+                "variable": "kms:ViaService"
+              }
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          },
+          {
+            "actions": [
+              "kms:Encrypt",
+              "kms:ReEncrypt*",
+              "kms:GenerateDataKey*"
+            ],
+            "condition": [
+              {
+                "test": "StringEquals",
+                "values": [
+                  "secretsmanager.us-east-1.amazonaws.com"
+                ],
+                "variable": "kms:ViaService"
+              }
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "\${aws_iam_role.Role_1ABCC5F0.arn}"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          }
+        ]
+      },
+      "Role_AssumeRolePolicy_B27E8126": {
+        "statement": [
+          {
+            "actions": [
+              "sts:AssumeRole"
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ]
+          }
+        ]
+      },
+      "Role_DefaultPolicy_2E5E5E0B": {
+        "statement": [
+          {
+            "actions": [
+              "secretsmanager:PutSecretValue",
+              "secretsmanager:UpdateSecret",
+              "secretsmanager:UpdateSecretVersionStage"
+            ],
+            "effect": "Allow",
+            "resources": [
+              "\${aws_secretsmanager_secret.Secret_A720EF05.arn}"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_secretsmanager_random_password": {
+      "Secret_RandomPassword_01FCD53F": {
+        "exclude_lowercase": false,
+        "exclude_numbers": false,
+        "exclude_punctuation": false,
+        "exclude_uppercase": false,
+        "include_space": false,
+        "password_length": 32,
+        "require_each_included_type": true
+      }
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "us-east-1"
+      }
+    ]
+  },
+  "resource": {
+    "aws_iam_role": {
+      "Role_1ABCC5F0": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.Role_AssumeRolePolicy_B27E8126.json}",
+        "name_prefix": "a123e4567-e89b-12d3-MyStackRole",
+        "tags": {
+          "Name": "Test-Role",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_iam_role_policy": {
+      "Role_DefaultPolicy_ResourceRoles0_50D8AFFD": {
+        "name": "MyStackRoleDefaultPolicy86F304AD",
+        "policy": "\${data.aws_iam_policy_document.Role_DefaultPolicy_2E5E5E0B.json}",
+        "role": "\${aws_iam_role.Role_1ABCC5F0.name}"
+      }
+    },
+    "aws_kms_key": {
+      "KMS_6B14D45A": {
+        "policy": "\${data.aws_iam_policy_document.KMS_Policy_BCC43B78.json}",
+        "tags": {
+          "Name": "Test-KMS",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret": {
+      "Secret_A720EF05": {
+        "kms_key_id": "\${aws_kms_key.KMS_6B14D45A.arn}",
+        "name": "MyStackSecret03F6D6E7",
+        "tags": {
+          "Name": "Test-Secret",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret_version": {
+      "Secret_SecretVersion_1CCEE6BD": {
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}",
+        "secret_string": "\${data.aws_secretsmanager_random_password.Secret_RandomPassword_01FCD53F.random_password}"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "http": {
+        "address": "http://localhost:3000"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`import by secretArn supports tokens for ARNs 1`] = `
+"{
+  "data": {
+    "terraform_remote_state": {
+      "cross-stack-reference-input-MyStack": {
+        "backend": "http",
+        "config": {
+          "address": "http://localhost:3000"
+        }
+      }
+    }
+  },
+  "output": {
+    "secretBSecretName": {
+      "value": "\${element(split(\\":\\", data.terraform_remote_state.cross-stack-reference-input-MyStack.outputs.cross-stack-output-aws_secretsmanager_secretSecretA_188F2817arn), 6)}"
+    }
+  },
+  "terraform": {
+    "backend": {
+      "http": {
+        "address": "http://localhost:3000"
+      }
+    }
+  }
+}"
+`;
+
+exports[`secret with generate secret string excludeCharacters 1`] = `
+"{
+  "data": {
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_secretsmanager_random_password": {
+      "Secret_RandomPassword_01FCD53F": {
+        "exclude_characters": "abc\\"@/\\\\",
+        "exclude_lowercase": false,
+        "exclude_numbers": false,
+        "exclude_punctuation": false,
+        "exclude_uppercase": false,
+        "include_space": false,
+        "password_length": 32,
+        "require_each_included_type": true
+      }
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "us-east-1"
+      }
+    ]
+  },
+  "resource": {
+    "aws_secretsmanager_secret": {
+      "Secret_A720EF05": {
+        "name": "MyStackSecret03F6D6E7",
+        "tags": {
+          "Name": "Test-Secret",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret_version": {
+      "Secret_SecretVersion_1CCEE6BD": {
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}",
+        "secret_string": "\${data.aws_secretsmanager_random_password.Secret_RandomPassword_01FCD53F.random_password}"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "http": {
+        "address": "http://localhost:3000"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`secret with generate secret string options 1`] = `
+"{
+  "data": {
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_secretsmanager_random_password": {
+      "Secret_RandomPassword_01FCD53F": {
+        "exclude_lowercase": false,
+        "exclude_numbers": false,
+        "exclude_punctuation": false,
+        "exclude_uppercase": true,
+        "include_space": false,
+        "password_length": 20,
+        "require_each_included_type": true
+      }
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "us-east-1"
+      }
+    ]
+  },
+  "resource": {
+    "aws_secretsmanager_secret": {
+      "Secret_A720EF05": {
+        "name": "MyStackSecret03F6D6E7",
+        "tags": {
+          "Name": "Test-Secret",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret_version": {
+      "Secret_SecretVersion_1CCEE6BD": {
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}",
+        "secret_string": "\${data.aws_secretsmanager_random_password.Secret_RandomPassword_01FCD53F.random_password}"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "http": {
+        "address": "http://localhost:3000"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`secret with kms 1`] = `
+"{
+  "data": {
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_iam_policy_document": {
+      "KMS_Policy_BCC43B78": {
+        "statement": [
+          {
+            "actions": [
+              "kms:*"
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          },
+          {
+            "actions": [
+              "kms:Decrypt",
+              "kms:Encrypt",
+              "kms:ReEncrypt*",
+              "kms:GenerateDataKey*"
+            ],
+            "condition": [
+              {
+                "test": "StringEquals",
+                "values": [
+                  "secretsmanager.us-east-1.amazonaws.com"
+                ],
+                "variable": "kms:ViaService"
+              }
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          },
+          {
+            "actions": [
+              "kms:CreateGrant",
+              "kms:DescribeKey"
+            ],
+            "condition": [
+              {
+                "test": "StringEquals",
+                "values": [
+                  "secretsmanager.us-east-1.amazonaws.com"
+                ],
+                "variable": "kms:ViaService"
+              }
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "arn:\${data.aws_partition.Partitition.partition}:iam::\${data.aws_caller_identity.CallerIdentity.account_id}:root"
+                ],
+                "type": "AWS"
+              }
+            ],
+            "resources": [
+              "*"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_secretsmanager_random_password": {
+      "Secret_RandomPassword_01FCD53F": {
+        "exclude_lowercase": false,
+        "exclude_numbers": false,
+        "exclude_punctuation": false,
+        "exclude_uppercase": false,
+        "include_space": false,
+        "password_length": 32,
+        "require_each_included_type": true
+      }
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "us-east-1"
+      }
+    ]
+  },
+  "resource": {
+    "aws_kms_key": {
+      "KMS_6B14D45A": {
+        "policy": "\${data.aws_iam_policy_document.KMS_Policy_BCC43B78.json}",
+        "tags": {
+          "Name": "Test-KMS",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret": {
+      "Secret_A720EF05": {
+        "kms_key_id": "\${aws_kms_key.KMS_6B14D45A.arn}",
+        "name": "MyStackSecret03F6D6E7",
+        "tags": {
+          "Name": "Test-Secret",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret_version": {
+      "Secret_SecretVersion_1CCEE6BD": {
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}",
+        "secret_string": "\${data.aws_secretsmanager_random_password.Secret_RandomPassword_01FCD53F.random_password}"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "http": {
+        "address": "http://localhost:3000"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`secretName is simply the first segment when the provided secret name has no hyphens 1`] = `
+"{
+  "data": {
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_secretsmanager_random_password": {
+      "Secret_RandomPassword_01FCD53F": {
+        "exclude_lowercase": false,
+        "exclude_numbers": false,
+        "exclude_punctuation": false,
+        "exclude_uppercase": false,
+        "include_space": false,
+        "password_length": 32,
+        "require_each_included_type": true
+      }
+    }
+  },
+  "output": {
+    "MySecretName": {
+      "value": "\${aws_secretsmanager_secret.Secret_A720EF05.name}"
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "us-east-1"
+      }
+    ]
+  },
+  "resource": {
+    "aws_secretsmanager_secret": {
+      "Secret_A720EF05": {
+        "name": "mySecret",
+        "tags": {
+          "Name": "Test-Secret",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret_version": {
+      "Secret_SecretVersion_1CCEE6BD": {
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}",
+        "secret_string": "\${data.aws_secretsmanager_random_password.Secret_RandomPassword_01FCD53F.random_password}"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "http": {
+        "address": "http://localhost:3000"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`secretName selects the 2 parts of the resource name when the secret name is provided 1`] = `
+"{
+  "data": {
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_secretsmanager_random_password": {
+      "Secret_RandomPassword_01FCD53F": {
+        "exclude_lowercase": false,
+        "exclude_numbers": false,
+        "exclude_punctuation": false,
+        "exclude_uppercase": false,
+        "include_space": false,
+        "password_length": 32,
+        "require_each_included_type": true
+      }
+    }
+  },
+  "output": {
+    "MySecretName": {
+      "value": "\${aws_secretsmanager_secret.Secret_A720EF05.name}"
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "us-east-1"
+      }
+    ]
+  },
+  "resource": {
+    "aws_secretsmanager_secret": {
+      "Secret_A720EF05": {
+        "name": "my-secret",
+        "tags": {
+          "Name": "Test-Secret",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret_version": {
+      "Secret_SecretVersion_1CCEE6BD": {
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}",
+        "secret_string": "\${data.aws_secretsmanager_random_password.Secret_RandomPassword_01FCD53F.random_password}"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "http": {
+        "address": "http://localhost:3000"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`secretName selects the 3 parts of the resource name when the secret name is provided 1`] = `
+"{
+  "data": {
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_secretsmanager_random_password": {
+      "Secret_RandomPassword_01FCD53F": {
+        "exclude_lowercase": false,
+        "exclude_numbers": false,
+        "exclude_punctuation": false,
+        "exclude_uppercase": false,
+        "include_space": false,
+        "password_length": 32,
+        "require_each_included_type": true
+      }
+    }
+  },
+  "output": {
+    "MySecretName": {
+      "value": "\${aws_secretsmanager_secret.Secret_A720EF05.name}"
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "us-east-1"
+      }
+    ]
+  },
+  "resource": {
+    "aws_secretsmanager_secret": {
+      "Secret_A720EF05": {
+        "name": "my-secret-hyphenated",
+        "tags": {
+          "Name": "Test-Secret",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret_version": {
+      "Secret_SecretVersion_1CCEE6BD": {
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}",
+        "secret_string": "\${data.aws_secretsmanager_random_password.Secret_RandomPassword_01FCD53F.random_password}"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "http": {
+        "address": "http://localhost:3000"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`secretName selects the 4 parts of the resource name when the secret name is provided 1`] = `
+"{
+  "data": {
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_secretsmanager_random_password": {
+      "Secret_RandomPassword_01FCD53F": {
+        "exclude_lowercase": false,
+        "exclude_numbers": false,
+        "exclude_punctuation": false,
+        "exclude_uppercase": false,
+        "include_space": false,
+        "password_length": 32,
+        "require_each_included_type": true
+      }
+    }
+  },
+  "output": {
+    "MySecretName": {
+      "value": "\${aws_secretsmanager_secret.Secret_A720EF05.name}"
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "us-east-1"
+      }
+    ]
+  },
+  "resource": {
+    "aws_secretsmanager_secret": {
+      "Secret_A720EF05": {
+        "name": "my-secret-with-hyphens",
+        "tags": {
+          "Name": "Test-Secret",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret_version": {
+      "Secret_SecretVersion_1CCEE6BD": {
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}",
+        "secret_string": "\${data.aws_secretsmanager_random_password.Secret_RandomPassword_01FCD53F.random_password}"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "http": {
+        "address": "http://localhost:3000"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`secretName selects the first two parts of the resource name when the name is auto-generated 1`] = `
+"{
+  "data": {
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_secretsmanager_random_password": {
+      "Secret_RandomPassword_01FCD53F": {
+        "exclude_lowercase": false,
+        "exclude_numbers": false,
+        "exclude_punctuation": false,
+        "exclude_uppercase": false,
+        "include_space": false,
+        "password_length": 32,
+        "require_each_included_type": true
+      }
+    }
+  },
+  "output": {
+    "MySecretName": {
+      "value": "\${aws_secretsmanager_secret.Secret_A720EF05.name}"
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "us-east-1"
+      }
+    ]
+  },
+  "resource": {
+    "aws_secretsmanager_secret": {
+      "Secret_A720EF05": {
+        "name": "MyStackSecret03F6D6E7",
+        "tags": {
+          "Name": "Test-Secret",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret_version": {
+      "Secret_SecretVersion_1CCEE6BD": {
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}",
+        "secret_string": "\${data.aws_secretsmanager_random_password.Secret_RandomPassword_01FCD53F.random_password}"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "http": {
+        "address": "http://localhost:3000"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`secretObjectValue can be used with a mixture of plain text and a resolvable token 1`] = `
+"{
+  "data": {
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_iam_policy_document": {
+      "Role_AssumeRolePolicy_B27E8126": {
+        "statement": [
+          {
+            "actions": [
+              "sts:AssumeRole"
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "\${data.aws_service_principal.aws_svcp_default_region_ec2.name}"
+                ],
+                "type": "Service"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_service_principal": {
+      "aws_svcp_default_region_ec2": {
+        "service_name": "ec2"
+      }
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "us-east-1"
+      }
+    ]
+  },
+  "resource": {
+    "aws_iam_role": {
+      "Role_1ABCC5F0": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.Role_AssumeRolePolicy_B27E8126.json}",
+        "name_prefix": "a123e4567-e89b-12d3-MyStackRole",
+        "tags": {
+          "Name": "Test-Role",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret": {
+      "Secret_A720EF05": {
+        "name": "MyStackSecret03F6D6E7",
+        "tags": {
+          "Name": "Test-Secret",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret_version": {
+      "Secret_SecretVersion_1CCEE6BD": {
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}",
+        "secret_string": "\${jsonencode({\\"username\\" = \\"username\\", \\"password\\" = aws_iam_role.Role_1ABCC5F0.arn})}"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "http": {
+        "address": "http://localhost:3000"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`secretStringValue can reference an arbitrary resolvable token 1`] = `
+"{
+  "data": {
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_iam_policy_document": {
+      "Role_AssumeRolePolicy_B27E8126": {
+        "statement": [
+          {
+            "actions": [
+              "sts:AssumeRole"
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "\${data.aws_service_principal.aws_svcp_default_region_ec2.name}"
+                ],
+                "type": "Service"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_service_principal": {
+      "aws_svcp_default_region_ec2": {
+        "service_name": "ec2"
+      }
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "us-east-1"
+      }
+    ]
+  },
+  "resource": {
+    "aws_iam_role": {
+      "Role_1ABCC5F0": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.Role_AssumeRolePolicy_B27E8126.json}",
+        "name_prefix": "a123e4567-e89b-12d3-MyStackRole",
+        "tags": {
+          "Name": "Test-Role",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret": {
+      "Secret_A720EF05": {
+        "name": "MyStackSecret03F6D6E7",
+        "tags": {
+          "Name": "Test-Secret",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret_version": {
+      "Secret_SecretVersion_1CCEE6BD": {
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}",
+        "secret_string": "\${aws_iam_role.Role_1ABCC5F0.arn}"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "http": {
+        "address": "http://localhost:3000"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;
+
+exports[`templated secret string 1`] = `
+"{
+  "data": {
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_secretsmanager_random_password": {
+      "Secret_RandomPassword_01FCD53F": {
+        "exclude_lowercase": false,
+        "exclude_numbers": false,
+        "exclude_punctuation": false,
+        "exclude_uppercase": false,
+        "include_space": false,
+        "password_length": 32,
+        "require_each_included_type": true
+      }
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+        "region": "us-east-1"
+      }
+    ]
+  },
+  "resource": {
+    "aws_secretsmanager_secret": {
+      "Secret_A720EF05": {
+        "name": "MyStackSecret03F6D6E7",
+        "tags": {
+          "Name": "Test-Secret",
+          "grid:EnvironmentName": "Test",
+          "grid:UUID": "a123e4567-e89b-12d3"
+        }
+      }
+    },
+    "aws_secretsmanager_secret_version": {
+      "Secret_SecretVersion_1CCEE6BD": {
+        "secret_id": "\${aws_secretsmanager_secret.Secret_A720EF05.arn}",
+        "secret_string": "\${jsonencode({\\"username\\" = \\"username\\", \\"password\\" = data.aws_secretsmanager_random_password.Secret_RandomPassword_01FCD53F.random_password})}"
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "http": {
+        "address": "http://localhost:3000"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;

--- a/test/aws/encryption/policy.test.ts
+++ b/test/aws/encryption/policy.test.ts
@@ -1,7 +1,7 @@
 // https://github.com/aws/aws-cdk/blob/v2.261.0/packages/aws-cdk-lib/aws-secretsmanager/test/policy.test.ts
 
 import { secretsmanagerSecretPolicy } from "@cdktn/provider-aws";
-import { Testing } from "cdktn";
+import { HttpBackend, Testing } from "cdktn";
 import "cdktn/lib/testing/adapters/jest";
 import { AwsStack } from "../../../src/aws/aws-stack";
 import * as encryption from "../../../src/aws/encryption";
@@ -79,6 +79,9 @@ describe("ResourcePolicy", () => {
     // GIVEN
     const app = Testing.app();
     const stack = new AwsStack(app);
+    // snapshot tests must not use the default local backend - its state file
+    // path is machine-dependent and would leak into the snapshot
+    new HttpBackend(stack, { address: "http://localhost:3000" });
     const secret = new encryption.Secret(stack, "Secret");
 
     // WHEN

--- a/test/aws/encryption/policy.test.ts
+++ b/test/aws/encryption/policy.test.ts
@@ -1,0 +1,91 @@
+// https://github.com/aws/aws-cdk/blob/v2.261.0/packages/aws-cdk-lib/aws-secretsmanager/test/policy.test.ts
+
+import { secretsmanagerSecretPolicy } from "@cdktn/provider-aws";
+import { Testing } from "cdktn";
+import "cdktn/lib/testing/adapters/jest";
+import { AwsStack } from "../../../src/aws/aws-stack";
+import * as encryption from "../../../src/aws/encryption";
+import * as iam from "../../../src/aws/iam";
+import { Template } from "../../assertions";
+
+describe("Secret Target Attachment Resource Policy", () => {
+  const environmentName = "Test";
+  const gridUUID = "a123e4567-e89b-12d3";
+  const providerConfig = { region: "us-east-1" };
+  const gridBackendConfig = {
+    address: "http://localhost:3000",
+  };
+
+  // TerraConstructs has no separate CloudFormation-style
+  // `AWS::SecretsManager::SecretTargetAttachment` resource: attaching a
+  // secret to a target does not create a distinct Terraform resource, and
+  // `addToResourcePolicy` calls on the attachment are forwarded to the
+  // original secret. This mirrors the upstream aws-cdk behavior gated behind
+  // the `SECRETS_MANAGER_TARGET_ATTACHMENT_RESOURCE_POLICY` feature flag
+  // (which is always "on" here): granting read on both the secret and its
+  // attachment results in a single resource policy on the main secret.
+  test("attaching a secret and granting read on both secret and attachment creates one policy", () => {
+    // GIVEN
+    const app = Testing.app();
+    const stack = new AwsStack(app, "TestStack", {
+      environmentName,
+      gridUUID,
+      providerConfig,
+      gridBackendConfig,
+    });
+
+    const secret = new encryption.Secret(stack, "Secret");
+    const servicePrincipalOne = new iam.ServicePrincipal(
+      "some-service-a.amazonaws.com",
+    );
+    const servicePrincipalTwo = new iam.ServicePrincipal(
+      "some-service-b.amazonaws.com",
+    );
+    const secretAttachment = secret.attach({
+      asSecretAttachmentTarget: () => ({
+        targetId: "mock-id",
+        targetType: encryption.AttachmentTargetType.RDS_DB_INSTANCE,
+      }),
+    });
+
+    // WHEN
+    secret.grantRead(servicePrincipalOne);
+    secretAttachment.grantRead(servicePrincipalTwo);
+
+    // THEN
+    const template = new Template(stack);
+    template.resourceCountIs(
+      secretsmanagerSecretPolicy.SecretsmanagerSecretPolicy,
+      1,
+    );
+  });
+
+  // NOTE: run-3 (v2.233 breadth) also carried a `test.skip` here exercising the same
+  // "attach() + addToResourcePolicy on both the secret and the attachment forwards to a single
+  // policy" scenario through a `MockAttachmentTarget` that supplies `connectionFields`. It isn't
+  // ported: under the combined `attach()` design (see `SecretTargetAttachment` in
+  // `src/aws/encryption/secret.ts`), attaching a target with `connectionFields` to a default
+  // `Secret` (a scalar generated password) throws `ValidationError` (`_attachConnectionFields`
+  // requires a JSON-object base) rather than reproducing the skipped test's scenario, and the
+  // "connectionFields forwarding + single policy" combination it was trying to reach is already
+  // covered by the `describe("attachment")` block in `secret.test.ts`
+  // ("addToResourcePolicy on the attachment forwards to the original secret (single policy)").
+});
+
+// Repo-specific snapshot coverage (see conventions.md "Test-suite conventions": snapshots are the
+// repo's main defense against emitted-Terraform drift).
+describe("ResourcePolicy", () => {
+  test("Should synth and match SnapShot", () => {
+    // GIVEN
+    const app = Testing.app();
+    const stack = new AwsStack(app);
+    const secret = new encryption.Secret(stack, "Secret");
+
+    // WHEN
+    new encryption.ResourcePolicy(stack, "Policy", { secret });
+
+    // THEN
+    stack.prepareStack(); // may generate additional resources
+    expect(Testing.synth(stack)).toMatchSnapshot();
+  });
+});

--- a/test/aws/encryption/rotation-schedule.test.ts
+++ b/test/aws/encryption/rotation-schedule.test.ts
@@ -1,0 +1,1055 @@
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/aws-cdk-lib/aws-secretsmanager/test/rotation-schedule.test.ts
+
+import {
+  secretsmanagerSecretRotation,
+  lambdaPermission,
+  dataAwsIamPolicyDocument,
+} from "@cdktn/provider-aws";
+import { App, Testing } from "cdktn";
+import "cdktn/lib/testing/adapters/jest";
+import { AwsStack } from "../../../src/aws/aws-stack";
+import * as compute from "../../../src/aws/compute";
+import * as encryption from "../../../src/aws/encryption";
+import { Duration } from "../../../src/duration";
+import { Template } from "../../assertions";
+
+describe("default tests", () => {
+  let app: App;
+  let stack: AwsStack;
+  beforeEach(() => {
+    app = Testing.app();
+    stack = new AwsStack(app);
+  });
+
+  test("create a rotation schedule with a rotation Lambda", () => {
+    // GIVEN
+    const secret = new encryption.Secret(stack, "Secret");
+    const rotationLambda = new compute.LambdaFunction(stack, "Lambda", {
+      runtime: compute.Runtime.NODEJS_LATEST,
+      code: compute.Code.fromInline("export.handler = event => event;"),
+      handler: "index.handler",
+    });
+
+    // WHEN
+    new encryption.RotationSchedule(stack, "RotationSchedule", {
+      secret,
+      rotationLambda,
+    });
+
+    // THEN
+    Template.synth(stack).toHaveResourceWithProperties(
+      secretsmanagerSecretRotation.SecretsmanagerSecretRotation,
+      {
+        secret_id: stack.resolve(secret.secretArn),
+        rotation_lambda_arn: stack.resolve(rotationLambda.functionArn),
+        rotation_rules: {
+          schedule_expression: "rate(30 days)",
+        },
+      },
+    );
+    // Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::RotationSchedule', {
+    //   SecretId: {
+    //     Ref: 'SecretA720EF05',
+    //   },
+    //   RotationLambdaARN: {
+    //     'Fn::GetAtt': [
+    //       'LambdaD247545B',
+    //       'Arn',
+    //     ],
+    //   },
+    //   RotationRules: {
+    //     ScheduleExpression: 'rate(30 days)',
+    //   },
+    // });
+  });
+
+  test("create a rotation schedule without immediate rotation", () => {
+    // GIVEN
+    const secret = new encryption.Secret(stack, "Secret");
+    const rotationLambda = new compute.LambdaFunction(stack, "Lambda", {
+      runtime: compute.Runtime.NODEJS_LATEST,
+      code: compute.Code.fromInline("export.handler = event => event;"),
+      handler: "index.handler",
+    });
+
+    // WHEN
+    new encryption.RotationSchedule(stack, "RotationSchedule", {
+      secret,
+      rotationLambda,
+      rotateImmediatelyOnUpdate: false,
+    });
+
+    // THEN
+    Template.synth(stack).toHaveResourceWithProperties(
+      secretsmanagerSecretRotation.SecretsmanagerSecretRotation,
+      {
+        secret_id: stack.resolve(secret.secretArn),
+        rotation_rules: {
+          schedule_expression: "rate(30 days)",
+        },
+        rotate_immediately: false,
+      },
+    );
+    // Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::RotationSchedule', {
+    //   SecretId: {
+    //     Ref: 'SecretA720EF05',
+    //   },
+    //   RotationRules: {
+    //     ScheduleExpression: 'rate(30 days)',
+    //   },
+    //   RotateImmediatelyOnUpdate: false,
+    // });
+  });
+
+  test("assign kms permissions for rotation schedule with a rotation Lambda", () => {
+    // GIVEN
+    const encryptionKey = new encryption.Key(stack, "Key");
+    const secret = new encryption.Secret(stack, "Secret", { encryptionKey });
+    const rotationLambda = new compute.LambdaFunction(stack, "Lambda", {
+      runtime: compute.Runtime.NODEJS_LATEST,
+      code: compute.Code.fromInline("export.handler = event => event;"),
+      handler: "index.handler",
+    });
+
+    // WHEN
+    new encryption.RotationSchedule(stack, "RotationSchedule", {
+      secret,
+      rotationLambda,
+    });
+
+    // THEN
+    Template.synth(stack).toHaveDataSourceWithProperties(
+      dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+      {
+        statement: expect.arrayContaining([
+          {
+            actions: [
+              "kms:Decrypt",
+              "kms:Encrypt",
+              "kms:ReEncrypt*",
+              "kms:GenerateDataKey*",
+            ],
+            effect: "Allow",
+            condition: [
+              {
+                test: "StringEquals",
+                variable: "kms:ViaService",
+                values: [
+                  "secretsmanager.${data.aws_region.Region.name}.amazonaws.com",
+                ],
+              },
+            ],
+            principals: [
+              {
+                identifiers: [stack.resolve(rotationLambda.role!.roleArn)],
+                type: "AWS",
+              },
+            ],
+            resources: ["*"],
+          },
+        ]),
+      },
+    );
+    // Template.fromStack(stack).hasResourceProperties('AWS::KMS::Key', {
+    //   KeyPolicy: {
+    //     Statement: [Match.anyValue(), Match.anyValue(), Match.anyValue(),
+    //       {
+    //         Action: [
+    //           'kms:Decrypt',
+    //           'kms:Encrypt',
+    //           'kms:ReEncrypt*',
+    //           'kms:GenerateDataKey*',
+    //         ],
+    //         Condition: {
+    //           StringEquals: {
+    //             'kms:ViaService': {
+    //               'Fn::Join': [
+    //                 '',
+    //                 [
+    //                   'secretsmanager.',
+    //                   {
+    //                     Ref: 'AWS::Region',
+    //                   },
+    //                   '.amazonaws.com',
+    //                 ],
+    //               ],
+    //             },
+    //           },
+    //         },
+    //         Effect: 'Allow',
+    //         Principal: {
+    //           AWS: {
+    //             'Fn::GetAtt': [
+    //               'LambdaServiceRoleA8ED4D3B',
+    //               'Arn',
+    //             ],
+    //           },
+    //         },
+    //         Resource: '*',
+    //       }],
+    //   },
+    // });
+  });
+
+  // NOTE (TerraConstructs deviation): `HostedRotation` is preserved in src/aws/encryption/
+  // rotation-schedule.ts for API compatibility only -- its `bind()` always throws (see the
+  // "TERRACONSTRUCTS DEVIATION" doc comment on the `HostedRotation` class there).
+  // `aws_secretsmanager_secret_rotation` has no equivalent of CloudFormation's `HostedRotationLambda`,
+  // which relies on the `AWS::SecretsManager-2024-09-16` transform to auto-provision a fully managed
+  // rotation Lambda from an AWS-published SAR template -- Terraform cannot do this. Because `bind()`
+  // is invoked unconditionally and immediately at the top of the `RotationSchedule` constructor
+  // (before any of the VPC/securityGroups/excludeCharacters/masterSecret logic below would run),
+  // every test in this suite that calls `secret.addRotationSchedule(..., { hostedRotation })` now
+  // throws the "not supported by the Terraform AWS provider" `ValidationError` immediately -- none of
+  // the CloudFormation-shaped assertions below are reachable. See
+  // test/aws/encryption/secret-rotation.test.ts for the analogous "always throws" coverage for the
+  // sibling `SecretRotation`/SAR construct.
+  // describe('hosted rotation', () => {
+  //   test('single user not in a vpc', () => {
+  //     // GIVEN
+  //     const app = new cdk.App();
+  //     stack = new cdk.Stack(app, 'TestStack');
+  //     const secret = new secretsmanager.Secret(stack, 'Secret');
+  //
+  //     // WHEN
+  //     secret.addRotationSchedule('RotationSchedule', {
+  //       hostedRotation: secretsmanager.HostedRotation.mysqlSingleUser(),
+  //     });
+  //
+  //     // THEN
+  //     Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::RotationSchedule', {
+  //       SecretId: {
+  //         Ref: 'SecretA720EF05',
+  //       },
+  //       HostedRotationLambda: {
+  //         RotationType: 'MySQLSingleUser',
+  //         ExcludeCharacters: " %+~`#$&*()|[]{}:;<>?!'/@\"\\",
+  //       },
+  //       RotationRules: {
+  //         ScheduleExpression: 'rate(30 days)',
+  //       },
+  //     });
+  //
+  //     expect(app.synth().getStackByName(stack.stackName).template).toEqual(expect.objectContaining({
+  //       Transform: 'AWS::SecretsManager-2024-09-16',
+  //     }));
+  //
+  //     Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::ResourcePolicy', {
+  //       ResourcePolicy: {
+  //         Statement: [
+  //           {
+  //             Action: 'secretsmanager:DeleteSecret',
+  //             Effect: 'Deny',
+  //             Principal: {
+  //               AWS: {
+  //                 'Fn::Join': [
+  //                   '',
+  //                   [
+  //                     'arn:',
+  //                     {
+  //                       Ref: 'AWS::Partition',
+  //                     },
+  //                     ':iam::',
+  //                     {
+  //                       Ref: 'AWS::AccountId',
+  //                     },
+  //                     ':root',
+  //                   ],
+  //                 ],
+  //               },
+  //             },
+  //             Resource: '*',
+  //           },
+  //         ],
+  //         Version: '2012-10-17',
+  //       },
+  //       SecretId: {
+  //         Ref: 'SecretA720EF05',
+  //       },
+  //     });
+  //   });
+  //
+  //   test('multi user not in a vpc', () => {
+  //     // GIVEN
+  //     const secret = new secretsmanager.Secret(stack, 'Secret');
+  //     const masterSecret = new secretsmanager.Secret(stack, 'MasterSecret');
+  //
+  //     // WHEN
+  //     secret.addRotationSchedule('RotationSchedule', {
+  //       hostedRotation: secretsmanager.HostedRotation.postgreSqlMultiUser({
+  //         masterSecret,
+  //       }),
+  //     });
+  //
+  //     // THEN
+  //     Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::RotationSchedule', {
+  //       SecretId: {
+  //         Ref: 'SecretA720EF05',
+  //       },
+  //       HostedRotationLambda: {
+  //         MasterSecretArn: {
+  //           Ref: 'MasterSecretA11BF785',
+  //         },
+  //         RotationType: 'PostgreSQLMultiUser',
+  //       },
+  //       RotationRules: {
+  //         ScheduleExpression: 'rate(30 days)',
+  //       },
+  //     });
+  //
+  //     Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::ResourcePolicy', {
+  //       ResourcePolicy: {
+  //         Statement: [
+  //           {
+  //             Action: 'secretsmanager:DeleteSecret',
+  //             Effect: 'Deny',
+  //             Principal: {
+  //               AWS: {
+  //                 'Fn::Join': [
+  //                   '',
+  //                   [
+  //                     'arn:',
+  //                     {
+  //                       Ref: 'AWS::Partition',
+  //                     },
+  //                     ':iam::',
+  //                     {
+  //                       Ref: 'AWS::AccountId',
+  //                     },
+  //                     ':root',
+  //                   ],
+  //                 ],
+  //               },
+  //             },
+  //             Resource: '*',
+  //           },
+  //         ],
+  //         Version: '2012-10-17',
+  //       },
+  //       SecretId: {
+  //         Ref: 'MasterSecretA11BF785',
+  //       },
+  //     });
+  //   });
+  //
+  //   test('single user in a vpc', () => {
+  //     // GIVEN
+  //     const vpc = new ec2.Vpc(stack, 'Vpc');
+  //     const secret = new secretsmanager.Secret(stack, 'Secret');
+  //     const dbSecurityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', { vpc });
+  //     const dbConnections = new ec2.Connections({
+  //       defaultPort: ec2.Port.tcp(3306),
+  //       securityGroups: [dbSecurityGroup],
+  //     });
+  //
+  //     // WHEN
+  //     const hostedRotation = secretsmanager.HostedRotation.mysqlSingleUser({ vpc });
+  //     secret.addRotationSchedule('RotationSchedule', { hostedRotation });
+  //     dbConnections.allowDefaultPortFrom(hostedRotation);
+  //
+  //     // THEN
+  //     Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::RotationSchedule', {
+  //       SecretId: {
+  //         Ref: 'SecretA720EF05',
+  //       },
+  //       HostedRotationLambda: {
+  //         RotationType: 'MySQLSingleUser',
+  //         VpcSecurityGroupIds: {
+  //           'Fn::GetAtt': [
+  //             'SecretRotationScheduleSecurityGroup3F1F76EA',
+  //             'GroupId',
+  //           ],
+  //         },
+  //         VpcSubnetIds: {
+  //           'Fn::Join': [
+  //             '',
+  //             [
+  //               {
+  //                 Ref: 'VpcPrivateSubnet1Subnet536B997A',
+  //               },
+  //               ',',
+  //               {
+  //                 Ref: 'VpcPrivateSubnet2Subnet3788AAA1',
+  //               },
+  //             ],
+  //           ],
+  //         },
+  //       },
+  //       RotationRules: {
+  //         ScheduleExpression: 'rate(30 days)',
+  //       },
+  //     });
+  //
+  //     Template.fromStack(stack).hasResourceProperties('AWS::EC2::SecurityGroupIngress', {
+  //       FromPort: 3306,
+  //       GroupId: {
+  //         'Fn::GetAtt': [
+  //           'SecurityGroupDD263621',
+  //           'GroupId',
+  //         ],
+  //       },
+  //       SourceSecurityGroupId: {
+  //         'Fn::GetAtt': [
+  //           'SecretRotationScheduleSecurityGroup3F1F76EA',
+  //           'GroupId',
+  //         ],
+  //       },
+  //       ToPort: 3306,
+  //     });
+  //   });
+  //
+  //   test('single user in a vpc with security groups', () => {
+  //     // GIVEN
+  //     const vpc = new ec2.Vpc(stack, 'Vpc');
+  //     const secret = new secretsmanager.Secret(stack, 'Secret');
+  //     const dbSecurityGroup = new ec2.SecurityGroup(stack, 'SecurityGroup', { vpc });
+  //     const dbConnections = new ec2.Connections({
+  //       defaultPort: ec2.Port.tcp(3306),
+  //       securityGroups: [dbSecurityGroup],
+  //     });
+  //
+  //     // WHEN
+  //     const hostedRotation = secretsmanager.HostedRotation.mysqlSingleUser({
+  //       vpc,
+  //       securityGroups: [
+  //         new ec2.SecurityGroup(stack, 'SG1', { vpc }),
+  //         new ec2.SecurityGroup(stack, 'SG2', { vpc }),
+  //       ],
+  //     });
+  //     secret.addRotationSchedule('RotationSchedule', { hostedRotation });
+  //     dbConnections.allowDefaultPortFrom(hostedRotation);
+  //
+  //     // THEN
+  //     Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::RotationSchedule', {
+  //       SecretId: {
+  //         Ref: 'SecretA720EF05',
+  //       },
+  //       HostedRotationLambda: {
+  //         RotationType: 'MySQLSingleUser',
+  //         VpcSecurityGroupIds: {
+  //           'Fn::Join': [
+  //             '',
+  //             [
+  //               {
+  //                 'Fn::GetAtt': [
+  //                   'SG1BA065B6E',
+  //                   'GroupId',
+  //                 ],
+  //               },
+  //               ',',
+  //               {
+  //                 'Fn::GetAtt': [
+  //                   'SG20CE3219C',
+  //                   'GroupId',
+  //                 ],
+  //               },
+  //             ],
+  //           ],
+  //         },
+  //         VpcSubnetIds: {
+  //           'Fn::Join': [
+  //             '',
+  //             [
+  //               {
+  //                 Ref: 'VpcPrivateSubnet1Subnet536B997A',
+  //               },
+  //               ',',
+  //               {
+  //                 Ref: 'VpcPrivateSubnet2Subnet3788AAA1',
+  //               },
+  //             ],
+  //           ],
+  //         },
+  //       },
+  //       RotationRules: {
+  //         ScheduleExpression: 'rate(30 days)',
+  //       },
+  //     });
+  //
+  //     Template.fromStack(stack).hasResourceProperties('AWS::EC2::SecurityGroupIngress', {
+  //       FromPort: 3306,
+  //       GroupId: {
+  //         'Fn::GetAtt': [
+  //           'SecurityGroupDD263621',
+  //           'GroupId',
+  //         ],
+  //       },
+  //       SourceSecurityGroupId: {
+  //         'Fn::GetAtt': [
+  //           'SG20CE3219C',
+  //           'GroupId',
+  //         ],
+  //       },
+  //       ToPort: 3306,
+  //     });
+  //   });
+  //
+  //   test('throws with security groups and no vpc', () => {
+  //     // GIVEN
+  //     const secret = new secretsmanager.Secret(stack, 'Secret');
+  //
+  //     // THEN
+  //     expect(() => secret.addRotationSchedule('RotationSchedule', {
+  //       hostedRotation: secretsmanager.HostedRotation.oracleSingleUser({
+  //         securityGroups: [ec2.SecurityGroup.fromSecurityGroupId(secret, 'SG', 'sg-12345678')],
+  //       }),
+  //     })).toThrow(/`vpc` must be specified when specifying `securityGroups`/);
+  //   });
+  //
+  //   test('throws when accessing the connections object when not in a vpc', () => {
+  //     // GIVEN
+  //     const secret = new secretsmanager.Secret(stack, 'Secret');
+  //
+  //     // WHEN
+  //     const hostedRotation = secretsmanager.HostedRotation.sqlServerSingleUser();
+  //     secret.addRotationSchedule('RotationSchedule', { hostedRotation });
+  //
+  //     // THEN
+  //     expect(() => hostedRotation.connections.allowToAnyIpv4(ec2.Port.allTraffic()))
+  //       .toThrow(/Cannot use connections for a hosted rotation that is not deployed in a VPC/);
+  //   });
+  //
+  //   test('can customize exclude characters', () => {
+  //     // GIVEN
+  //     const app = new cdk.App();
+  //     stack = new cdk.Stack(app, 'TestStack');
+  //     const secret = new secretsmanager.Secret(stack, 'Secret');
+  //
+  //     // WHEN
+  //     secret.addRotationSchedule('RotationSchedule', {
+  //       hostedRotation: secretsmanager.HostedRotation.mysqlSingleUser({
+  //         excludeCharacters: '()',
+  //       }),
+  //     });
+  //
+  //     // THEN
+  //     Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::RotationSchedule', {
+  //       HostedRotationLambda: {
+  //         RotationType: 'MySQLSingleUser',
+  //         ExcludeCharacters: '()',
+  //       },
+  //     });
+  //   });
+  //
+  //   test('exclude characters default to secret exclude characters', () => {
+  //     // GIVEN
+  //     const app = new cdk.App();
+  //     stack = new cdk.Stack(app, 'TestStack');
+  //     const secret = new secretsmanager.Secret(stack, 'Secret', {
+  //       generateSecretString: {
+  //         excludeCharacters: '[]',
+  //       },
+  //     });
+  //
+  //     // WHEN
+  //     secret.addRotationSchedule('RotationSchedule', {
+  //       hostedRotation: secretsmanager.HostedRotation.mysqlSingleUser(),
+  //     });
+  //
+  //     // THEN
+  //     Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::RotationSchedule', {
+  //       HostedRotationLambda: {
+  //         RotationType: 'MySQLSingleUser',
+  //         ExcludeCharacters: '[]',
+  //       },
+  //     });
+  //   });
+  //
+  //   test('the arn is used as it is when specifying masterSecret as an imported secret with full arn', () => {
+  //     // GIVEN
+  //     const secret = new secretsmanager.Secret(stack, 'Secret');
+  //     const importedSecret = secretsmanager.Secret.fromSecretCompleteArn(stack, 'MasterSecretImported', 'arn:aws:secretsmanager:us-east-1:123456789012:secret:MySecret-123456');
+  //
+  //     // WHEN
+  //     secret.addRotationSchedule('RotationSchedule', {
+  //       hostedRotation: secretsmanager.HostedRotation.postgreSqlMultiUser({
+  //         masterSecret: importedSecret,
+  //       }),
+  //     });
+  //
+  //     // THEN
+  //     Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::RotationSchedule', {
+  //       SecretId: {
+  //         Ref: 'SecretA720EF05',
+  //       },
+  //       HostedRotationLambda: {
+  //         MasterSecretArn: 'arn:aws:secretsmanager:us-east-1:123456789012:secret:MySecret-123456',
+  //       },
+  //     });
+  //   });
+  //
+  //   test('the arn is used with -?????? when specifying masterSecret as an imported secret with partial arn', () => {
+  //     // GIVEN
+  //     const secret = new secretsmanager.Secret(stack, 'Secret');
+  //     const importedSecret = secretsmanager.Secret.fromSecretNameV2(stack, 'MasterSecretImported', 'MySecret');
+  //
+  //     // WHEN
+  //     secret.addRotationSchedule('RotationSchedule', {
+  //       hostedRotation: secretsmanager.HostedRotation.postgreSqlMultiUser({
+  //         masterSecret: importedSecret,
+  //       }),
+  //     });
+  //
+  //     // THEN
+  //     Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::RotationSchedule', {
+  //       SecretId: {
+  //         Ref: 'SecretA720EF05',
+  //       },
+  //       HostedRotationLambda: {
+  //         MasterSecretArn: {
+  //           'Fn::Join': [
+  //             '',
+  //             [
+  //               'arn:',
+  //               { Ref: 'AWS::Partition' },
+  //               ':secretsmanager:',
+  //               { Ref: 'AWS::Region' },
+  //               ':',
+  //               { Ref: 'AWS::AccountId' },
+  //               ':secret:MySecret-??????',
+  //             ],
+  //           ],
+  //         },
+  //       },
+  //     });
+  //   });
+  // });
+
+  describe("manual rotations", () => {
+    // TERRACONSTRUCTS DEVIATION: upstream expects a zero `automaticallyAfter` duration (of any
+    // unit) to leave `RotationRules` unset entirely -- CloudFormation's sentinel for "manual
+    // rotation only". Terraform's `aws_secretsmanager_secret_rotation` resource requires a
+    // populated `rotation_rules` block (see the "Never synthesize provider-invalid config for CFN
+    // sentinel semantics" rule in conventions.md, and the JSDoc on
+    // `RotationScheduleOptions.automaticallyAfter` in src/aws/encryption/rotation-schedule.ts) -- an
+    // empty block fails `tofu validate`. Every zero-valued `Duration` therefore throws a
+    // `ValidationError` at construct time instead of silently synthesizing an invalid resource; this
+    // test asserts that throw rather than the (unreachable) "RotationRules unset" shape.
+    test("automaticallyAfter with any duration of zero throws (no Terraform equivalent of CFN's 'leave RotationRules unset' sentinel)", () => {
+      const checkRotationThrows = (automaticallyAfter: Duration) => {
+        // GIVEN
+        const localApp = Testing.app();
+        const localStack = new AwsStack(localApp);
+        const secret = new encryption.Secret(localStack, "Secret");
+        const rotationLambda = new compute.LambdaFunction(
+          localStack,
+          "Lambda",
+          {
+            runtime: compute.Runtime.NODEJS_LATEST,
+            code: compute.Code.fromInline("export.handler = event => event;"),
+            handler: "index.handler",
+          },
+        );
+
+        // WHEN / THEN
+        expect(
+          () =>
+            new encryption.RotationSchedule(localStack, "RotationSchedule", {
+              secret,
+              rotationLambda,
+              automaticallyAfter,
+            }),
+        ).toThrow(/`automaticallyAfter` cannot be `Duration\.days\(0\)`/);
+      };
+
+      checkRotationThrows(Duration.days(0));
+      checkRotationThrows(Duration.hours(0));
+      checkRotationThrows(Duration.minutes(0));
+      checkRotationThrows(Duration.seconds(0));
+      checkRotationThrows(Duration.millis(0));
+    });
+    // Template.fromStack(localStack).hasResourceProperties('AWS::SecretsManager::RotationSchedule', Match.objectEquals({
+    //   SecretId: { Ref: 'SecretA720EF05' },
+    //   RotationLambdaARN: {
+    //     'Fn::GetAtt': [
+    //       'LambdaD247545B',
+    //       'Arn',
+    //     ],
+    //   },
+    // }));
+  });
+
+  test("rotation schedule should have a dependency on lambda permissions", () => {
+    // GIVEN
+    const secret = new encryption.Secret(stack, "Secret");
+    const rotationLambda = new compute.LambdaFunction(stack, "Lambda", {
+      runtime: compute.Runtime.NODEJS_20_X,
+      code: compute.Code.fromInline("export.handler = event => event;"),
+      handler: "index.handler",
+    });
+
+    // WHEN
+    secret.addRotationSchedule("RotationSchedule", {
+      rotationLambda,
+    });
+
+    // THEN
+    const t = new Template(stack);
+    const rotations = t.resourceTypeArray(
+      secretsmanagerSecretRotation.SecretsmanagerSecretRotation,
+    ) as any[];
+    expect(rotations).toHaveLength(1);
+    // NOTE (TerraConstructs deviation): the depended-on `aws_lambda_permission` logical id is
+    // derived from a content hash of the grantee principal (see `grantInvoke()` in
+    // src/aws/compute/function-base.ts), analogous to -- but not byte-identical with -- upstream's
+    // own CDK-side hash (`LambdaInvokeN0a2GKfZP0JmDqDEVhhu6A0TUv3NyNbk4YMFKNc69846677`). Assert the
+    // shape of the dependency (a `depends_on` entry pointing at the generated
+    // `aws_lambda_permission` resource) rather than the exact hash string.
+    expect(rotations[0].depends_on).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/^aws_lambda_permission\./),
+      ]),
+    );
+    // Template.fromStack(stack).hasResource('AWS::SecretsManager::RotationSchedule', {
+    //   DependsOn: [
+    //     'LambdaInvokeN0a2GKfZP0JmDqDEVhhu6A0TUv3NyNbk4YMFKNc69846677',
+    //   ],
+    // });
+  });
+
+  test("automaticallyAfter set scheduleExpression with days duration", () => {
+    // GIVEN
+    const secret = new encryption.Secret(stack, "Secret");
+    const rotationLambda = new compute.LambdaFunction(stack, "Lambda", {
+      runtime: compute.Runtime.NODEJS_LATEST,
+      code: compute.Code.fromInline("export.handler = event => event;"),
+      handler: "index.handler",
+    });
+
+    // WHEN
+    new encryption.RotationSchedule(stack, "RotationSchedule", {
+      secret,
+      rotationLambda,
+      automaticallyAfter: Duration.days(90),
+    });
+
+    // THEN
+    Template.synth(stack).toHaveResourceWithProperties(
+      secretsmanagerSecretRotation.SecretsmanagerSecretRotation,
+      {
+        secret_id: stack.resolve(secret.secretArn),
+        rotation_lambda_arn: stack.resolve(rotationLambda.functionArn),
+        rotation_rules: {
+          schedule_expression: "rate(90 days)",
+        },
+      },
+    );
+    // Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::RotationSchedule', Match.objectEquals({
+    //   SecretId: { Ref: 'SecretA720EF05' },
+    //   RotationLambdaARN: {
+    //     'Fn::GetAtt': [
+    //       'LambdaD247545B',
+    //       'Arn',
+    //     ],
+    //   },
+    //   RotationRules: {
+    //     ScheduleExpression: 'rate(90 days)',
+    //   },
+    // }));
+  });
+
+  test("automaticallyAfter set scheduleExpression with hours duration", () => {
+    // GIVEN
+    const secret = new encryption.Secret(stack, "Secret");
+    const rotationLambda = new compute.LambdaFunction(stack, "Lambda", {
+      runtime: compute.Runtime.NODEJS_LATEST,
+      code: compute.Code.fromInline("export.handler = event => event;"),
+      handler: "index.handler",
+    });
+
+    // WHEN
+    new encryption.RotationSchedule(stack, "RotationSchedule", {
+      secret,
+      rotationLambda,
+      automaticallyAfter: Duration.hours(6),
+    });
+
+    // THEN
+    Template.synth(stack).toHaveResourceWithProperties(
+      secretsmanagerSecretRotation.SecretsmanagerSecretRotation,
+      {
+        secret_id: stack.resolve(secret.secretArn),
+        rotation_lambda_arn: stack.resolve(rotationLambda.functionArn),
+        rotation_rules: {
+          schedule_expression: "rate(6 hours)",
+        },
+      },
+    );
+    // Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::RotationSchedule', Match.objectEquals({
+    //   SecretId: { Ref: 'SecretA720EF05' },
+    //   RotationLambdaARN: {
+    //     'Fn::GetAtt': [
+    //       'LambdaD247545B',
+    //       'Arn',
+    //     ],
+    //   },
+    //   RotationRules: {
+    //     ScheduleExpression: 'rate(6 hours)',
+    //   },
+    // }));
+  });
+
+  test("automaticallyAfter must not be smaller than 4 hours", () => {
+    // GIVEN
+    const secret = new encryption.Secret(stack, "Secret");
+    const rotationLambda = new compute.LambdaFunction(stack, "Lambda", {
+      runtime: compute.Runtime.NODEJS_LATEST,
+      code: compute.Code.fromInline("export.handler = event => event;"),
+      handler: "index.handler",
+    });
+
+    // WHEN
+    // THEN
+    expect(
+      () =>
+        new encryption.RotationSchedule(stack, "RotationSchedule", {
+          secret,
+          rotationLambda,
+          automaticallyAfter: Duration.hours(2),
+        }),
+    ).toThrow(
+      /automaticallyAfter must not be smaller than 4 hours, got 2 hours/,
+    );
+  });
+
+  test("automaticallyAfter must not be greater than 1000 days", () => {
+    // GIVEN
+    const secret = new encryption.Secret(stack, "Secret");
+    const rotationLambda = new compute.LambdaFunction(stack, "Lambda", {
+      runtime: compute.Runtime.NODEJS_LATEST,
+      code: compute.Code.fromInline("export.handler = event => event;"),
+      handler: "index.handler",
+    });
+
+    // WHEN
+    // THEN
+    expect(
+      () =>
+        new encryption.RotationSchedule(stack, "RotationSchedule", {
+          secret,
+          rotationLambda,
+          automaticallyAfter: Duration.days(1001),
+        }),
+    ).toThrow(
+      /automaticallyAfter must not be greater than 1000 days, got 1001 days/,
+    );
+  });
+});
+
+describe("feature tests", () => {
+  // NOTE (TerraConstructs deviation): upstream parameterizes both nested describes below via the
+  // `@aws-cdk/aws-lambda:createNewPoliciesWithAddToRolePolicy` context feature flag (cx-api). That
+  // per-module context-flag mechanism is not ported in this repo (see src/aws/cx-api.ts -- no such
+  // flag entry). `iam.Role.addToPrincipalPolicy` (src/aws/iam/role.ts) always merges granted
+  // statements into a single "DefaultPolicy" child resource -- matching only the flag's "disabled"
+  // (legacy) behavior. The "enabled" branch (a separate per-grant
+  // "...inlinePolicyAddedToExecutionRole..." `Policy` resource) has no code path here, so only the
+  // "disabled" test of each pair is portable; the "enabled" test is dropped.
+  describe("grants correct permissions for secret imported by name", () => {
+    test("@aws-cdk/aws-lambda:createNewPoliciesWithAddToRolePolicy disabled", () => {
+      // GIVEN
+      const app = Testing.app();
+      const stack = new AwsStack(app);
+      const secret = encryption.Secret.fromSecretNameV2(
+        stack,
+        "Secret",
+        "mySecretName",
+      );
+      const rotationLambda = new compute.LambdaFunction(stack, "Lambda", {
+        runtime: compute.Runtime.NODEJS_LATEST,
+        code: compute.Code.fromInline("export.handler = event => event;"),
+        handler: "index.handler",
+      });
+
+      // WHEN
+      new encryption.RotationSchedule(stack, "RotationSchedule", {
+        secret,
+        rotationLambda,
+      });
+
+      // THEN
+      Template.synth(stack).toHaveDataSourceWithProperties(
+        dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+        {
+          statement: expect.arrayContaining([
+            expect.objectContaining({
+              actions: [
+                "secretsmanager:DescribeSecret",
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:PutSecretValue",
+                "secretsmanager:UpdateSecretVersionStage",
+              ],
+              effect: "Allow",
+              resources: [`${stack.resolve(secret.secretArn)}-??????`],
+            }),
+          ]),
+        },
+      );
+      // Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
+      //   PolicyDocument: {
+      //     Statement: Match.arrayWith([
+      //       {
+      //         Action: [
+      //           'secretsmanager:DescribeSecret',
+      //           'secretsmanager:GetSecretValue',
+      //           'secretsmanager:PutSecretValue',
+      //           'secretsmanager:UpdateSecretVersionStage',
+      //         ],
+      //         Effect: 'Allow',
+      //         Resource: {
+      //           'Fn::Join': ['', [
+      //             'arn:',
+      //             { Ref: 'AWS::Partition' },
+      //             ':secretsmanager:',
+      //             { Ref: 'AWS::Region' },
+      //             ':',
+      //             { Ref: 'AWS::AccountId' },
+      //             ':secret:mySecretName-??????',
+      //           ]],
+      //         },
+      //       },
+      //     ]),
+      //     Version: '2012-10-17',
+      //   },
+      //   PolicyName: 'LambdainlinePolicyAddedToExecutionRole06CEA97D1',
+      //   Roles: [
+      //     {
+      //       Ref: 'LambdaServiceRoleA8ED4D3B',
+      //     },
+      //   ],
+      // });
+    });
+  });
+
+  describe("assign permissions for rotation schedule with a rotation Lambda", () => {
+    test("@aws-cdk/aws-lambda:createNewPoliciesWithAddToRolePolicy disabled", () => {
+      // GIVEN
+      const app = Testing.app();
+      const stack = new AwsStack(app);
+      const secret = new encryption.Secret(stack, "Secret");
+      const rotationLambda = new compute.LambdaFunction(stack, "Lambda", {
+        runtime: compute.Runtime.NODEJS_LATEST,
+        code: compute.Code.fromInline("export.handler = event => event;"),
+        handler: "index.handler",
+      });
+
+      // WHEN
+      new encryption.RotationSchedule(stack, "RotationSchedule", {
+        secret,
+        rotationLambda,
+      });
+
+      // THEN
+      Template.synth(stack).toHaveResourceWithProperties(
+        lambdaPermission.LambdaPermission,
+        {
+          action: "lambda:InvokeFunction",
+          function_name: stack.resolve(rotationLambda.functionArn),
+          principal: "secretsmanager.amazonaws.com",
+        },
+      );
+      // Template.fromStack(stack).hasResourceProperties('AWS::Lambda::Permission', {
+      //   Action: 'lambda:InvokeFunction',
+      //   FunctionName: {
+      //     'Fn::GetAtt': [
+      //       'LambdaD247545B',
+      //       'Arn',
+      //     ],
+      //   },
+      //   Principal: 'secretsmanager.amazonaws.com',
+      // });
+
+      // NOTE: unlike an `arrayContaining`, a plain array requires an exact-length match (see the
+      // NOTE on "grantRead with KMS Key" in secret.test.ts) -- the Lambda's inline policy also
+      // carries its default X-Ray tracing statement alongside the two secretsmanager statements
+      // below, so `arrayContaining` (matching the sibling "grants correct permissions for secret
+      // imported by name" test above) is used instead of a fixed-length array.
+      Template.synth(stack).toHaveDataSourceWithProperties(
+        dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+        {
+          statement: expect.arrayContaining([
+            expect.objectContaining({
+              actions: [
+                "secretsmanager:DescribeSecret",
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:PutSecretValue",
+                "secretsmanager:UpdateSecretVersionStage",
+              ],
+              effect: "Allow",
+              resources: [stack.resolve(secret.secretArn)],
+            }),
+            expect.objectContaining({
+              actions: ["secretsmanager:GetRandomPassword"],
+              effect: "Allow",
+              resources: ["*"],
+            }),
+          ]),
+        },
+      );
+      // Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
+      //   PolicyDocument: {
+      //     Statement: [
+      //       {
+      //         Action: [
+      //           'secretsmanager:DescribeSecret',
+      //           'secretsmanager:GetSecretValue',
+      //           'secretsmanager:PutSecretValue',
+      //           'secretsmanager:UpdateSecretVersionStage',
+      //         ],
+      //         Effect: 'Allow',
+      //         Resource: {
+      //           Ref: 'SecretA720EF05',
+      //         },
+      //       },
+      //     ],
+      //     Version: '2012-10-17',
+      //   },
+      //   PolicyName: 'LambdainlinePolicyAddedToExecutionRole06CEA97D1',
+      //   Roles: [
+      //     {
+      //       Ref: 'LambdaServiceRoleA8ED4D3B',
+      //     },
+      //   ],
+      // });
+      //
+      // Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
+      //   PolicyDocument: {
+      //     Statement: [
+      //       {
+      //         Action: 'secretsmanager:GetRandomPassword',
+      //         Effect: 'Allow',
+      //         Resource: '*',
+      //       },
+      //     ],
+      //   },
+      // });
+    });
+  });
+});
+
+// Repo-specific snapshot coverage (see conventions.md "Test-suite conventions": snapshots are the
+// repo's main defense against emitted-Terraform drift).
+describe("RotationSchedule", () => {
+  test("Should synth and match SnapShot", () => {
+    // GIVEN
+    const app = Testing.app();
+    const stack = new AwsStack(app);
+    const secret = new encryption.Secret(stack, "Secret");
+    const rotationLambda = new compute.LambdaFunction(stack, "Lambda", {
+      runtime: compute.Runtime.NODEJS_LATEST,
+      code: compute.Code.fromInline("export.handler = event => event;"),
+      handler: "index.handler",
+    });
+
+    // WHEN
+    new encryption.RotationSchedule(stack, "RotationSchedule", {
+      secret,
+      rotationLambda,
+      automaticallyAfter: Duration.days(14),
+    });
+
+    // THEN
+    stack.prepareStack(); // may generate additional resources
+    expect(Testing.synth(stack)).toMatchSnapshot();
+  });
+});

--- a/test/aws/encryption/rotation-schedule.test.ts
+++ b/test/aws/encryption/rotation-schedule.test.ts
@@ -5,7 +5,7 @@ import {
   lambdaPermission,
   dataAwsIamPolicyDocument,
 } from "@cdktn/provider-aws";
-import { App, Testing } from "cdktn";
+import { App, HttpBackend, Testing } from "cdktn";
 import "cdktn/lib/testing/adapters/jest";
 import { AwsStack } from "../../../src/aws/aws-stack";
 import * as compute from "../../../src/aws/compute";
@@ -1034,6 +1034,9 @@ describe("RotationSchedule", () => {
     // GIVEN
     const app = Testing.app();
     const stack = new AwsStack(app);
+    // snapshot tests must not use the default local backend - its state file
+    // path is machine-dependent and would leak into the snapshot
+    new HttpBackend(stack, { address: "http://localhost:3000" });
     const secret = new encryption.Secret(stack, "Secret");
     const rotationLambda = new compute.LambdaFunction(stack, "Lambda", {
       runtime: compute.Runtime.NODEJS_LATEST,

--- a/test/aws/encryption/secret-rotation.test.ts
+++ b/test/aws/encryption/secret-rotation.test.ts
@@ -1,0 +1,468 @@
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/aws-cdk-lib/aws-secretsmanager/test/secret-rotation.test.ts
+
+import { App, Testing } from "cdktn";
+import "cdktn/lib/testing/adapters/jest";
+import { AwsStack } from "../../../src/aws/aws-stack";
+import * as ec2 from "../../../src/aws/compute";
+import * as encryption from "../../../src/aws/encryption";
+
+// Repo-specific coverage (see conventions.md "Test-suite conventions": snapshots are the repo's
+// main defense against emitted-Terraform drift). `SecretRotation` has no successful synth path to
+// snapshot -- see the "TERRACONSTRUCTS DEVIATION (HARD BLOCKER)" doc comment on the class in
+// src/aws/encryption/secret-rotation.ts: upstream deploys the rotation Lambda via an AWS-published
+// Serverless Application Repository (SAR) app (`AWS::Serverless::Application`), and
+// `terraform-provider-aws` has no `serverlessrepo` resource, so the constructor unconditionally
+// throws a `ValidationError` instead of ever synthesizing a half/invalid resource. This test
+// defends that deviation (an intentional, permanent throw) against silent regressions.
+describe("SecretRotation", () => {
+  test("always throws: no Terraform serverlessrepo resource for the SAR rotation app", () => {
+    // GIVEN
+    const app = Testing.app();
+    const stack = new AwsStack(app);
+    const vpc = new ec2.Vpc(stack, "VPC");
+    const secret = new encryption.Secret(stack, "Secret");
+    const securityGroup = new ec2.SecurityGroup(stack, "SecurityGroup", {
+      vpc,
+    });
+    const target = new ec2.Connections({
+      defaultPort: ec2.Port.tcp(3306),
+      securityGroups: [securityGroup],
+    });
+
+    // WHEN / THEN
+    expect(
+      () =>
+        new encryption.SecretRotation(stack, "SecretRotation", {
+          application:
+            encryption.SecretRotationApplication.MYSQL_ROTATION_SINGLE_USER,
+          secret,
+          target,
+          vpc,
+        }),
+    ).toThrow(/SecretRotation is not supported/);
+  });
+});
+
+let app: App;
+let stack: AwsStack;
+let vpc: ec2.IVpc;
+let secret: encryption.ISecret;
+let securityGroup: ec2.SecurityGroup;
+let target: ec2.Connections;
+beforeEach(() => {
+  app = Testing.app();
+  stack = new AwsStack(app);
+  vpc = new ec2.Vpc(stack, "VPC");
+  secret = new encryption.Secret(stack, "Secret");
+  securityGroup = new ec2.SecurityGroup(stack, "SecurityGroup", { vpc });
+  target = new ec2.Connections({
+    defaultPort: ec2.Port.tcp(3306),
+    securityGroups: [securityGroup],
+  });
+});
+
+// Not supported by Terraform Provider: `SecretRotation` always throws at construction time (see
+// the "TERRACONSTRUCTS DEVIATION" doc comment in src/aws/encryption/secret-rotation.ts) because it
+// deploys its rotation Lambda via an AWS Serverless Application Repository (SAR) app
+// (`AWS::Serverless::Application`), and `terraform-provider-aws` has no `serverlessrepo` resource.
+// This test asserted the synthesized `AWS::EC2::SecurityGroupIngress` / `AWS::SecretsManager::
+// RotationSchedule` / `AWS::EC2::SecurityGroup` / `AWS::Serverless::Application` /
+// `AWS::SecretsManager::ResourcePolicy` CloudFormation resources produced by a successful
+// construction, which can never happen here.
+// test('secret rotation single user', () => {
+//   // GIVEN
+//   const excludeCharacters = ' ;+%{}' + '@\'"`/\\#'; // DMS and BASH problem chars
+//
+//   // WHEN
+//   new secretsmanager.SecretRotation(stack, 'SecretRotation', {
+//     application: secretsmanager.SecretRotationApplication.MYSQL_ROTATION_SINGLE_USER,
+//     secret,
+//     target,
+//     vpc,
+//     excludeCharacters: excludeCharacters,
+//   });
+//
+//   // THEN
+//   Template.fromStack(stack).hasResourceProperties('AWS::EC2::SecurityGroupIngress', {
+//     IpProtocol: 'tcp',
+//     Description: 'from SecretRotationSecurityGroupAEC520AB:3306',
+//     FromPort: 3306,
+//     GroupId: {
+//       'Fn::GetAtt': [
+//         'SecurityGroupDD263621',
+//         'GroupId',
+//       ],
+//     },
+//     SourceSecurityGroupId: {
+//       'Fn::GetAtt': [
+//         'SecretRotationSecurityGroup9985012B',
+//         'GroupId',
+//       ],
+//     },
+//     ToPort: 3306,
+//   });
+//
+//   Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::RotationSchedule', {
+//     SecretId: {
+//       Ref: 'SecretA720EF05',
+//     },
+//     RotationLambdaARN: {
+//       'Fn::GetAtt': [
+//         'SecretRotationA9FFCFA9',
+//         'Outputs.RotationLambdaARN',
+//       ],
+//     },
+//     RotationRules: {
+//       ScheduleExpression: 'rate(30 days)',
+//     },
+//   });
+//
+//   Template.fromStack(stack).hasResourceProperties('AWS::EC2::SecurityGroup', {
+//     GroupDescription: 'Default/SecretRotation/SecurityGroup',
+//   });
+//
+//   Template.fromStack(stack).hasResource('AWS::Serverless::Application', {
+//     Properties: {
+//       Location: {
+//         ApplicationId: {
+//           'Fn::FindInMap': ['SecretRotationSARMappingC10A2F5D', { Ref: 'AWS::Partition' }, 'applicationId'],
+//         },
+//         SemanticVersion: {
+//           'Fn::FindInMap': ['SecretRotationSARMappingC10A2F5D', { Ref: 'AWS::Partition' }, 'semanticVersion'],
+//         },
+//       },
+//       Parameters: {
+//         endpoint: {
+//           'Fn::Join': [
+//             '',
+//             [
+//               'https://secretsmanager.',
+//               {
+//                 Ref: 'AWS::Region',
+//               },
+//               '.',
+//               {
+//                 Ref: 'AWS::URLSuffix',
+//               },
+//             ],
+//           ],
+//         },
+//         functionName: 'SecretRotation',
+//         excludeCharacters: excludeCharacters,
+//         vpcSecurityGroupIds: {
+//           'Fn::GetAtt': [
+//             'SecretRotationSecurityGroup9985012B',
+//             'GroupId',
+//           ],
+//         },
+//         vpcSubnetIds: {
+//           'Fn::Join': [
+//             '',
+//             [
+//               {
+//                 Ref: 'VPCPrivateSubnet1Subnet8BCA10E0',
+//               },
+//               ',',
+//               {
+//                 Ref: 'VPCPrivateSubnet2SubnetCFCDAA7A',
+//               },
+//             ],
+//           ],
+//         },
+//       },
+//     },
+//     DeletionPolicy: 'Delete',
+//     UpdateReplacePolicy: 'Delete',
+//   });
+//
+//   Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::ResourcePolicy', {
+//     ResourcePolicy: {
+//       Statement: [
+//         {
+//           Action: 'secretsmanager:DeleteSecret',
+//           Effect: 'Deny',
+//           Principal: {
+//             AWS: {
+//               'Fn::Join': [
+//                 '',
+//                 [
+//                   'arn:',
+//                   {
+//                     Ref: 'AWS::Partition',
+//                   },
+//                   ':iam::',
+//                   {
+//                     Ref: 'AWS::AccountId',
+//                   },
+//                   ':root',
+//                 ],
+//               ],
+//             },
+//           },
+//           Resource: '*',
+//         },
+//       ],
+//       Version: '2012-10-17',
+//     },
+//     SecretId: {
+//       Ref: 'SecretA720EF05',
+//     },
+//   });
+// });
+
+// Not supported by Terraform Provider: see reason above ('secret rotation single user').
+// test('secret rotation multi user', () => {
+//   // GIVEN
+//   const masterSecret = new secretsmanager.Secret(stack, 'MasterSecret');
+//
+//   // WHEN
+//   new secretsmanager.SecretRotation(stack, 'SecretRotation', {
+//     application: secretsmanager.SecretRotationApplication.MYSQL_ROTATION_MULTI_USER,
+//     secret,
+//     masterSecret,
+//     target,
+//     vpc,
+//   });
+//
+//   // THEN
+//   Template.fromStack(stack).hasResourceProperties('AWS::Serverless::Application', {
+//     Parameters: {
+//       endpoint: {
+//         'Fn::Join': [
+//           '',
+//           [
+//             'https://secretsmanager.',
+//             {
+//               Ref: 'AWS::Region',
+//             },
+//             '.',
+//             {
+//               Ref: 'AWS::URLSuffix',
+//             },
+//           ],
+//         ],
+//       },
+//       functionName: 'SecretRotation',
+//       vpcSecurityGroupIds: {
+//         'Fn::GetAtt': [
+//           'SecretRotationSecurityGroup9985012B',
+//           'GroupId',
+//         ],
+//       },
+//       vpcSubnetIds: {
+//         'Fn::Join': [
+//           '',
+//           [
+//             {
+//               Ref: 'VPCPrivateSubnet1Subnet8BCA10E0',
+//             },
+//             ',',
+//             {
+//               Ref: 'VPCPrivateSubnet2SubnetCFCDAA7A',
+//             },
+//           ],
+//         ],
+//       },
+//       masterSecretArn: {
+//         Ref: 'MasterSecretA11BF785',
+//       },
+//     },
+//   });
+//
+//   Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::ResourcePolicy', {
+//     ResourcePolicy: {
+//       Statement: [
+//         {
+//           Action: 'secretsmanager:DeleteSecret',
+//           Effect: 'Deny',
+//           Principal: {
+//             AWS: {
+//               'Fn::Join': [
+//                 '',
+//                 [
+//                   'arn:',
+//                   {
+//                     Ref: 'AWS::Partition',
+//                   },
+//                   ':iam::',
+//                   {
+//                     Ref: 'AWS::AccountId',
+//                   },
+//                   ':root',
+//                 ],
+//               ],
+//             },
+//           },
+//           Resource: '*',
+//         },
+//       ],
+//       Version: '2012-10-17',
+//     },
+//     SecretId: {
+//       Ref: 'MasterSecretA11BF785',
+//     },
+//   });
+// });
+
+// Not supported by Terraform Provider: see reason above ('secret rotation single user').
+// test('secret rotation allows passing an empty string for excludeCharacters', () => {
+//   // WHEN
+//   new secretsmanager.SecretRotation(stack, 'SecretRotation', {
+//     application: secretsmanager.SecretRotationApplication.MARIADB_ROTATION_SINGLE_USER,
+//     secret,
+//     target,
+//     vpc,
+//     excludeCharacters: '',
+//   });
+//
+//   // THEN
+//   Template.fromStack(stack).hasResourceProperties('AWS::Serverless::Application', {
+//     Parameters: {
+//       excludeCharacters: '',
+//     },
+//   });
+// });
+
+// Not supported by Terraform Provider: see reason above ('secret rotation single user').
+// test('secret rotation without immediate rotation', () => {
+//   // WHEN
+//   new secretsmanager.SecretRotation(stack, 'SecretRotation', {
+//     application: secretsmanager.SecretRotationApplication.MARIADB_ROTATION_SINGLE_USER,
+//     secret,
+//     target,
+//     vpc,
+//     rotateImmediatelyOnUpdate: false,
+//   });
+//
+//   // THEN
+//   Template.fromStack(stack).hasResourceProperties('AWS::SecretsManager::RotationSchedule', {
+//     RotateImmediatelyOnUpdate: false,
+//   });
+// });
+
+test("throws when connections object has no default port range", () => {
+  // WHEN
+  const targetWithoutDefaultPort = new ec2.Connections({
+    securityGroups: [securityGroup],
+  });
+
+  // THEN
+  expect(
+    () =>
+      new encryption.SecretRotation(stack, "Rotation", {
+        secret,
+        application:
+          encryption.SecretRotationApplication.MYSQL_ROTATION_SINGLE_USER,
+        vpc,
+        target: targetWithoutDefaultPort,
+      }),
+  ).toThrow(/`target`.+default port range/);
+});
+
+test("throws when master secret is missing for a multi user application", () => {
+  // THEN
+  expect(
+    () =>
+      new encryption.SecretRotation(stack, "Rotation", {
+        secret,
+        application:
+          encryption.SecretRotationApplication.MYSQL_ROTATION_MULTI_USER,
+        vpc,
+        target,
+      }),
+  ).toThrow(
+    /The `masterSecret` must be specified for application using the multi user scheme/,
+  );
+});
+
+// Not supported by Terraform Provider: see reason above ('secret rotation single user'). This
+// test asserted the `AWS::Serverless::Application` `functionName` Parameter truncation/collision
+// avoidance for long construct ids, which is entirely SAR-CfnApplication-specific.
+// test('rotation function name does not exceed 64 chars', () => {
+//   // WHEN
+//   const id = 'SecretRotation'.repeat(5);
+//   new secretsmanager.SecretRotation(stack, id, {
+//     application: secretsmanager.SecretRotationApplication.MYSQL_ROTATION_SINGLE_USER,
+//     secret,
+//     target,
+//     vpc,
+//   });
+//
+//   // THEN
+//   Template.fromStack(stack).hasResourceProperties('AWS::Serverless::Application', {
+//     Parameters: {
+//       endpoint: {
+//         'Fn::Join': [
+//           '',
+//           [
+//             'https://secretsmanager.',
+//             {
+//               Ref: 'AWS::Region',
+//             },
+//             '.',
+//             {
+//               Ref: 'AWS::URLSuffix',
+//             },
+//           ],
+//         ],
+//       },
+//       functionName: 'RotationSecretRotationSecretRotationSecretRotationSecretRotation',
+//       vpcSecurityGroupIds: {
+//         'Fn::GetAtt': [
+//           'SecretRotationSecretRotationSecretRotationSecretRotationSecretRotationSecurityGroupBFCB171A',
+//           'GroupId',
+//         ],
+//       },
+//       vpcSubnetIds: {
+//         'Fn::Join': [
+//           '',
+//           [
+//             {
+//               Ref: 'VPCPrivateSubnet1Subnet8BCA10E0',
+//             },
+//             ',',
+//             {
+//               Ref: 'VPCPrivateSubnet2SubnetCFCDAA7A',
+//             },
+//           ],
+//         ],
+//       },
+//     },
+//   });
+// });
+
+// Not supported by Terraform Provider: see reason above ('secret rotation single user'). This
+// test additionally exercised `ec2.InterfaceVpcEndpoint` wiring into the SAR CfnApplication's
+// `endpoint` Parameter, which is unreachable now that construction always throws.
+// test('with interface vpc endpoint', () => {
+//   // GIVEN
+//   const endpoint = new ec2.InterfaceVpcEndpoint(stack, 'SecretsManagerEndpoint', {
+//     service: ec2.InterfaceVpcEndpointAwsService.SECRETS_MANAGER,
+//     vpc,
+//   });
+//
+//   // WHEN
+//   new secretsmanager.SecretRotation(stack, 'SecretRotation', {
+//     application: secretsmanager.SecretRotationApplication.MYSQL_ROTATION_SINGLE_USER,
+//     secret,
+//     target,
+//     vpc,
+//     endpoint,
+//   });
+//
+//   // THEN
+//   Template.fromStack(stack).hasResourceProperties('AWS::Serverless::Application', {
+//     Parameters: {
+//       endpoint: {
+//         'Fn::Join': ['', [
+//           'https://',
+//           { Ref: 'SecretsManagerEndpoint5E83C66B' },
+//           '.secretsmanager.',
+//           { Ref: 'AWS::Region' },
+//           '.',
+//           { Ref: 'AWS::URLSuffix' },
+//         ]],
+//       },
+//     },
+//   });
+// });

--- a/test/aws/encryption/secret.test.ts
+++ b/test/aws/encryption/secret.test.ts
@@ -1,0 +1,1484 @@
+// https://github.com/aws/aws-cdk/blob/v2.261.0/packages/aws-cdk-lib/aws-secretsmanager/test/secret.test.ts
+
+import {
+  secretsmanagerSecret,
+  dataAwsSecretsmanagerRandomPassword,
+  secretsmanagerSecretRotation,
+  dataAwsIamPolicyDocument,
+  secretsmanagerSecretVersion,
+  secretsmanagerSecretPolicy,
+  kmsKey,
+} from "@cdktn/provider-aws";
+import { App, Testing, TerraformOutput } from "cdktn";
+import "cdktn/lib/testing/adapters/jest";
+import { AwsStack } from "../../../src/aws";
+import * as compute from "../../../src/aws/compute";
+import * as encryption from "../../../src/aws/encryption";
+import * as iam from "../../../src/aws/iam";
+import { Duration } from "../../../src/duration";
+import { Template } from "../../assertions";
+
+const environmentName = "Test";
+const gridUUID = "a123e4567-e89b-12d3";
+const gridUUID2 = "a123e4567-e89b-12d4";
+const providerConfig = { region: "us-east-1" };
+const gridBackendConfig = {
+  address: "http://localhost:3000",
+};
+
+let app: App;
+let stack: AwsStack;
+beforeEach(() => {
+  app = Testing.app();
+  stack = new AwsStack(app, "MyStack", {
+    environmentName,
+    gridUUID,
+    providerConfig,
+    gridBackendConfig,
+  });
+});
+
+test("default secret", () => {
+  // WHEN
+  const secret = new encryption.Secret(stack, "Secret");
+
+  // THEN
+  const t = new Template(stack, { snapshot: true });
+  t.expect.toHaveDataSource(
+    dataAwsSecretsmanagerRandomPassword.DataAwsSecretsmanagerRandomPassword,
+  );
+  t.expect.toHaveResourceWithProperties(
+    secretsmanagerSecretVersion.SecretsmanagerSecretVersion,
+    {
+      secret_id: stack.resolve(secret.secretArn),
+    },
+  );
+});
+
+test("set recoveryWindow to secret", () => {
+  // WHEN
+  new encryption.Secret(stack, "Secret", {
+    recoveryWindow: Duration.days(7),
+  });
+
+  // THEN
+  Template.synth(stack).toHaveResourceWithProperties(
+    secretsmanagerSecret.SecretsmanagerSecret,
+    {
+      recovery_window_in_days: 7,
+    },
+  );
+});
+
+test("secret with kms", () => {
+  // GIVEN
+  const key = new encryption.Key(stack, "KMS");
+
+  // WHEN
+  new encryption.Secret(stack, "Secret", { encryptionKey: key });
+
+  // THEN
+  const t = new Template(stack, { snapshot: true });
+  // NOTE: unlike CloudFormation's separate KMS::Key + IAM::Policy resources,
+  // the Terraform aws_kms_key resource carries its resource policy inline via
+  // the `policy` attribute (there is no separate "key policy" resource).
+  t.expect.toHaveResourceWithProperties(kmsKey.KmsKey, {
+    policy: expect.stringMatching(
+      /^\$\{data\.aws_iam_policy_document\.KMS_Policy_[0-9A-F]+\.json\}$/,
+    ),
+  });
+  t.expect.toHaveDataSourceWithProperties(
+    dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+    {
+      statement: expect.arrayContaining([
+        {
+          actions: [
+            "kms:Decrypt",
+            "kms:Encrypt",
+            "kms:ReEncrypt*",
+            "kms:GenerateDataKey*",
+          ],
+          condition: [
+            {
+              test: "StringEquals",
+              values: ["secretsmanager.us-east-1.amazonaws.com"],
+              variable: "kms:ViaService",
+            },
+          ],
+          effect: "Allow",
+          principals: [
+            {
+              identifiers: [
+                "arn:${data.aws_partition.Partitition.partition}:iam::${data.aws_caller_identity.CallerIdentity.account_id}:root",
+              ],
+              type: "AWS",
+            },
+          ],
+          resources: ["*"],
+        },
+        {
+          actions: ["kms:CreateGrant", "kms:DescribeKey"],
+          condition: [
+            {
+              test: "StringEquals",
+              values: ["secretsmanager.us-east-1.amazonaws.com"],
+              variable: "kms:ViaService",
+            },
+          ],
+          effect: "Allow",
+          principals: [
+            {
+              identifiers: [
+                "arn:${data.aws_partition.Partitition.partition}:iam::${data.aws_caller_identity.CallerIdentity.account_id}:root",
+              ],
+              type: "AWS",
+            },
+          ],
+          resources: ["*"],
+        },
+      ]),
+    },
+  );
+});
+
+test("secret with generate secret string options", () => {
+  // WHEN
+  new encryption.Secret(stack, "Secret", {
+    generateSecretString: {
+      excludeUppercase: true,
+      passwordLength: 20,
+    },
+  });
+
+  // THEN
+  const t = new Template(stack, { snapshot: true });
+  t.expect.toHaveDataSourceWithProperties(
+    dataAwsSecretsmanagerRandomPassword.DataAwsSecretsmanagerRandomPassword,
+    {
+      exclude_uppercase: true,
+      password_length: 20,
+    },
+  );
+  t.expect.toHaveResourceWithProperties(
+    secretsmanagerSecretVersion.SecretsmanagerSecretVersion,
+    {
+      secret_string: expect.stringMatching(
+        /^\$\{data\.aws_secretsmanager_random_password\.Secret_RandomPassword_[0-9A-F]+\.random_password\}$/,
+      ),
+    },
+  );
+});
+
+test("secret with generate secret string excludeCharacters", () => {
+  // WHEN
+  new encryption.Secret(stack, "Secret", {
+    generateSecretString: {
+      excludeCharacters: 'abc"@/\\',
+    },
+  });
+
+  // THEN
+  const t = new Template(stack, { snapshot: true });
+  t.expect.toHaveDataSourceWithProperties(
+    dataAwsSecretsmanagerRandomPassword.DataAwsSecretsmanagerRandomPassword,
+    {
+      exclude_characters: 'abc"@/\\',
+    },
+  );
+});
+
+test("templated secret string", () => {
+  // WHEN
+  new encryption.Secret(stack, "Secret", {
+    generateSecretString: {
+      secretStringTemplate: JSON.stringify({ username: "username" }),
+      generateStringKey: "password",
+    },
+  });
+
+  // THEN
+  const t = new Template(stack, { snapshot: true });
+  t.expect.toHaveDataSourceWithProperties(
+    dataAwsSecretsmanagerRandomPassword.DataAwsSecretsmanagerRandomPassword,
+    {
+      exclude_uppercase: false,
+      password_length: 32,
+    },
+  );
+  t.expect.toHaveResourceWithProperties(
+    secretsmanagerSecretVersion.SecretsmanagerSecretVersion,
+    {
+      secret_string: expect.stringMatching(
+        /^\$\{jsonencode\(\{"username" = "username", "password" = data\.aws_secretsmanager_random_password\.Secret_RandomPassword_[0-9A-F]+\.random_password\}\)\}$/,
+      ),
+    },
+  );
+});
+
+describe("secretStringValue", () => {
+  test("can reference an arbitrary resolvable token", () => {
+    const role = new iam.Role(stack, "Role", {
+      assumedBy: new iam.ServicePrincipal("ec2.amazonaws.com"),
+    });
+
+    new encryption.Secret(stack, "Secret", {
+      secretStringValue: role.roleArn,
+    });
+
+    const t = new Template(stack, { snapshot: true });
+    // GenerateSecretString: Match.absent(),
+    t.expect.not.toHaveDataSource(
+      dataAwsSecretsmanagerRandomPassword.DataAwsSecretsmanagerRandomPassword,
+    );
+    t.expect.toHaveResourceWithProperties(
+      secretsmanagerSecretVersion.SecretsmanagerSecretVersion,
+      {
+        secret_string: stack.resolve(role.roleArn),
+      },
+    );
+  });
+});
+
+test("grantRead", () => {
+  // GIVEN
+  const secret = new encryption.Secret(stack, "Secret");
+  const role = new iam.Role(stack, "Role", {
+    assumedBy: new iam.AccountRootPrincipal(),
+  });
+
+  // WHEN
+  secret.grantRead(role);
+
+  // THEN
+  Template.synth(stack).toHaveDataSourceWithProperties(
+    dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+    {
+      statement: [
+        {
+          actions: [
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:DescribeSecret",
+          ],
+          effect: "Allow",
+          resources: [stack.resolve(secret.secretArn)],
+        },
+      ],
+    },
+  );
+});
+
+// TODO: This does not throw because AwsStack does not have a concrete
+// accountId by default, so tokenComparison is always matching
+// (dataAwsCallerIdentity.CallerIdentity Token).
+test.skip("Error when grantRead with different role and no KMS", () => {
+  // GIVEN
+  const testStack = new AwsStack(app, "TestStack", {
+    environmentName,
+    gridUUID: gridUUID2,
+    providerConfig,
+    gridBackendConfig,
+  });
+
+  const secret = new encryption.Secret(testStack, "Secret");
+  const role = iam.Role.fromRoleArn(
+    testStack,
+    "RoleFromArn",
+    "arn:aws:iam::111111111111:role/SomeRole",
+  );
+
+  // THEN
+  expect(() => {
+    secret.grantRead(role);
+  }).toThrow("KMS Key must be provided for cross account access to Secret");
+});
+
+test("grantRead with KMS Key", () => {
+  // GIVEN
+  const key = new encryption.Key(stack, "KMS");
+  const secret = new encryption.Secret(stack, "Secret", {
+    encryptionKey: key,
+  });
+  const role = new iam.Role(stack, "Role", {
+    assumedBy: new iam.AccountRootPrincipal(),
+  });
+
+  // WHEN
+  secret.grantRead(role);
+
+  // THEN
+  const t = new Template(stack, { snapshot: true });
+  t.expect.toHaveDataSourceWithProperties(
+    dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+    {
+      statement: [
+        {
+          actions: [
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:DescribeSecret",
+          ],
+          effect: "Allow",
+          resources: [stack.resolve(secret.secretArn)],
+        },
+      ],
+    },
+  );
+  t.expect.toHaveDataSourceWithProperties(
+    dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+    {
+      statement: expect.arrayContaining([
+        {
+          actions: ["kms:Decrypt"],
+          condition: [
+            {
+              test: "StringEquals",
+              values: ["secretsmanager.us-east-1.amazonaws.com"],
+              variable: "kms:ViaService",
+            },
+          ],
+          effect: "Allow",
+          principals: [
+            {
+              identifiers: [stack.resolve(role.roleArn)],
+              type: "AWS",
+            },
+          ],
+          resources: ["*"],
+        },
+      ]),
+    },
+  );
+});
+
+test("grantRead cross account", () => {
+  // GIVEN
+  const key = new encryption.Key(stack, "KMS");
+  const secret = new encryption.Secret(stack, "Secret", {
+    encryptionKey: key,
+  });
+  const principal = new iam.AccountPrincipal("1234");
+
+  // WHEN
+  secret.grantRead(principal, ["FOO", "bar"]).assertSuccess();
+
+  // THEN
+  const t = new Template(stack, { snapshot: true });
+  t.expect.toHaveDataSourceWithProperties(
+    dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+    {
+      statement: [
+        {
+          actions: [
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:DescribeSecret",
+          ],
+          effect: "Allow",
+          condition: [
+            {
+              test: "ForAnyValue:StringEquals",
+              values: ["FOO", "bar"],
+              variable: "secretsmanager:VersionStage",
+            },
+          ],
+          principals: [
+            {
+              identifiers: [
+                "arn:${data.aws_partition.Partitition.partition}:iam::1234:root",
+              ],
+              type: "AWS",
+            },
+          ],
+          resources: [stack.resolve(secret.secretArn)],
+        },
+      ],
+    },
+  );
+  t.expect.toHaveResourceWithProperties(
+    secretsmanagerSecretPolicy.SecretsmanagerSecretPolicy,
+    {
+      secret_arn: stack.resolve(secret.secretArn),
+    },
+  );
+  t.expect.toHaveDataSourceWithProperties(
+    dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+    {
+      statement: expect.arrayContaining([
+        {
+          actions: ["kms:Decrypt"],
+          condition: [
+            {
+              test: "StringEquals",
+              values: ["secretsmanager.us-east-1.amazonaws.com"],
+              variable: "kms:ViaService",
+            },
+          ],
+          effect: "Allow",
+          principals: [
+            {
+              identifiers: [
+                "arn:${data.aws_partition.Partitition.partition}:iam::1234:root",
+              ],
+              type: "AWS",
+            },
+          ],
+          resources: ["*"],
+        },
+      ]),
+    },
+  );
+});
+
+test("grantRead with version label constraint", () => {
+  // GIVEN
+  const key = new encryption.Key(stack, "KMS");
+  const secret = new encryption.Secret(stack, "Secret", {
+    encryptionKey: key,
+  });
+  const role = new iam.Role(stack, "Role", {
+    assumedBy: new iam.AccountRootPrincipal(),
+  });
+
+  // WHEN
+  secret.grantRead(role, ["FOO", "bar"]);
+
+  // THEN
+  const t = new Template(stack, { snapshot: true });
+  t.expect.toHaveDataSourceWithProperties(
+    dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+    {
+      statement: [
+        {
+          actions: [
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:DescribeSecret",
+          ],
+          resources: [stack.resolve(secret.secretArn)],
+          effect: "Allow",
+          condition: [
+            {
+              test: "ForAnyValue:StringEquals",
+              values: ["FOO", "bar"],
+              variable: "secretsmanager:VersionStage",
+            },
+          ],
+        },
+      ],
+    },
+  );
+  t.expect.toHaveDataSourceWithProperties(
+    dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+    {
+      statement: expect.arrayContaining([
+        {
+          actions: ["kms:Decrypt"],
+          condition: [
+            {
+              test: "StringEquals",
+              values: ["secretsmanager.us-east-1.amazonaws.com"],
+              variable: "kms:ViaService",
+            },
+          ],
+          effect: "Allow",
+          principals: [
+            {
+              identifiers: [stack.resolve(role.roleArn)],
+              type: "AWS",
+            },
+          ],
+          resources: ["*"],
+        },
+      ]),
+    },
+  );
+});
+
+test("grantWrite", () => {
+  // GIVEN
+  const secret = new encryption.Secret(stack, "Secret", {});
+  const role = new iam.Role(stack, "Role", {
+    assumedBy: new iam.AccountRootPrincipal(),
+  });
+
+  // WHEN
+  secret.grantWrite(role);
+
+  // THEN
+  Template.synth(stack).toHaveDataSourceWithProperties(
+    dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+    {
+      statement: [
+        {
+          actions: [
+            "secretsmanager:PutSecretValue",
+            "secretsmanager:UpdateSecret",
+            "secretsmanager:UpdateSecretVersionStage",
+          ],
+          effect: "Allow",
+          resources: [stack.resolve(secret.secretArn)],
+        },
+      ],
+    },
+  );
+});
+
+test("grantWrite with kms", () => {
+  // GIVEN
+  const key = new encryption.Key(stack, "KMS");
+  const secret = new encryption.Secret(stack, "Secret", {
+    encryptionKey: key,
+  });
+  const role = new iam.Role(stack, "Role", {
+    assumedBy: new iam.AccountRootPrincipal(),
+  });
+
+  // WHEN
+  secret.grantWrite(role);
+
+  // THEN
+  const t = new Template(stack, { snapshot: true });
+  t.expect.toHaveDataSourceWithProperties(
+    dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+    {
+      statement: [
+        {
+          actions: [
+            "secretsmanager:PutSecretValue",
+            "secretsmanager:UpdateSecret",
+            "secretsmanager:UpdateSecretVersionStage",
+          ],
+          effect: "Allow",
+          resources: [stack.resolve(secret.secretArn)],
+        },
+      ],
+    },
+  );
+  t.expect.toHaveDataSourceWithProperties(
+    dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+    {
+      statement: expect.arrayContaining([
+        {
+          actions: ["kms:Encrypt", "kms:ReEncrypt*", "kms:GenerateDataKey*"],
+          condition: [
+            {
+              test: "StringEquals",
+              values: ["secretsmanager.us-east-1.amazonaws.com"],
+              variable: "kms:ViaService",
+            },
+          ],
+          effect: "Allow",
+          principals: [
+            {
+              identifiers: [stack.resolve(role.roleArn)],
+              type: "AWS",
+            },
+          ],
+          resources: ["*"],
+        },
+      ]),
+    },
+  );
+});
+
+// NOTE (TerraConstructs deviation, combined-landing breadcrumb): upstream's `secretValue` test
+// (`secret.secretValue` / `secretValueFromJson`) is dropped. `core.SecretValue` / CloudFormation
+// dynamic references are not ported in this repo -- see the `ISecret` NOTE in `secret.ts`. Use
+// `SecretProps.secretStringValue` / `secretObjectValue` to seed a concrete value instead.
+
+describe("secretName", () => {
+  test("selects the first two parts of the resource name when the name is auto-generated", () => {
+    const secret = new encryption.Secret(stack, "Secret");
+    new TerraformOutput(stack, "MySecretName", {
+      value: secret.secretName,
+    });
+
+    const t = new Template(stack, { snapshot: true });
+    const output = t.outputByName("MySecretName");
+    expect(output).toEqual({
+      value: stack.resolve(secret.secretName),
+    });
+  });
+
+  test("is simply the first segment when the provided secret name has no hyphens", () => {
+    const secret = new encryption.Secret(stack, "Secret", {
+      secretName: "mySecret",
+    });
+    new TerraformOutput(stack, "MySecretName", {
+      value: secret.secretName,
+    });
+
+    const t = new Template(stack, { snapshot: true });
+    const output = t.outputByName("MySecretName");
+    expect(output).toEqual({
+      value: stack.resolve(secret.secretName),
+    });
+  });
+
+  function assertSegments(secret: encryption.Secret) {
+    new TerraformOutput(stack, "MySecretName", {
+      value: secret.secretName,
+    });
+
+    const t = new Template(stack, { snapshot: true });
+    const output = t.outputByName("MySecretName");
+    expect(output).toEqual({
+      value: stack.resolve(secret.secretName),
+    });
+  }
+
+  test("selects the 2 parts of the resource name when the secret name is provided", () => {
+    const secret = new encryption.Secret(stack, "Secret", {
+      secretName: "my-secret",
+    });
+    assertSegments(secret);
+  });
+
+  test("selects the 3 parts of the resource name when the secret name is provided", () => {
+    const secret = new encryption.Secret(stack, "Secret", {
+      secretName: "my-secret-hyphenated",
+    });
+    assertSegments(secret);
+  });
+
+  test("selects the 4 parts of the resource name when the secret name is provided", () => {
+    const secret = new encryption.Secret(stack, "Secret", {
+      secretName: "my-secret-with-hyphens",
+    });
+    assertSegments(secret);
+  });
+});
+
+test("import by secretArn throws if ARN is malformed", () => {
+  // GIVEN
+  const arnWithoutResourceName =
+    "arn:aws:secretsmanager:eu-west-1:111111111111:secret";
+
+  // WHEN
+  expect(() =>
+    encryption.Secret.fromSecretAttributes(stack, "Secret1", {
+      secretPartialArn: arnWithoutResourceName,
+    }),
+  ).toThrow(/invalid ARN format/);
+});
+
+test("import by secretArn supports tokens for ARNs", () => {
+  // GIVEN
+  const stackB = new AwsStack(app, "TestStack", {
+    environmentName,
+    gridUUID: gridUUID2,
+    providerConfig,
+    gridBackendConfig,
+  });
+  const secretA = new encryption.Secret(stack, "SecretA");
+
+  // WHEN
+  const secretB = encryption.Secret.fromSecretCompleteArn(
+    stackB,
+    "SecretB",
+    secretA.secretArn,
+  );
+  new TerraformOutput(stackB, "secretBSecretName", {
+    value: secretB.secretName,
+  });
+
+  // THEN
+  expect(secretB.secretArn).toBe(secretA.secretArn);
+  const t = new Template(stackB, { snapshot: true });
+  const output = t.outputByName("secretBSecretName");
+  expect(output).toEqual({
+    value: expect.stringMatching(
+      /^\$\{element\(split\(":", data\.terraform_remote_state\.cross-stack-reference-input-MyStack\.outputs\.cross-stack-output-aws_secretsmanager_secretSecretA_[0-9A-F]+arn\), 6\)\}$/,
+    ),
+  });
+});
+
+test("fromSecretCompleteArn", () => {
+  // GIVEN
+  const secretArn =
+    "arn:aws:secretsmanager:eu-west-1:111111111111:secret:MySecret-f3gDy9";
+
+  // WHEN
+  const secret = encryption.Secret.fromSecretCompleteArn(
+    stack,
+    "Secret",
+    secretArn,
+  );
+
+  // THEN
+  expect(secret.secretArn).toBe(secretArn);
+  expect(secret.secretFullArn).toBe(secretArn);
+  expect(secret.secretName).toBe("MySecret");
+  expect(secret.encryptionKey).toBeUndefined();
+  // NOTE: upstream also asserts `stack.resolve(secret.secretValue)` /
+  // `secret.secretValueFromJson(...)` here -- dropped, see the breadcrumb near
+  // `describe("secretName")` above.
+});
+
+test("fromSecretCompleteArn - grants", () => {
+  // GIVEN
+  const secretArn =
+    "arn:aws:secretsmanager:eu-west-1:111111111111:secret:MySecret-f3gDy9";
+  const secret = encryption.Secret.fromSecretCompleteArn(
+    stack,
+    "Secret",
+    secretArn,
+  );
+  const role = new iam.Role(stack, "Role", {
+    assumedBy: new iam.AccountRootPrincipal(),
+  });
+
+  // WHEN
+  secret.grantRead(role);
+  secret.grantWrite(role);
+
+  // THEN
+  Template.synth(stack).toHaveDataSourceWithProperties(
+    dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+    {
+      statement: [
+        {
+          actions: [
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:DescribeSecret",
+          ],
+          effect: "Allow",
+          resources: [secretArn],
+        },
+        {
+          actions: [
+            "secretsmanager:PutSecretValue",
+            "secretsmanager:UpdateSecret",
+            "secretsmanager:UpdateSecretVersionStage",
+          ],
+          effect: "Allow",
+          resources: [secretArn],
+        },
+      ],
+    },
+  );
+});
+
+// NOTE (TerraConstructs deviation, combined-landing breadcrumb): upstream's
+// "fromSecretCompleteArn - can be assigned to a property with type number" test threaded
+// `secret.secretValueFromJson(...)` through `Token.asNumber(...)` into a Lambda's `memorySize`.
+// Dropped along with `secretValueFromJson` -- see the breadcrumb near `describe("secretName")`
+// above.
+
+test("fromSecretPartialArn", () => {
+  // GIVEN
+  const secretArn =
+    "arn:aws:secretsmanager:eu-west-1:111111111111:secret:MySecret";
+
+  // WHEN
+  const secret = encryption.Secret.fromSecretPartialArn(
+    stack,
+    "Secret",
+    secretArn,
+  );
+
+  // THEN
+  expect(secret.secretArn).toBe(secretArn);
+  expect(secret.secretFullArn).toBeUndefined();
+  expect(secret.secretName).toBe("MySecret");
+  expect(secret.encryptionKey).toBeUndefined();
+  // NOTE: upstream also asserts `stack.resolve(secret.secretValue)` /
+  // `secret.secretValueFromJson(...)` here -- dropped, see the breadcrumb near
+  // `describe("secretName")` above.
+});
+
+test("fromSecretPartialArn preserves a secret name whose trailing hyphen-separated segment is 6 characters", () => {
+  // GIVEN: a partial ARN by definition carries no Secrets Manager-supplied
+  // suffix, so a trailing "-abcdef" here is part of the real secret name,
+  // not a suffix to strip.
+  const secretArn =
+    "arn:aws:secretsmanager:us-east-1:111122223333:secret:orders-abcdef";
+
+  // WHEN
+  const secret = encryption.Secret.fromSecretPartialArn(
+    stack,
+    "Secret",
+    secretArn,
+  );
+
+  // THEN
+  expect(secret.secretName).toBe("orders-abcdef");
+  expect(secret.secretArn).toBe(secretArn);
+  expect(secret.secretFullArn).toBeUndefined();
+});
+
+test("fromSecretCompleteArn still strips the Secrets Manager 6-character suffix", () => {
+  // GIVEN: a complete ARN DOES carry the AWS-supplied suffix, so it must
+  // still be stripped from `secretName`.
+  const secretArn =
+    "arn:aws:secretsmanager:us-east-1:111122223333:secret:orders-abcdef";
+
+  // WHEN
+  const secret = encryption.Secret.fromSecretCompleteArn(
+    stack,
+    "Secret",
+    secretArn,
+  );
+
+  // THEN
+  expect(secret.secretName).toBe("orders");
+  expect(secret.secretFullArn).toBe(secretArn);
+});
+
+test("fromSecretPartialArn - grants", () => {
+  // GIVEN
+  const secretArn =
+    "arn:aws:secretsmanager:eu-west-1:111111111111:secret:MySecret";
+  const secret = encryption.Secret.fromSecretPartialArn(
+    stack,
+    "Secret",
+    secretArn,
+  );
+  const role = new iam.Role(stack, "Role", {
+    assumedBy: new iam.AccountRootPrincipal(),
+  });
+
+  // WHEN
+  secret.grantRead(role);
+  secret.grantWrite(role);
+
+  // THEN
+  Template.synth(stack).toHaveDataSourceWithProperties(
+    dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+    {
+      statement: [
+        {
+          actions: [
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:DescribeSecret",
+          ],
+          effect: "Allow",
+          resources: [`${secretArn}-??????`],
+        },
+        {
+          actions: [
+            "secretsmanager:PutSecretValue",
+            "secretsmanager:UpdateSecret",
+            "secretsmanager:UpdateSecretVersionStage",
+          ],
+          effect: "Allow",
+          resources: [`${secretArn}-??????`],
+        },
+      ],
+    },
+  );
+});
+
+describe("fromSecretAttributes", () => {
+  test("import by attributes", () => {
+    // GIVEN
+    const encryptionKey = new encryption.Key(stack, "KMS");
+    const secretArn =
+      "arn:aws:secretsmanager:eu-west-1:111111111111:secret:MySecret-f3gDy9";
+
+    // WHEN
+    const secret = encryption.Secret.fromSecretAttributes(stack, "Secret", {
+      secretCompleteArn: secretArn,
+      encryptionKey,
+    });
+
+    // THEN
+    expect(secret.secretArn).toBe(secretArn);
+    expect(secret.secretFullArn).toBe(secretArn);
+    expect(secret.secretName).toBe("MySecret");
+    expect(secret.encryptionKey).toBe(encryptionKey);
+    // NOTE: upstream also asserts `stack.resolve(secret.secretValue)` /
+    // `secret.secretValueFromJson(...)` here -- dropped, see the breadcrumb near
+    // `describe("secretName")` above.
+  });
+
+  // v2.233 currency addition (run-3): exercises the deprecated `SecretAttributes.secretArn`
+  // field's cross-validation against `secretCompleteArn`/`secretPartialArn` -- ported from run-3's
+  // secret.test.ts (upstream: testDeprecated(...), converted to a plain `test` since
+  // `testDeprecated` -- an `@aws-cdk/cdk-build-tools` test-harness helper that only suppresses
+  // deprecation-usage warnings during the test -- isn't ported in this repo and has no bearing on
+  // the assertion itself).
+  test("throws if secretArn and either secretCompleteArn or secretPartialArn are provided", () => {
+    const secretArn =
+      "arn:aws:secretsmanager:eu-west-1:111111111111:secret:MySecret-f3gDy9";
+
+    const error =
+      /cannot use `secretArn` with `secretCompleteArn` or `secretPartialArn`/;
+    expect(() =>
+      encryption.Secret.fromSecretAttributes(stack, "Secret", {
+        secretArn,
+        secretCompleteArn: secretArn,
+      }),
+    ).toThrow(error);
+    expect(() =>
+      encryption.Secret.fromSecretAttributes(stack, "Secret", {
+        secretArn,
+        secretPartialArn: secretArn,
+      }),
+    ).toThrow(error);
+  });
+
+  test("throws if no ARN is provided", () => {
+    expect(() =>
+      encryption.Secret.fromSecretAttributes(stack, "Secret", {}),
+    ).toThrow(/must use only one of `secretCompleteArn` or `secretPartialArn`/);
+  });
+
+  test("throws if both complete and partial ARNs are provided", () => {
+    const secretArn =
+      "arn:aws:secretsmanager:eu-west-1:111111111111:secret:MySecret-f3gDy9";
+    expect(() =>
+      encryption.Secret.fromSecretAttributes(stack, "Secret", {
+        secretPartialArn: secretArn,
+        secretCompleteArn: secretArn,
+      }),
+    ).toThrow(/must use only one of `secretCompleteArn` or `secretPartialArn`/);
+  });
+
+  test("throws if secretCompleteArn is not complete", () => {
+    expect(() =>
+      encryption.Secret.fromSecretAttributes(stack, "Secret", {
+        secretCompleteArn:
+          "arn:aws:secretsmanager:eu-west-1:111111111111:secret:MySecret",
+      }),
+    ).toThrow(/does not appear to be complete/);
+  });
+
+  test("parses environment from secretArn", () => {
+    // GIVEN
+    const secretAccount = "222222222222";
+
+    // WHEN
+    const secret = encryption.Secret.fromSecretAttributes(stack, "Secret", {
+      secretCompleteArn: `arn:aws:secretsmanager:eu-west-1:${secretAccount}:secret:MySecret-f3gDy9`,
+    });
+
+    // THEN
+    expect(secret.env.account).toBe(secretAccount);
+  });
+});
+
+// v2.233 currency addition (run-3): `Secret.fromSecretName` -- ported from run-3's
+// secret.test.ts (upstream: testDeprecated(...), converted to a plain `test`, see the note on
+// "throws if secretArn and either secretCompleteArn or secretPartialArn are provided" above).
+test("import by secret name", () => {
+  // GIVEN
+  const secretName = "MySecret";
+
+  // WHEN
+  const secret = encryption.Secret.fromSecretName(stack, "Secret", secretName);
+
+  // THEN
+  expect(secret.secretArn).toBe(secretName);
+  expect(secret.secretName).toBe(secretName);
+  expect(secret.secretFullArn).toBeUndefined();
+  // NOTE: upstream also asserts `stack.resolve(secret.secretValue)` /
+  // `secret.secretValueFromJson(...)` here -- dropped, see the breadcrumb near
+  // `describe("secretName")` above.
+});
+
+test("import by secret name with grants", () => {
+  // GIVEN
+  const role = new iam.Role(stack, "Role", {
+    assumedBy: new iam.AccountRootPrincipal(),
+  });
+  const secret = encryption.Secret.fromSecretName(stack, "Secret", "MySecret");
+
+  // WHEN
+  secret.grantRead(role);
+  secret.grantWrite(role);
+
+  // THEN
+  const expectedSecretReference =
+    "arn:${data.aws_partition.Partitition.partition}:secretsmanager:us-east-1:${data.aws_caller_identity.CallerIdentity.account_id}:secret:MySecret*";
+  Template.synth(stack).toHaveDataSourceWithProperties(
+    dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+    {
+      statement: [
+        {
+          actions: [
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:DescribeSecret",
+          ],
+          effect: "Allow",
+          resources: [expectedSecretReference],
+        },
+        {
+          actions: [
+            "secretsmanager:PutSecretValue",
+            "secretsmanager:UpdateSecret",
+            "secretsmanager:UpdateSecretVersionStage",
+          ],
+          effect: "Allow",
+          resources: [expectedSecretReference],
+        },
+      ],
+    },
+  );
+});
+
+test("import by secret name v2", () => {
+  // GIVEN
+  const secretName = "MySecret";
+
+  // WHEN
+  const secret = encryption.Secret.fromSecretNameV2(
+    stack,
+    "Secret",
+    secretName,
+  );
+
+  // THEN
+  expect(secret.secretArn).toBe(
+    `arn:${stack.partition}:secretsmanager:${stack.region}:${stack.account}:secret:MySecret`,
+  );
+  expect(secret.secretName).toBe(secretName);
+  expect(secret.secretFullArn).toBeUndefined();
+  // NOTE: upstream also asserts `stack.resolve(secret.secretValue)` here -- dropped, see the
+  // breadcrumb near `describe("secretName")` above.
+});
+
+test("import by secret name v2 with grants", () => {
+  // GIVEN
+  const role = new iam.Role(stack, "Role", {
+    assumedBy: new iam.AccountRootPrincipal(),
+  });
+  const secret = encryption.Secret.fromSecretNameV2(
+    stack,
+    "Secret",
+    "MySecret",
+  );
+
+  // WHEN
+  secret.grantRead(role);
+  secret.grantWrite(role);
+
+  // THEN
+  const expectedSecretReference =
+    "arn:${data.aws_partition.Partitition.partition}:secretsmanager:us-east-1:${data.aws_caller_identity.CallerIdentity.account_id}:secret:MySecret-??????";
+  Template.synth(stack).toHaveDataSourceWithProperties(
+    dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+    {
+      statement: [
+        {
+          actions: [
+            "secretsmanager:GetSecretValue",
+            "secretsmanager:DescribeSecret",
+          ],
+          effect: "Allow",
+          resources: [expectedSecretReference],
+        },
+        {
+          actions: [
+            "secretsmanager:PutSecretValue",
+            "secretsmanager:UpdateSecret",
+            "secretsmanager:UpdateSecretVersionStage",
+          ],
+          effect: "Allow",
+          resources: [expectedSecretReference],
+        },
+      ],
+    },
+  );
+});
+
+describe("attachment", () => {
+  // Small in-test mock target implementing ISecretAttachmentTarget. Real
+  // implementers (DatabaseInstance/DatabaseCluster/DatabaseProxy from
+  // aws-rds, and the DocDB/Redshift equivalents) are not yet ported to
+  // TerraConstructs -- see the JSDoc on `ISecretAttachmentTarget`.
+  function mockTarget(
+    targetId = "target-id",
+  ): encryption.ISecretAttachmentTarget {
+    return {
+      asSecretAttachmentTarget: () => ({
+        targetId,
+        targetType: encryption.AttachmentTargetType.DOCDB_DB_INSTANCE,
+      }),
+    };
+  }
+
+  test("attach() merges the target's connection details into the secret's single version", () => {
+    // GIVEN
+    const secret = new encryption.Secret(stack, "Secret", {
+      generateSecretString: {
+        secretStringTemplate: JSON.stringify({ username: "admin" }),
+        generateStringKey: "password",
+      },
+    });
+    const asSecretAttachmentTarget = jest.fn().mockReturnValue({
+      targetId: "target-id",
+      targetType: encryption.AttachmentTargetType.RDS_DB_INSTANCE,
+      connectionFields: {
+        engine: "postgres",
+        host: "db.example.com",
+        port: "5432",
+        dbname: "appdb",
+      },
+    });
+
+    // WHEN
+    const attached = secret.attach({ asSecretAttachmentTarget });
+
+    // THEN
+    expect(asSecretAttachmentTarget).toHaveBeenCalled();
+    // No separate CloudFormation-style SecretTargetAttachment resource exists
+    // in Terraform, so the "attached" secret mirrors the original secret's
+    // ARN/name.
+    expect(attached.secretArn).toBe(secret.secretArn);
+    expect(attached.secretName).toBe(secret.secretName);
+
+    // Exactly ONE secret version is synthesized for the secret (no conflicting
+    // second AWSCURRENT version), and its value merges the target's connection
+    // details over the base credentials via merge(jsondecode(base), fields).
+    const versions = Template.resourceObjects(
+      stack,
+      secretsmanagerSecretVersion.SecretsmanagerSecretVersion,
+    );
+    expect(Object.keys(versions)).toHaveLength(1);
+    const secretString = (Object.values(versions)[0] as any)
+      .secret_string as string;
+    expect(secretString).toContain("merge(");
+    expect(secretString).toContain("jsondecode(");
+    expect(secretString).toContain("db.example.com");
+    expect(secretString).toContain("appdb");
+  });
+
+  function mockTargetWithConnectionFields(connectionFields: {
+    [key: string]: string;
+  }): encryption.ISecretAttachmentTarget {
+    return {
+      asSecretAttachmentTarget: () => ({
+        targetId: "target-id",
+        targetType: encryption.AttachmentTargetType.RDS_DB_INSTANCE,
+        connectionFields,
+      }),
+    };
+  }
+
+  test("attach() with connectionFields throws when the secret's base value is not a JSON object (default)", () => {
+    // GIVEN: default Secret -- SecretsManager generates a scalar random password.
+    const secret = new encryption.Secret(stack, "Secret");
+
+    // WHEN/THEN
+    expect(() =>
+      secret.attach(mockTargetWithConnectionFields({ engine: "postgres" })),
+    ).toThrow(
+      /Cannot merge attachment connectionFields into this Secret because its value is not a JSON object\. Use secretObjectValue, or generateSecretString with a secretStringTemplate\./,
+    );
+  });
+
+  test("attach() with connectionFields throws when secretStringValue is a scalar", () => {
+    // GIVEN
+    const secret = new encryption.Secret(stack, "Secret", {
+      secretStringValue: "plain-string",
+    });
+
+    // WHEN/THEN
+    expect(() =>
+      secret.attach(mockTargetWithConnectionFields({ engine: "postgres" })),
+    ).toThrow(
+      /Cannot merge attachment connectionFields into this Secret because its value is not a JSON object\./,
+    );
+  });
+
+  test("attach() with connectionFields succeeds when secretObjectValue is a JSON object", () => {
+    // GIVEN
+    const secret = new encryption.Secret(stack, "Secret", {
+      secretObjectValue: {
+        username: "admin",
+        password: "hunter2",
+      },
+    });
+
+    // WHEN
+    const attached = secret.attach(
+      mockTargetWithConnectionFields({
+        engine: "postgres",
+        host: "db.example.com",
+      }),
+    );
+
+    // THEN: exactly one version is synthesized, merging the connection fields
+    // over the base JSON object.
+    expect(attached.secretArn).toBe(secret.secretArn);
+    const versions = Template.resourceObjects(
+      stack,
+      secretsmanagerSecretVersion.SecretsmanagerSecretVersion,
+    );
+    expect(Object.keys(versions)).toHaveLength(1);
+    const secretString = (Object.values(versions)[0] as any)
+      .secret_string as string;
+    expect(secretString).toContain("merge(");
+    expect(secretString).toContain("jsondecode(");
+    expect(secretString).toContain("db.example.com");
+  });
+
+  test("attach() with connectionFields throws for an imported secret", () => {
+    // GIVEN
+    const imported = encryption.Secret.fromSecretCompleteArn(
+      stack,
+      "Imported",
+      "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-imported-secret-Ab12Cd",
+    );
+
+    // WHEN/THEN
+    expect(() =>
+      imported.attach(mockTargetWithConnectionFields({ engine: "postgres" })),
+    ).toThrow(
+      /Cannot merge attachment connectionFields into an imported secret; attach\(\) with connectionFields is only supported for owned Secret constructs\./,
+    );
+  });
+
+  test("attach() adds no second version and the single version is idempotent across synth passes", () => {
+    // GIVEN
+    const secret = new encryption.Secret(stack, "Secret");
+
+    // WHEN
+    secret.attach(mockTarget());
+
+    // THEN
+    // The sole version is created in Secret.toTerraform() (invoked by
+    // prepareStack on every synth pass) and guarded by `tryFindChild`, so
+    // attach() adds NO second version and re-synth must not raise the count.
+    expect(
+      Object.keys(
+        Template.resourceObjects(
+          stack,
+          secretsmanagerSecretVersion.SecretsmanagerSecretVersion,
+        ),
+      ),
+    ).toHaveLength(1);
+    expect(
+      Object.keys(
+        Template.resourceObjects(
+          stack,
+          secretsmanagerSecretVersion.SecretsmanagerSecretVersion,
+        ),
+      ),
+    ).toHaveLength(1);
+  });
+
+  test("throws when trying to attach a target multiple times to a secret", () => {
+    // GIVEN
+    const secret = new encryption.Secret(stack, "Secret");
+    const target = mockTarget();
+    secret.attach(target);
+
+    // THEN
+    expect(() => secret.attach(target)).toThrow(
+      /Secret is already attached to a target/,
+    );
+  });
+
+  test("add a rotation schedule to an attached secret", () => {
+    // GIVEN
+    const secret = new encryption.Secret(stack, "Secret");
+    const attachedSecret = secret.attach(mockTarget());
+    const rotationLambda = new compute.LambdaFunction(stack, "Lambda", {
+      runtime: compute.Runtime.NODEJS_LATEST,
+      code: compute.Code.fromInline("exports.handler = event => event;"),
+      handler: "index.handler",
+    });
+
+    // WHEN
+    attachedSecret.addRotationSchedule("RotationSchedule", {
+      rotationLambda,
+    });
+
+    // THEN
+    // The rotation schedule is created against the original secret's ARN,
+    // since the "attached" secret returned by attach() mirrors it (see
+    // attach() test above).
+    Template.synth(stack).toHaveResourceWithProperties(
+      secretsmanagerSecretRotation.SecretsmanagerSecretRotation,
+      {
+        secret_id: stack.resolve(secret.secretArn),
+      },
+    );
+  });
+
+  test("addToResourcePolicy on the attachment forwards to the original secret (single policy)", () => {
+    // GIVEN
+    const secret = new encryption.Secret(stack, "Secret");
+    const attachedSecret = secret.attach(mockTarget());
+
+    // WHEN
+    secret.addToResourcePolicy(
+      new iam.PolicyStatement({
+        actions: ["secretsmanager:GetSecretValue"],
+        resources: ["*"],
+        principals: [
+          new iam.ArnPrincipal("arn:aws:iam::123456789012:user/cool-user"),
+        ],
+      }),
+    );
+    attachedSecret.addToResourcePolicy(
+      new iam.PolicyStatement({
+        actions: ["secretsmanager:DescribeSecret"],
+        resources: ["*"],
+        principals: [
+          new iam.ArnPrincipal("arn:aws:iam::123456789012:user/other-user"),
+        ],
+      }),
+    );
+
+    // THEN
+    const template = new Template(stack);
+    template.resourceCountIs(
+      secretsmanagerSecretPolicy.SecretsmanagerSecretPolicy,
+      1,
+    );
+  });
+});
+
+test("throws when specifying secretStringTemplate but not generateStringKey", () => {
+  expect(
+    () =>
+      new encryption.Secret(stack, "Secret", {
+        generateSecretString: {
+          secretStringTemplate: JSON.stringify({ username: "username" }),
+        },
+      }),
+  ).toThrow(/`secretStringTemplate`.+`generateStringKey`/);
+});
+
+test("throws when specifying generateStringKey but not secretStringTemplate", () => {
+  expect(
+    () =>
+      new encryption.Secret(stack, "Secret", {
+        generateSecretString: {
+          generateStringKey: "password",
+        },
+      }),
+  ).toThrow(/`secretStringTemplate`.+`generateStringKey`/);
+});
+
+test("can add to the resource policy of a secret", () => {
+  // GIVEN
+  const secret = new encryption.Secret(stack, "Secret");
+
+  // WHEN
+  secret.addToResourcePolicy(
+    new iam.PolicyStatement({
+      actions: ["secretsmanager:GetSecretValue"],
+      resources: ["*"],
+      principals: [
+        new iam.ArnPrincipal("arn:aws:iam::123456789012:user/cool-user"),
+      ],
+    }),
+  );
+
+  // THEN
+  Template.synth(stack).toHaveDataSourceWithProperties(
+    dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+    {
+      statement: [
+        {
+          actions: ["secretsmanager:GetSecretValue"],
+          effect: "Allow",
+          principals: [
+            {
+              identifiers: ["arn:aws:iam::123456789012:user/cool-user"],
+              type: "AWS",
+            },
+          ],
+          resources: ["*"],
+        },
+      ],
+    },
+  );
+});
+
+test("fails if secret policy has no actions", () => {
+  // GIVEN
+  const secret = new encryption.Secret(stack, "Secret");
+
+  // WHEN
+  secret.addToResourcePolicy(
+    new iam.PolicyStatement({
+      resources: ["*"],
+      principals: [new iam.ArnPrincipal("arn")],
+    }),
+  );
+
+  // THEN
+  expect(() => app.synth()).toThrow(
+    /A PolicyStatement must specify at least one \'action\' or \'notAction\'/,
+  );
+});
+
+test("fails if secret policy has no IAM principals", () => {
+  // GIVEN
+  const secret = new encryption.Secret(stack, "Secret");
+
+  // WHEN
+  secret.addToResourcePolicy(
+    new iam.PolicyStatement({
+      resources: ["*"],
+      actions: ["secretsmanager:*"],
+    }),
+  );
+
+  // THEN
+  expect(() => app.synth()).toThrow(
+    /A PolicyStatement used in a resource-based policy must specify at least one IAM principal/,
+  );
+});
+
+test("with replication regions", () => {
+  // WHEN
+  const secret = new encryption.Secret(stack, "Secret", {
+    replicaRegions: [{ region: "eu-west-1" }],
+  });
+  secret.addReplicaRegion(
+    "eu-central-1",
+    encryption.Key.fromKeyArn(
+      stack,
+      "Key",
+      "arn:aws:kms:eu-central-1:123456789012:key/my-key-id",
+    ),
+  );
+
+  // THEN
+  Template.synth(stack).toHaveResourceWithProperties(
+    secretsmanagerSecret.SecretsmanagerSecret,
+    {
+      replica: [
+        {
+          region: "eu-west-1",
+        },
+        {
+          kmsKeyId: "arn:aws:kms:eu-central-1:123456789012:key/my-key-id",
+          region: "eu-central-1",
+        },
+      ],
+    },
+  );
+});
+
+describe("secretObjectValue", () => {
+  test("can be used with a mixture of plain text and a resolvable token", () => {
+    const role = new iam.Role(stack, "Role", {
+      assumedBy: new iam.ServicePrincipal("ec2.amazonaws.com"),
+    });
+    new encryption.Secret(stack, "Secret", {
+      secretObjectValue: {
+        username: "username",
+        password: role.roleArn,
+      },
+    });
+
+    const t = new Template(stack, { snapshot: true });
+    // GenerateSecretString: Match.absent(),
+    t.expect.not.toHaveDataSource(
+      dataAwsSecretsmanagerRandomPassword.DataAwsSecretsmanagerRandomPassword,
+    );
+    t.expect.toHaveResourceWithProperties(
+      secretsmanagerSecretVersion.SecretsmanagerSecretVersion,
+      {
+        secret_string: `\${jsonencode({"username" = "username", "password" = ${stack
+          .resolve(role.roleArn)
+          .replace(/^\$\{/, "")
+          .replace(/\}$/, "")}})}`,
+      },
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Combined landing of AWS CDK's `aws-secretsmanager` L2 constructs (`src/aws/encryption/`), superseding #117. This PR merges #117's `Secret.attach()` design with run-3's blind-conversion breadth against v2.233.0, per the adjudication in `report-run3-aws-secretsmanager.md` (opus, "reference is not an oracle" framing).

## Why a combination, not just #117

Run 3 was a blind re-conversion of `aws-secretsmanager` (agents forbidden from reading #117 or `base`), then evaluated against #117 afterward. The adjudication found genuine wins on both sides:

- **#117 wins decisively on `attach()` design.** Run-3's pipeline used an eager-version + throw-if-version guard, which inverts the canonical usage pattern (`new Secret().attach(db)` would throw) and, on the imported-only path, clobbers `AWSCURRENT` with connection fields — dropping the credential. #117's **lazy single-version** (created in `toTerraform()`, first `prepareStack()` pass) + `jsonencode(merge(jsondecode(base), connectionFields))` matches upstream semantics and avoids a second conflicting version. **Adopted from #117.**
- **`generate_secret_string` defaults and `recoveryWindow`: #117 wins.** Run-3 over-dropped `recoveryWindow` (a plain provider number needing no `RemovalPolicy` machinery) and #117 pins the two load-bearing password-generation defaults correctly. **Adopted from #117.**
- **v2.233 breadth: run-3 wins.** Run-3 independently derived the zero-duration-rotation `ValidationError` that #117 only gained after external review, and mapped `CfnSecretTargetAttachment` to the composition (`aws_secretsmanager_secret_version` + target family) blind — the same design #117 arrived at, without seeing it. Run-3 also ships `secret-rotation.ts` (dedicated rotation-lambda construct), broader test coverage, and closer alignment with the pinned v2.233 upstream surface. **Adopted from run-3**, including `secret-rotation.ts`.
- **`SecretValue` surface: dropped from both.** #117's plaintext-`string` stubs are a quiet security downgrade (no upstream no-plaintext guarantee once in TF state) versus run-3's clean omission. Landing keeps the drop, pending a real `core.SecretValue`/ephemeral-resource port (CDKTN ephemeral resources are still unavailable).

## What came from where

| Area | Source | Notes |
|---|---|---|
| `secret.ts` — `Secret`/`SecretBase`/`ISecret`, `attach()`, lazy version | #117 core | zero-duration-rotation guard reconciled with run-3's independently-derived version |
| `policy.ts` — `ResourcePolicy` | run-3 | |
| `rotation-schedule.ts` — `RotationSchedule` + `HostedRotation` | run-3 | `HostedRotation` still throws (no Terraform equivalent) |
| `secret-rotation.ts` — dedicated rotation-lambda construct | run-3 | not present in #117 |
| Test suites / snapshots | run-3 breadth | superset of #117's coverage |
| `SecretValue` stubs | neither | dropped pending `core.SecretValue` |

Credit to #117 for the `attach()` composition design (working around Terraform having no `AWS::SecretsManager::SecretTargetAttachment` equivalent — see the [HashiCorp design-decision doc](https://github.com/hashicorp/terraform-provider-aws/blob/main/docs/design-decisions/secretsmanager-secret-target-attachment.md) it cites) and its post-review fixes, which form the core of this PR.

## Stacked order

`main` → #118 (servicediscovery) → #119 (autoscaling) → **this PR**. Base is `convert-aws-autoscaling`; GitHub will retarget as the earlier PRs in the stack merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
