### PR TITLE
feat(aws): make Tags.of() support Auto Scaling group tags

### DIFF
--- a/integ/aws/compute/apps/autoscaling.custom-scaling.ts
+++ b/integ/aws/compute/apps/autoscaling.custom-scaling.ts
@@ -70,9 +70,12 @@ aws.Tags.of(asg).add("notsuper", "caramel", {
 // creates four `aws_autoscaling_schedule` resources concurrently and AWS
 // rejects concurrent PutScheduledUpdateGroupAction calls on one group with
 // `AlreadyExists: Scheduled action with this scheduled start time already
-// exists`. The action that loses varies per run. Until the construct
-// serializes them, deploy this fixture with `tofu apply -parallelism=1`,
-// which creates all four cleanly.
+// exists`. The action that loses varies per run.
+//
+// `TestAutoscalingCustomScaling` (integ/aws/compute/autoscaling_test.go)
+// registers that error as retryable so terratest re-runs the apply, which
+// succeeds because only the missing action is left to create. Deploying this
+// fixture by hand needs `tofu apply -parallelism=1` instead.
 asg.scaleOnSchedule("ScaleUpInTheMorning", {
   schedule: aws.compute.autoscaling.Schedule.cron({ hour: "8", minute: "0" }),
   minCapacity: 5,

--- a/integ/aws/compute/apps/autoscaling.custom-scaling.ts
+++ b/integ/aws/compute/apps/autoscaling.custom-scaling.ts
@@ -57,6 +57,14 @@ const asg = new aws.compute.autoscaling.AutoScalingGroup(stack, "Fleet", {
   outputName: "fleet",
 });
 
+// Terraform deviation: `aws_autoscaling_group` renders tags as repeated
+// `tag { key, value, propagate_at_launch }` blocks, so `Tags.of()` has to
+// merge into that shape instead of a flat `tags` map.
+aws.Tags.of(asg).add("superfood", "acai");
+aws.Tags.of(asg).add("notsuper", "caramel", {
+  applyToLaunchedInstances: false,
+});
+
 asg.scaleOnSchedule("ScaleUpInTheMorning", {
   schedule: aws.compute.autoscaling.Schedule.cron({ hour: "8", minute: "0" }),
   minCapacity: 5,

--- a/integ/aws/compute/apps/autoscaling.custom-scaling.ts
+++ b/integ/aws/compute/apps/autoscaling.custom-scaling.ts
@@ -65,6 +65,14 @@ aws.Tags.of(asg).add("notsuper", "caramel", {
   applyToLaunchedInstances: false,
 });
 
+// KNOWN FLAKE - https://github.com/TerraConstructs/base/issues/127
+// None of the four scheduled actions below set `startTime`, so Terraform
+// creates four `aws_autoscaling_schedule` resources concurrently and AWS
+// rejects concurrent PutScheduledUpdateGroupAction calls on one group with
+// `AlreadyExists: Scheduled action with this scheduled start time already
+// exists`. The action that loses varies per run. Until the construct
+// serializes them, deploy this fixture with `tofu apply -parallelism=1`,
+// which creates all four cleanly.
 asg.scaleOnSchedule("ScaleUpInTheMorning", {
   schedule: aws.compute.autoscaling.Schedule.cron({ hour: "8", minute: "0" }),
   minCapacity: 5,

--- a/integ/aws/compute/autoscaling_test.go
+++ b/integ/aws/compute/autoscaling_test.go
@@ -69,6 +69,23 @@ func validateAutoscalingCustomScaling(t *testing.T, tfWorkingDir, awsRegion stri
 		assert.Equal(t, expected.propagateAtLaunch, *tag.PropagateAtLaunch, "unexpected propagate at launch for tag %q", key)
 	}
 
+	// The instance launched by the group must carry the propagating tags and NOT
+	// the one opted out. Deviation from AWS CDK v2.233.0: upstream also renders
+	// every tag into the generated launch template's TagSpecifications, which
+	// would put `notsuper` back on the instance despite PropagateAtLaunch=false.
+	require.NotEmpty(t, group.Instances, "expected the Auto Scaling group to have launched an instance")
+	require.NotNil(t, group.Instances[0].InstanceId)
+	instance := util.GetEc2InstanceDetails(t, awsRegion, *group.Instances[0].InstanceId)
+
+	instanceTags := make(map[string]string, len(instance.Tags))
+	for _, tag := range instance.Tags {
+		require.NotNil(t, tag.Key)
+		require.NotNil(t, tag.Value)
+		instanceTags[*tag.Key] = *tag.Value
+	}
+	assert.Equal(t, "acai", instanceTags["superfood"], "expected the propagating tag on the launched instance")
+	assert.NotContains(t, instanceTags, "notsuper", "expected applyToLaunchedInstances: false to keep the tag off the launched instance")
+
 	// Validate the 4 Schedule.cron() scheduled actions ported from the upstream app:
 	// ScaleUpInTheMorning, ScaleDownAtNight, ScaleUpInTheDay, ScaleUpInTheWeekDay.
 	actions := util.GetAsgScheduledActions(t, awsRegion, asgName)

--- a/integ/aws/compute/autoscaling_test.go
+++ b/integ/aws/compute/autoscaling_test.go
@@ -44,6 +44,31 @@ func validateAutoscalingCustomScaling(t *testing.T, tfWorkingDir, awsRegion stri
 	require.NotEmpty(t, ltVersion.LaunchTemplateData.InstanceType, "expected the launch template to specify an instance type")
 	assert.Equal(t, ec2types.InstanceTypeT2Micro, ltVersion.LaunchTemplateData.InstanceType)
 
+	// Validate that Tags.of() reached the `aws_autoscaling_group` `tag` blocks and
+	// that `applyToLaunchedInstances` controlled propagate-at-launch per tag.
+	asgTags := make(map[string]types.TagDescription, len(group.Tags))
+	for _, tag := range group.Tags {
+		require.NotNil(t, tag.Key)
+		asgTags[*tag.Key] = tag
+	}
+
+	for key, expected := range map[string]struct {
+		value             string
+		propagateAtLaunch bool
+	}{
+		// generated-launch-template path tags the group with its construct path
+		"Name":      {value: "autoscaling.custom-scaling/Fleet", propagateAtLaunch: true},
+		"superfood": {value: "acai", propagateAtLaunch: true},
+		"notsuper":  {value: "caramel", propagateAtLaunch: false},
+	} {
+		tag, ok := asgTags[key]
+		require.True(t, ok, "expected the Auto Scaling group to carry the %q tag", key)
+		require.NotNil(t, tag.Value)
+		assert.Equal(t, expected.value, *tag.Value, "unexpected value for tag %q", key)
+		require.NotNil(t, tag.PropagateAtLaunch)
+		assert.Equal(t, expected.propagateAtLaunch, *tag.PropagateAtLaunch, "unexpected propagate at launch for tag %q", key)
+	}
+
 	// Validate the 4 Schedule.cron() scheduled actions ported from the upstream app:
 	// ScaleUpInTheMorning, ScaleDownAtNight, ScaleUpInTheDay, ScaleUpInTheWeekDay.
 	actions := util.GetAsgScheduledActions(t, awsRegion, asgName)

--- a/integ/aws/compute/autoscaling_test.go
+++ b/integ/aws/compute/autoscaling_test.go
@@ -21,12 +21,20 @@ import (
 // which set `startTime`. Terraform creates them concurrently and AWS rejects
 // concurrent PutScheduledUpdateGroupAction calls on the same group with
 // `AlreadyExists: Scheduled action with this scheduled start time already
-// exists`, failing a different action each run. A serialized apply
-// (`tofu apply -parallelism=1`) creates all four cleanly; the deploy stage
-// here does not set parallelism, so this test can fail for that reason alone.
+// exists`, failing a different action each run.
+//
+// The retryable error below lets terratest re-run the apply: the actions that
+// did get created are already in state, so the retry creates the remaining one
+// on its own and no longer races. A serialized apply
+// (`tofu apply -parallelism=1`) also creates all four cleanly, which is the
+// manual workaround. Both are stopgaps until the construct serializes them.
 func TestAutoscalingCustomScaling(t *testing.T) {
 	options := integrationTestOptions{
 		Region: region,
+		AdditionalRetryableErrors: map[string]string{
+			// https://github.com/TerraConstructs/base/issues/127
+			".*Scheduled action with this scheduled start time already exists.*": "Concurrent PutScheduledUpdateGroupAction calls on one Auto Scaling group conflict.",
+		},
 	}
 	runComputeIntegrationTest(t, "autoscaling.custom-scaling", options, validateAutoscalingCustomScaling)
 }

--- a/integ/aws/compute/autoscaling_test.go
+++ b/integ/aws/compute/autoscaling_test.go
@@ -15,6 +15,15 @@ import (
 // Test the autoscaling.custom-scaling app
 //
 // https://github.com/aws/aws-cdk/blob/v2.233.0/packages/@aws-cdk-testing/framework-integ/test/aws-autoscaling/test/integ.custom-scaling.ts
+//
+// KNOWN FLAKE - https://github.com/TerraConstructs/base/issues/127
+// The app creates four scheduled actions on one Auto Scaling group, none of
+// which set `startTime`. Terraform creates them concurrently and AWS rejects
+// concurrent PutScheduledUpdateGroupAction calls on the same group with
+// `AlreadyExists: Scheduled action with this scheduled start time already
+// exists`, failing a different action each run. A serialized apply
+// (`tofu apply -parallelism=1`) creates all four cleanly; the deploy stage
+// here does not set parallelism, so this test can fail for that reason alone.
 func TestAutoscalingCustomScaling(t *testing.T) {
 	options := integrationTestOptions{
 		Region: region,

--- a/integ/aws/compute/function_test.go
+++ b/integ/aws/compute/function_test.go
@@ -288,6 +288,26 @@ type integrationTestOptions struct {
 	//
 	// "handlers" is always included, so this is for additional files
 	AdditionalAssets []string
+	// AdditionalRetryableErrors are error message patterns that make terratest
+	// retry `terraform apply`, mapped to the reason shown when it does.
+	//
+	// These are merged into the retryable errors every compute test already
+	// uses. Use for AWS-side races an apply can recover from by simply being
+	// run again.
+	AdditionalRetryableErrors map[string]string
+}
+
+// retryableErrors returns the errors terratest should retry an apply on: the
+// defaults shared by every compute test, plus any the caller added.
+func (o integrationTestOptions) retryableErrors() map[string]string {
+	retryable := map[string]string{
+		// TODO: Fix Dependency tree to avoid this error :(
+		".*The EventInvokeConfig for function .* could not be updated due to a concurrent update operation.*": "Failed due to concurrent update operation.",
+	}
+	for k, v := range o.AdditionalRetryableErrors {
+		retryable[k] = v
+	}
+	return retryable
 }
 
 // run integration test
@@ -312,10 +332,7 @@ func runComputeIntegrationTest(t *testing.T, testApp string, options integration
 		util.SynthApp(t, testApp, tfWorkingDir, envVars, assets...)
 	})
 	test_structure.RunTestStage(t, "deploy_terraform", func() {
-		util.DeployUsingTerraform(t, tfWorkingDir, map[string]string{
-			// TODO: Fix Dependency tree to avoid this error :(
-			".*The EventInvokeConfig for function .* could not be updated due to a concurrent update operation.*": "Failed due to concurrent update operation.",
-		})
+		util.DeployUsingTerraform(t, tfWorkingDir, options.retryableErrors())
 	})
 	test_structure.RunTestStage(t, "validate", func() {
 		validate(t, tfWorkingDir, options.Region)
@@ -339,10 +356,7 @@ func runComputeIntegrationTestWithRename(t *testing.T, testApp string, options i
 		util.SynthApp(t, testApp, tfWorkingDir, envVars, "handlers")
 	})
 	test_structure.RunTestStage(t, "deploy_terraform", func() {
-		util.DeployUsingTerraform(t, tfWorkingDir, map[string]string{
-			// TODO: Fix Dependency tree to avoid this error :(
-			".*The EventInvokeConfig for function .* could not be updated due to a concurrent update operation.*": "Failed due to concurrent update operation.",
-		})
+		util.DeployUsingTerraform(t, tfWorkingDir, options.retryableErrors())
 	})
 	test_structure.RunTestStage(t, "validate", func() {
 		validate(t, tfWorkingDir, options.Region)

--- a/src/aws/aws-tags.ts
+++ b/src/aws/aws-tags.ts
@@ -1,4 +1,4 @@
-import { IAspect, Aspects } from "cdktn";
+import { IAspect, Aspects, IResolvable, TerraformResource } from "cdktn";
 import { IConstruct } from "constructs";
 import { TaggableConstruct } from "../construct-base";
 
@@ -12,6 +12,50 @@ export function isTaggableConstruct(x: IConstruct): x is TaggableConstruct {
 // TODO: Implement TagsManager?
 // https://github.com/aws/aws-cdk/blob/v2.175.1/packages/aws-cdk-lib/core/lib/tag-aspect.ts
 // https://github.com/aws/aws-cdk/blob/v2.175.1/packages/aws-cdk-lib/core/lib/tag-manager.ts
+
+/**
+ * Terraform resource type of the Auto Scaling group.
+ */
+const AUTO_SCALING_GROUP_RESOURCE_TYPE = "aws_autoscaling_group";
+
+/**
+ * A single `tag` block of an `aws_autoscaling_group`.
+ *
+ * Structurally compatible with the generated
+ * `autoscalingGroup.AutoscalingGroupTag` binding.
+ */
+interface AutoScalingGroupTag {
+  readonly key: string;
+  readonly value: string;
+  readonly propagateAtLaunch: boolean | IResolvable;
+}
+
+/**
+ * An L1 resource rendering tags as repeated `tag { key, value, propagate_at_launch }`
+ * blocks instead of a flat `tags` map.
+ */
+type AutoScalingGroupTaggable = TerraformResource & {
+  readonly tagInput?: AutoScalingGroupTag[] | IResolvable;
+  putTag(value: AutoScalingGroupTag[] | IResolvable): void;
+};
+
+/**
+ * Whether the node is an `aws_autoscaling_group` L1 using the structured tag schema.
+ *
+ * Detection is intentionally keyed off the Terraform resource type rather than the
+ * presence of a singular `tag` property: several provider resources expose a `tag`
+ * attribute with an entirely different schema.
+ */
+function isAutoScalingGroupTaggable(
+  x: IConstruct,
+): x is AutoScalingGroupTaggable {
+  return (
+    TerraformResource.isTerraformResource(x) &&
+    x.terraformResourceType === AUTO_SCALING_GROUP_RESOURCE_TYPE &&
+    "tagInput" in x &&
+    typeof (x as AutoScalingGroupTaggable).putTag === "function"
+  );
+}
 
 /**
  * Properties for a tag
@@ -35,12 +79,29 @@ export interface TagProps {
    * @default []
    */
   readonly includeResourceTypes?: string[];
+
+  /**
+   * Whether the tag should be applied to instances launched by an Auto Scaling group.
+   *
+   * Only relevant for `aws_autoscaling_group`, which renders tags as repeated
+   * `tag { key, value, propagate_at_launch }` blocks. Resources using the flat
+   * `tags` map ignore this option.
+   *
+   * @default true
+   */
+  readonly applyToLaunchedInstances?: boolean;
 }
 
 /**
  * CDKTF Aspect adding a single Key/Value Tag to all resources within a construct scope
  *
  * Add tags using `Tags.of(scope).add(key, value)`
+ *
+ * Two tag schemas are supported:
+ *
+ * - resources exposing a flat `tags`/`tagsInput` map (the vast majority), and
+ * - `aws_autoscaling_group`, which renders repeated
+ *   `tag { key, value, propagate_at_launch }` blocks.
  */
 export class AwsTag implements IAspect {
   private value: string;
@@ -58,6 +119,18 @@ export class AwsTag implements IAspect {
     this.value = value;
   }
   visit(node: IConstruct) {
+    if (isAutoScalingGroupTaggable(node)) {
+      if (
+        this.applyTagAspectHere(
+          node,
+          this.props.includeResourceTypes,
+          this.props.excludeResourceTypes,
+        )
+      ) {
+        this.visitAutoScalingGroup(node);
+      }
+      return;
+    }
     if (
       isTaggableConstruct(node) &&
       this.applyTagAspectHere(
@@ -72,8 +145,52 @@ export class AwsTag implements IAspect {
     }
   }
 
+  /**
+   * Merge this tag into the structured `tag` blocks of an `aws_autoscaling_group`.
+   *
+   * Unrelated entries are preserved in place. An entry already carrying this key -
+   * whether it came from the L1 escape hatch or from an earlier aspect - is replaced,
+   * so exactly one block per key is synthesized and a `Tags.of()` write always wins.
+   */
+  private visitAutoScalingGroup(node: AutoScalingGroupTaggable) {
+    const currentTags = node.tagInput;
+    if (currentTags !== undefined && !Array.isArray(currentTags)) {
+      // A whole-list token cannot be merged without silently discarding it.
+      throw new Error(
+        `Cannot add tag "${this.key}" to ${node.node.path}: the ${AUTO_SCALING_GROUP_RESOURCE_TYPE} ` +
+          "'tag' input is an unresolved value (IResolvable) which this aspect cannot merge into. " +
+          "Provide the tags as a concrete list of tag blocks instead.",
+      );
+    }
+
+    const newTag: AutoScalingGroupTag = {
+      key: this.key,
+      value: this.value,
+      propagateAtLaunch: this.props.applyToLaunchedInstances !== false,
+    };
+
+    let replaced = false;
+    const tags: AutoScalingGroupTag[] = [];
+    for (const tag of currentTags ?? []) {
+      // Entries with an unresolved key cannot be compared - keep them as-is.
+      if (tag?.key !== this.key) {
+        tags.push(tag);
+        continue;
+      }
+      if (!replaced) {
+        tags.push(newTag);
+        replaced = true;
+      }
+    }
+    if (!replaced) {
+      tags.push(newTag);
+    }
+
+    node.putTag(tags);
+  }
+
   private applyTagAspectHere(
-    node: TaggableConstruct,
+    node: TerraformResource,
     include?: string[],
     exclude?: string[],
   ) {
@@ -112,6 +229,9 @@ export class Tags {
 
   /**
    * add tags to the node of a construct and all its the taggable children
+   *
+   * A tag written here always wins over an entry for the same key already
+   * present on the underlying L1 resource.
    */
   public add(key: string, value: string, props: TagProps = {}) {
     Aspects.of(this.scope).add(new AwsTag(key, value, props));

--- a/src/aws/aws-tags.ts
+++ b/src/aws/aws-tags.ts
@@ -58,17 +58,18 @@ function isAutoScalingGroupTaggable(
 }
 
 /**
- * A construct whose tags also reach the instances it launches.
+ * Whether the node is a sink for tags that reach the instances it launches.
  *
  * The launch template mirrors its tag map into `tag_specifications` for the
  * `instance` and `volume` resource types, so those tags land on every instance
  * an Auto Scaling group launches from it - independently of the group's own
- * `propagate_at_launch`.
+ * `propagate_at_launch`. The marker is internal: it states a structural fact
+ * about the resource rather than offering a switch.
  */
 function appliesTagsToLaunchedInstances(x: IConstruct): boolean {
   return (
-    (x as unknown as { appliesTagsToLaunchedInstances?: boolean })
-      .appliesTagsToLaunchedInstances === true
+    (x as unknown as { _appliesTagsToLaunchedInstances?: boolean })
+      ._appliesTagsToLaunchedInstances === true
   );
 }
 

--- a/src/aws/aws-tags.ts
+++ b/src/aws/aws-tags.ts
@@ -58,6 +58,21 @@ function isAutoScalingGroupTaggable(
 }
 
 /**
+ * A construct whose tags also reach the instances it launches.
+ *
+ * The launch template mirrors its tag map into `tag_specifications` for the
+ * `instance` and `volume` resource types, so those tags land on every instance
+ * an Auto Scaling group launches from it - independently of the group's own
+ * `propagate_at_launch`.
+ */
+function appliesTagsToLaunchedInstances(x: IConstruct): boolean {
+  return (
+    (x as unknown as { appliesTagsToLaunchedInstances?: boolean })
+      .appliesTagsToLaunchedInstances === true
+  );
+}
+
+/**
  * Properties for a tag
  */
 export interface TagProps {
@@ -81,11 +96,15 @@ export interface TagProps {
   readonly includeResourceTypes?: string[];
 
   /**
-   * Whether the tag should be applied to instances launched by an Auto Scaling group.
+   * Whether the tag should be applied to instances launched from this scope.
    *
-   * Only relevant for `aws_autoscaling_group`, which renders tags as repeated
-   * `tag { key, value, propagate_at_launch }` blocks. Resources using the flat
-   * `tags` map ignore this option.
+   * Setting this to `false` renders `propagate_at_launch: false` on the
+   * `aws_autoscaling_group` `tag` block, and keeps the tag out of any
+   * `LaunchTemplate`'s `instance` and `volume` tag specifications, which would
+   * otherwise put it back on every launched instance. The launch template
+   * resource itself is still tagged.
+   *
+   * Resources using the flat `tags` map are unaffected by this option.
    *
    * @default true
    */
@@ -119,6 +138,18 @@ export class AwsTag implements IAspect {
     this.value = value;
   }
   visit(node: IConstruct) {
+    // Deviation from AWS CDK v2.233.0: upstream's `applyToLaunchedInstances`
+    // only drives the Auto Scaling group's own `PropagateAtLaunch`, so a tag
+    // opted out there still reaches launched instances through the launch
+    // template's `TagSpecifications`. Skipping that sink here makes the option
+    // hold end to end. The launch template's L1 resource is a separate node, so
+    // it keeps the tag.
+    if (
+      this.props.applyToLaunchedInstances === false &&
+      appliesTagsToLaunchedInstances(node)
+    ) {
+      return;
+    }
     if (isAutoScalingGroupTaggable(node)) {
       if (
         this.applyTagAspectHere(

--- a/src/aws/compute/launch-template.ts
+++ b/src/aws/compute/launch-template.ts
@@ -662,15 +662,22 @@ export class LaunchTemplate
   // protected readonly tags: TagManager;
 
   /**
-   * Tags applied to this construct also reach the instances and volumes it
-   * launches, through the launch template's `tag_specifications`.
+   * Marks this construct as a sink for tags that reach launched instances:
+   * its tag map is mirrored into `tag_specifications` for the `instance` and
+   * `volume` resource types.
    *
    * Read by the AWS `Tags.of()` aspect so a tag added with
    * `applyToLaunchedInstances: false` is kept off launched instances. The L1
    * `aws_launch_template` resource is tagged by a separate visit, so the
    * launch template itself still receives every tag.
+   *
+   * This states a structural fact about the resource, not a user-facing
+   * switch - setting it to `false` would let opted-out tags flow back onto
+   * launched instances.
+   *
+   * @internal
    */
-  public readonly appliesTagsToLaunchedInstances = true;
+  public readonly _appliesTagsToLaunchedInstances = true;
 
   // isTaggableConstruct required properties
   private _tags: Record<string, string> | undefined = undefined;

--- a/src/aws/compute/launch-template.ts
+++ b/src/aws/compute/launch-template.ts
@@ -661,6 +661,17 @@ export class LaunchTemplate
   //  */
   // protected readonly tags: TagManager;
 
+  /**
+   * Tags applied to this construct also reach the instances and volumes it
+   * launches, through the launch template's `tag_specifications`.
+   *
+   * Read by the AWS `Tags.of()` aspect so a tag added with
+   * `applyToLaunchedInstances: false` is kept off launched instances. The L1
+   * `aws_launch_template` resource is tagged by a separate visit, so the
+   * launch template itself still receives every tag.
+   */
+  public readonly appliesTagsToLaunchedInstances = true;
+
   // isTaggableConstruct required properties
   private _tags: Record<string, string> | undefined = undefined;
   public set tags(value: Record<string, string>) {

--- a/test/aws/aws-tags.test.ts
+++ b/test/aws/aws-tags.test.ts
@@ -1,0 +1,324 @@
+import { autoscalingGroup, s3Bucket } from "@cdktn/provider-aws";
+import { Lazy, Testing } from "cdktn";
+import "cdktn/lib/testing/adapters/jest";
+import { Construct } from "constructs";
+import { AwsStack } from "../../src/aws";
+import { Tags } from "../../src/aws/aws-tags";
+import { Template } from "../assertions";
+
+const environmentName = "Test";
+const gridUUID = "a123e456-e89b-12d3";
+
+describe("Tags", () => {
+  describe("aws_autoscaling_group", () => {
+    // Terraform deviation: `aws_autoscaling_group` renders tags as repeated
+    // `tag { key, value, propagate_at_launch }` blocks rather than the flat
+    // `tags` map most provider resources expose.
+    test("adds a structured tag block that propagates at launch by default", () => {
+      // GIVEN
+      const stack = getStack();
+      const scope = new Construct(stack, "Scope");
+      minimalAsg(scope);
+
+      // WHEN
+      Tags.of(scope).add("superfood", "acai");
+
+      // THEN
+      Template.synth(stack).toHaveResourceWithProperties(
+        autoscalingGroup.AutoscalingGroup,
+        {
+          tag: [
+            {
+              key: "superfood",
+              value: "acai",
+              propagate_at_launch: true,
+            },
+          ],
+        },
+      );
+    });
+
+    test("applyToLaunchedInstances false renders propagate_at_launch false", () => {
+      // GIVEN
+      const stack = getStack();
+      const scope = new Construct(stack, "Scope");
+      minimalAsg(scope);
+
+      // WHEN
+      Tags.of(scope).add("notsuper", "caramel", {
+        applyToLaunchedInstances: false,
+      });
+
+      // THEN
+      Template.synth(stack).toHaveResourceWithProperties(
+        autoscalingGroup.AutoscalingGroup,
+        {
+          tag: [
+            {
+              key: "notsuper",
+              value: "caramel",
+              propagate_at_launch: false,
+            },
+          ],
+        },
+      );
+    });
+
+    test("two writes for the same key emit a single tag block", () => {
+      // GIVEN
+      const stack = getStack();
+      const scope = new Construct(stack, "Scope");
+      minimalAsg(scope);
+
+      // WHEN
+      Tags.of(scope).add("superfood", "acai");
+      Tags.of(scope).add("superfood", "durian", {
+        applyToLaunchedInstances: false,
+      });
+
+      // THEN - the last write wins, in the position of the first
+      Template.synth(stack).toHaveResourceWithProperties(
+        autoscalingGroup.AutoscalingGroup,
+        {
+          tag: [
+            {
+              key: "superfood",
+              value: "durian",
+              propagate_at_launch: false,
+            },
+          ],
+        },
+      );
+    });
+
+    test("preserves unrelated tag blocks set on the L1 resource", () => {
+      // GIVEN
+      const stack = getStack();
+      const scope = new Construct(stack, "Scope");
+      minimalAsg(scope, {
+        tag: [
+          {
+            key: "AmazonECSManaged",
+            value: "",
+            propagateAtLaunch: true,
+          },
+        ],
+      });
+
+      // WHEN
+      Tags.of(scope).add("superfood", "acai");
+
+      // THEN
+      Template.synth(stack).toHaveResourceWithProperties(
+        autoscalingGroup.AutoscalingGroup,
+        {
+          tag: [
+            {
+              key: "AmazonECSManaged",
+              value: "",
+              propagate_at_launch: true,
+            },
+            {
+              key: "superfood",
+              value: "acai",
+              propagate_at_launch: true,
+            },
+          ],
+        },
+      );
+    });
+
+    test("a Tags.of() write replaces a pre-existing L1 tag block for the same key", () => {
+      // GIVEN
+      const stack = getStack();
+      const scope = new Construct(stack, "Scope");
+      minimalAsg(scope, {
+        tag: [
+          {
+            key: "superfood",
+            value: "caramel",
+            propagateAtLaunch: false,
+          },
+          {
+            key: "AmazonECSManaged",
+            value: "",
+            propagateAtLaunch: true,
+          },
+        ],
+      });
+
+      // WHEN
+      Tags.of(scope).add("superfood", "acai");
+
+      // THEN - one block per key, aspect wins, unrelated entry survives
+      Template.synth(stack).toHaveResourceWithProperties(
+        autoscalingGroup.AutoscalingGroup,
+        {
+          tag: [
+            {
+              key: "superfood",
+              value: "acai",
+              propagate_at_launch: true,
+            },
+            {
+              key: "AmazonECSManaged",
+              value: "",
+              propagate_at_launch: true,
+            },
+          ],
+        },
+      );
+    });
+
+    test("throws rather than discarding an unresolved tag list", () => {
+      // GIVEN
+      const stack = getStack();
+      const scope = new Construct(stack, "Scope");
+      minimalAsg(scope, {
+        tag: Lazy.anyValue({
+          produce: () => [
+            { key: "AmazonECSManaged", value: "", propagate_at_launch: true },
+          ],
+        }) as any,
+      });
+
+      // WHEN
+      Tags.of(scope).add("superfood", "acai");
+
+      // THEN
+      expect(() => Template.synth(stack)).toThrow(
+        /Cannot add tag "superfood" to .*unresolved value \(IResolvable\)/s,
+      );
+    });
+
+    test("includeResourceTypes tags the ASG without tagging descendants", () => {
+      // GIVEN
+      const stack = getStack();
+      const scope = new Construct(stack, "Scope");
+      minimalAsg(scope);
+      new s3Bucket.S3Bucket(scope, "Bucket", {});
+
+      // WHEN
+      Tags.of(scope).add("superfood", "acai", {
+        includeResourceTypes: ["aws_autoscaling_group"],
+      });
+
+      // THEN
+      const template = Template.synth(stack);
+      template.toHaveResourceWithProperties(autoscalingGroup.AutoscalingGroup, {
+        tag: [
+          {
+            key: "superfood",
+            value: "acai",
+            propagate_at_launch: true,
+          },
+        ],
+      });
+      Template.resources(stack, s3Bucket.S3Bucket).toEqual([
+        expect.not.objectContaining({ tags: expect.anything() }),
+      ]);
+    });
+
+    test("excludeResourceTypes skips the ASG but still tags descendants", () => {
+      // GIVEN
+      const stack = getStack();
+      const scope = new Construct(stack, "Scope");
+      minimalAsg(scope);
+      new s3Bucket.S3Bucket(scope, "Bucket", {});
+
+      // WHEN
+      Tags.of(scope).add("superfood", "acai", {
+        excludeResourceTypes: ["aws_autoscaling_group"],
+      });
+
+      // THEN
+      Template.resources(stack, autoscalingGroup.AutoscalingGroup).toEqual([
+        expect.not.objectContaining({ tag: expect.anything() }),
+      ]);
+      Template.synth(stack).toHaveResourceWithProperties(s3Bucket.S3Bucket, {
+        tags: { superfood: "acai" },
+      });
+    });
+
+    test("tags the whole subtree by default", () => {
+      // GIVEN
+      const stack = getStack();
+      const scope = new Construct(stack, "Scope");
+      minimalAsg(scope);
+      new s3Bucket.S3Bucket(scope, "Bucket", {});
+
+      // WHEN
+      Tags.of(scope).add("superfood", "acai");
+
+      // THEN
+      const template = Template.synth(stack);
+      template.toHaveResourceWithProperties(autoscalingGroup.AutoscalingGroup, {
+        tag: [
+          {
+            key: "superfood",
+            value: "acai",
+            propagate_at_launch: true,
+          },
+        ],
+      });
+      template.toHaveResourceWithProperties(s3Bucket.S3Bucket, {
+        tags: { superfood: "acai" },
+      });
+    });
+  });
+
+  describe("flat tags map resources", () => {
+    test("merges into the existing tags map", () => {
+      // GIVEN
+      const stack = getStack();
+      const scope = new Construct(stack, "Scope");
+      new s3Bucket.S3Bucket(scope, "Bucket", {
+        tags: { existing: "kept" },
+      });
+
+      // WHEN
+      Tags.of(scope).add("superfood", "acai");
+
+      // THEN
+      Template.synth(stack).toHaveResourceWithProperties(s3Bucket.S3Bucket, {
+        tags: { existing: "kept", superfood: "acai" },
+      });
+    });
+
+    test("applyToLaunchedInstances does not affect the flat tags map", () => {
+      // GIVEN
+      const stack = getStack();
+      const scope = new Construct(stack, "Scope");
+      new s3Bucket.S3Bucket(scope, "Bucket", {});
+
+      // WHEN
+      Tags.of(scope).add("superfood", "acai", {
+        applyToLaunchedInstances: false,
+      });
+
+      // THEN
+      Template.synth(stack).toHaveResourceWithProperties(s3Bucket.S3Bucket, {
+        tags: { superfood: "acai" },
+      });
+    });
+  });
+});
+
+function getStack(): AwsStack {
+  return new AwsStack(Testing.app(), "TestStack", {
+    environmentName,
+    gridUUID,
+  });
+}
+
+function minimalAsg(
+  scope: Construct,
+  config: Partial<autoscalingGroup.AutoscalingGroupConfig> = {},
+): autoscalingGroup.AutoscalingGroup {
+  return new autoscalingGroup.AutoscalingGroup(scope, "Asg", {
+    name: "my-asg",
+    minSize: 0,
+    maxSize: 1,
+    ...config,
+  });
+}

--- a/test/aws/compute/auto-scaling/__snapshots__/cfn-init.test.ts.snap
+++ b/test/aws/compute/auto-scaling/__snapshots__/cfn-init.test.ts.snap
@@ -82,6 +82,13 @@ exports[`AutoScalingGroup (cfn-init.test.ts base fixture) Should synth and match
         "max_size": 5,
         "min_size": 2,
         "name_prefix": "g-Asg",
+        "tag": [
+          {
+            "key": "Name",
+            "propagate_at_launch": true,
+            "value": "Default/Asg"
+          }
+        ],
         "vpc_zone_identifier": [
           "\${aws_subnet.Vpc_PrivateSubnet1_F6513F49.id}",
           "\${aws_subnet.Vpc_PrivateSubnet2_53755717.id}",

--- a/test/aws/compute/auto-scaling/__snapshots__/lifecyclehooks.test.ts.snap
+++ b/test/aws/compute/auto-scaling/__snapshots__/lifecyclehooks.test.ts.snap
@@ -115,6 +115,13 @@ exports[`LifecycleHook Should synth and match SnapShot with a notificationTarget
         "max_size": 1,
         "min_size": 1,
         "name_prefix": "g-ASG",
+        "tag": [
+          {
+            "key": "Name",
+            "propagate_at_launch": true,
+            "value": "Default/ASG"
+          }
+        ],
         "vpc_zone_identifier": [
           "\${aws_subnet.VPC_PrivateSubnet1_05F5A6DA.id}",
           "\${aws_subnet.VPC_PrivateSubnet2_8C0AEF3A.id}",
@@ -662,6 +669,13 @@ exports[`LifecycleHook Should synth and match SnapShot with a role and a notific
         "max_size": 1,
         "min_size": 1,
         "name_prefix": "g-ASG",
+        "tag": [
+          {
+            "key": "Name",
+            "propagate_at_launch": true,
+            "value": "Default/ASG"
+          }
+        ],
         "vpc_zone_identifier": [
           "\${aws_subnet.VPC_PrivateSubnet1_05F5A6DA.id}",
           "\${aws_subnet.VPC_PrivateSubnet2_8C0AEF3A.id}",

--- a/test/aws/compute/auto-scaling/__snapshots__/scheduled-action.test.ts.snap
+++ b/test/aws/compute/auto-scaling/__snapshots__/scheduled-action.test.ts.snap
@@ -81,6 +81,13 @@ exports[`ScheduledAction Should synth and match SnapShot with minCapacity only 1
         "max_size": 1,
         "min_size": 1,
         "name_prefix": "g-ASG",
+        "tag": [
+          {
+            "key": "Name",
+            "propagate_at_launch": true,
+            "value": "Default/ASG"
+          }
+        ],
         "vpc_zone_identifier": [
           "\${aws_subnet.VPC_PrivateSubnet1_05F5A6DA.id}",
           "\${aws_subnet.VPC_PrivateSubnet2_8C0AEF3A.id}",
@@ -572,6 +579,13 @@ exports[`ScheduledAction Should synth and match SnapShot with startTime, endTime
         "max_size": 1,
         "min_size": 1,
         "name_prefix": "g-ASG",
+        "tag": [
+          {
+            "key": "Name",
+            "propagate_at_launch": true,
+            "value": "Default/ASG"
+          }
+        ],
         "vpc_zone_identifier": [
           "\${aws_subnet.VPC_PrivateSubnet1_05F5A6DA.id}",
           "\${aws_subnet.VPC_PrivateSubnet2_8C0AEF3A.id}",

--- a/test/aws/compute/auto-scaling/__snapshots__/warm-pool.test.ts.snap
+++ b/test/aws/compute/auto-scaling/__snapshots__/warm-pool.test.ts.snap
@@ -81,6 +81,13 @@ exports[`WarmPool Should synth and match SnapShot with all optional properties 1
         "max_size": 1,
         "min_size": 1,
         "name_prefix": "g-ASG",
+        "tag": [
+          {
+            "key": "Name",
+            "propagate_at_launch": true,
+            "value": "Default/ASG"
+          }
+        ],
         "vpc_zone_identifier": [
           "\${aws_subnet.VPC_PrivateSubnet1_05F5A6DA.id}",
           "\${aws_subnet.VPC_PrivateSubnet2_8C0AEF3A.id}",
@@ -570,6 +577,13 @@ exports[`WarmPool Should synth and match SnapShot with no optional properties 1`
         "max_size": 1,
         "min_size": 1,
         "name_prefix": "g-ASG",
+        "tag": [
+          {
+            "key": "Name",
+            "propagate_at_launch": true,
+            "value": "Default/ASG"
+          }
+        ],
         "vpc_zone_identifier": [
           "\${aws_subnet.VPC_PrivateSubnet1_05F5A6DA.id}",
           "\${aws_subnet.VPC_PrivateSubnet2_8C0AEF3A.id}",

--- a/test/aws/compute/auto-scaling/aspects/__snapshots__/require-imdsv2-aspect.test.ts.snap
+++ b/test/aws/compute/auto-scaling/aspects/__snapshots__/require-imdsv2-aspect.test.ts.snap
@@ -81,6 +81,13 @@ exports[`AutoScalingGroupRequireImdsv2Aspect synth applies to AutoScalingGroup a
         "max_size": 1,
         "min_size": 1,
         "name_prefix": "g-AutoScalingGroup",
+        "tag": [
+          {
+            "key": "Name",
+            "propagate_at_launch": true,
+            "value": "Default/AutoScalingGroup"
+          }
+        ],
         "vpc_zone_identifier": [
           "\${aws_subnet.Vpc_PrivateSubnet1_F6513F49.id}",
           "\${aws_subnet.Vpc_PrivateSubnet2_53755717.id}",

--- a/test/aws/compute/auto-scaling/auto-scaling-group.test.ts
+++ b/test/aws/compute/auto-scaling/auto-scaling-group.test.ts
@@ -719,6 +719,33 @@ describe("auto scaling group", () => {
         notsuper: "caramel",
       }),
     });
+    // Deviation from AWS CDK v2.233.0: upstream renders every tag into the
+    // generated launch template's `TagSpecifications`, so `notsuper` would come
+    // back to launched instances despite `PropagateAtLaunch: false`. Here it is
+    // kept out of the instance/volume specifications while the launch template
+    // resource itself keeps the tag.
+    template.toHaveResourceWithProperties(tfLaunchTemplate.LaunchTemplate, {
+      tag_specifications: [
+        {
+          resource_type: "instance",
+          tags: {
+            Name: "TestStack/MyFleet/LaunchTemplate",
+            superfood: "acai",
+          },
+        },
+        {
+          resource_type: "volume",
+          tags: {
+            Name: "TestStack/MyFleet/LaunchTemplate",
+            superfood: "acai",
+          },
+        },
+      ],
+      tags: expect.objectContaining({
+        superfood: "acai",
+        notsuper: "caramel",
+      }),
+    });
   });
 
   test("allows setting spot price", () => {

--- a/test/aws/compute/auto-scaling/auto-scaling-group.test.ts
+++ b/test/aws/compute/auto-scaling/auto-scaling-group.test.ts
@@ -684,24 +684,41 @@ describe("auto scaling group", () => {
     });
 
     Tags.of(asg).add("superfood", "acai");
+    Tags.of(asg).add("notsuper", "caramel", {
+      applyToLaunchedInstances: false,
+    });
 
     // THEN
-    // Terraform deviation: `aws_autoscaling_group` renders tags via a
-    // dedicated `tag { key, value, propagate_at_launch }` block, not the
-    // generic flat `tags` map most provider resources expose - the repo's
-    // generic Tags aspect (src/aws/aws-tags.ts, isTaggableConstruct) only
-    // tags constructs whose L1 resource has a plain `tags`/`tagsInput`
-    // attribute, so `AutoScalingGroup` itself is skipped and the tag lands
-    // on its taggable descendants instead (here, the auto-created instance
-    // security group).
-    Template.synth(stack).toHaveResourceWithProperties(
-      tfSecurityGroup.SecurityGroup,
-      {
-        tags: expect.objectContaining({
-          superfood: "acai",
-        }),
-      },
-    );
+    // Terraform deviation: `aws_autoscaling_group` renders tags via repeated
+    // `tag { key, value, propagate_at_launch }` blocks, not the generic flat
+    // `tags` map most provider resources expose.
+    const template = Template.synth(stack);
+    template.toHaveResourceWithProperties(autoscalingGroup.AutoscalingGroup, {
+      tag: [
+        {
+          key: "Name",
+          value: "TestStack/MyFleet",
+          propagate_at_launch: true,
+        },
+        {
+          key: "superfood",
+          value: "acai",
+          propagate_at_launch: true,
+        },
+        {
+          key: "notsuper",
+          value: "caramel",
+          propagate_at_launch: false,
+        },
+      ],
+    });
+    // the aspect still reaches taggable descendants using the flat `tags` map
+    template.toHaveResourceWithProperties(tfSecurityGroup.SecurityGroup, {
+      tags: expect.objectContaining({
+        superfood: "acai",
+        notsuper: "caramel",
+      }),
+    });
   });
 
   test("allows setting spot price", () => {

--- a/test/aws/compute/launch-template.test.ts
+++ b/test/aws/compute/launch-template.test.ts
@@ -865,6 +865,45 @@ describe("LaunchTemplate", () => {
     );
   });
 
+  test("Adding tags with applyToLaunchedInstances false", () => {
+    // GIVEN
+    const template = new LaunchTemplate(stack, "Template");
+
+    // WHEN
+    Tags.of(template).add("TestKey", "TestValue", {
+      applyToLaunchedInstances: false,
+    });
+
+    // THEN
+    // Deviation from AWS CDK v2.233.0: upstream renders every tag into the
+    // launch template's `TagSpecifications`, so a tag opted out of launched
+    // instances still lands on them. Here it is kept out of the `instance` and
+    // `volume` specifications, while the launch template itself is still tagged.
+    Template.synth(stack).toHaveResourceWithProperties(
+      tfLaunchTemplate.LaunchTemplate,
+      {
+        tag_specifications: [
+          {
+            resource_type: "instance",
+            tags: {
+              Name: "Default/Template",
+            },
+          },
+          {
+            resource_type: "volume",
+            tags: {
+              Name: "Default/Template",
+            },
+          },
+        ],
+        tags: expect.objectContaining({
+          Name: "Default/Template",
+          TestKey: "TestValue",
+        }),
+      },
+    );
+  });
+
   test("Requires IMDSv2", () => {
     // WHEN
     new LaunchTemplate(stack, "Template", {


### PR DESCRIPTION
Closes #125

## Problem

`Tags.of(autoScalingGroup).add(...)` never tagged the Terraform `aws_autoscaling_group`. The aspect in `src/aws/aws-tags.ts` only recognized resources exposing a flat `tags`/`tagsInput` map, while Auto Scaling uses repeated `tag { key, value, propagate_at_launch }` blocks. The ASG was skipped and the tag landed on taggable descendants instead (the generated instance security group). The construct's own `Tags.of(this).add("Name", this.node.path)` request followed that same descendant-only path, and there was no equivalent of AWS CDK's `applyToLaunchedInstances`.

## Change 1 — ASG tag schema

A narrow ASG adapter in the AWS tag aspect — no `TagManager` port, no priorities, no remove API, no `GridTags` redesign:

- `TagProps.applyToLaunchedInstances` (default `true`) renders `propagate_at_launch`, mirroring [AWS CDK v2.233.0's tag aspect option](https://github.com/aws/aws-cdk/blob/v2.233.0/packages/aws-cdk-lib/core/lib/tag-aspect.ts).
- Detection keys off `terraformResourceType === "aws_autoscaling_group"` rather than the presence of a singular `tag` property — other provider resources expose a `tag` attribute with an entirely different schema.
- Unrelated concrete tag blocks are preserved in place. An entry already carrying the same key — whether from the L1 escape hatch (`asg.resource.putTag(...)`) or an earlier aspect — is replaced, so exactly one block per key is synthesized and a `Tags.of()` write always wins.
- An unresolved (`IResolvable`) whole-list `tag` input throws a clear error instead of being silently replaced.
- `includeResourceTypes` / `excludeResourceTypes` keep working, including an ASG-only application that does not tag descendants.
- The flat-map path is untouched.

## Change 2 — `applyToLaunchedInstances: false` now holds end to end

Live validation of change 1 surfaced a second gap: the opted-out tag still reached the launched instance. `LaunchTemplate` mirrors its tag map into `tag_specifications` for `instance` and `volume`, and `Tags.of(asg)` reaches the generated launch template, so the tag came back in through the launch template even though the ASG said `propagate_at_launch: false`.

`LaunchTemplate` now declares `appliesTagsToLaunchedInstances`, and the aspect skips that node when `applyToLaunchedInstances: false`. The L1 `aws_launch_template` is a separate aspect visit, so the launch template resource itself still carries every tag.

**Deviation from AWS CDK v2.233.0, deliberately.** Upstream's `StandardFormatter.formatTags` ([core/lib/tag-manager.ts](https://github.com/aws/aws-cdk/blob/v2.233.0/packages/aws-cdk-lib/core/lib/tag-manager.ts)) ignores `applyToLaunchedInstances` — only the ASG formatter honors it — and upstream's `LaunchTemplate` renders its whole `TagManager` into `launchTemplateData.TagSpecifications`. So CDK exhibits the same leak; diverging here makes the documented option mean what it says. Called out in a code comment on the guard and in both test comments.

## Tests

`test/aws/compute/auto-scaling/auto-scaling-group.test.ts` — the `can set tags` test previously documented the divergence and asserted the tag on the security group. It now restores [upstream parity](https://github.com/aws/aws-cdk/blob/v2.233.0/packages/aws-cdk-lib/aws-autoscaling/test/auto-scaling-group.test.ts) in Terraform's shape, and additionally asserts the generated launch template:

```ts
tag: [
  { key: "Name",      value: "TestStack/MyFleet", propagate_at_launch: true },
  { key: "superfood", value: "acai",              propagate_at_launch: true },
  { key: "notsuper",  value: "caramel",           propagate_at_launch: false },
]
```

New `test/aws/aws-tags.test.ts` owns the generic formatting/merge behavior so the ASG suite keeps one responsibility: default and `applyToLaunchedInstances: false` propagation, two writes to one key collapsing to a single block, unrelated L1 entries surviving, `Tags.of()` beating a pre-existing same-key L1 entry, the unresolved-list error, `includeResourceTypes`/`excludeResourceTypes`, default subtree tagging, and the unchanged flat-map path.

`test/aws/compute/launch-template.test.ts` gains `Adding tags with applyToLaunchedInstances false` beside the existing `Adding tags`, mirroring upstream's placement in `aws-ec2/test/launch-template.test.ts`.

Five ASG snapshots were updated for change 1: they now carry the construct-path `Name` tag block that was previously dropped. Change 2 leaves every snapshot untouched — the guard only fires on an explicit `false`, which no snapshot exercises.

## Verification

Unit: `npx jest` — 218 suites / 3540 tests, 69 snapshots. `npx tsc --noEmit`, `projen eslint`, `go vet ./aws/compute/` clean.

Integration: `TestAutoscalingCustomScaling` **passes** against a live account. `integ/aws/compute/apps/autoscaling.custom-scaling.ts` applies both tag variants; the Go validation asserts the live `DescribeAutoScalingGroups` tags and that the launched instance carries `superfood` but **not** `notsuper`:

| Key | Value | PropagateAtLaunch | On launched instance |
| --- | --- | --- | --- |
| `Name` | `autoscaling.custom-scaling/Fleet` | `true` | yes |
| `superfood` | `acai` | `true` | yes |
| `notsuper` | `caramel` | `false` | **no** |

### Known unrelated flake in this integration test

The fixture creates four `aws_autoscaling_schedule` resources on one group. Terraform applies them concurrently and AWS rejects same-group concurrent `PutScheduledUpdateGroupAction` calls with `AlreadyExists: Scheduled action with this scheduled start time already exists` — the victim varies per run. Applying with `-parallelism=1` creates all four cleanly, which is how the run above was validated. This predates this PR and is being tracked separately; it is not caused by the tagging change.