### PR TITLE
feat(aws): support instance refresh on AutoScalingGroup

### DIFF
--- a/integ/aws/autoscaling.go
+++ b/integ/aws/autoscaling.go
@@ -108,3 +108,31 @@ func GetAsgScalingPolicies(t testing.TestingT, region, asgName string) []types.S
 	require.NoError(t, err)
 	return policies
 }
+
+// GetAsgInstanceRefreshesE lists the instance refreshes of the given Auto Scaling group,
+// most recent first.
+//
+// EC2 Auto Scaling keeps the last 100 refreshes for 6 weeks, so this covers refreshes that
+// have already finished as well as one that is still running.
+func GetAsgInstanceRefreshesE(t testing.TestingT, region, asgName string) ([]types.InstanceRefresh, error) {
+	logger.Log(t, fmt.Sprintf("Describing instance refreshes for Auto Scaling group %s in %s", asgName, region))
+	client, err := NewAsgClientE(t, region)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := client.DescribeInstanceRefreshes(context.Background(), &autoscaling.DescribeInstanceRefreshesInput{
+		AutoScalingGroupName: aws.String(asgName),
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp.InstanceRefreshes, nil
+}
+
+// GetAsgInstanceRefreshes fetches the instance refreshes or fails the test.
+func GetAsgInstanceRefreshes(t testing.TestingT, region, asgName string) []types.InstanceRefresh {
+	refreshes, err := GetAsgInstanceRefreshesE(t, region, asgName)
+	require.NoError(t, err)
+	return refreshes
+}

--- a/integ/aws/compute/Makefile
+++ b/integ/aws/compute/Makefile
@@ -44,6 +44,10 @@ autoscaling.custom-scaling: ## Test AutoScalingGroup custom scaling (Schedule.cr
 	go test -v -count 1 -timeout 30m ./... -run ^TestAutoscalingCustomScaling$
 .PHONY: autoscaling.custom-scaling
 
+autoscaling.update-policy: ## Test AutoScalingGroup UpdatePolicy.instanceRefresh (launch template change rolls out)
+	go test -v -count 1 -timeout 45m ./... -run ^TestAutoscalingUpdatePolicy$
+.PHONY: autoscaling.update-policy
+
 instance-public: ## Test Compute Instance with public IP
 	go test -v -count 1 -timeout 15m ./... -run ^TestInstancePublic$
 .PHONY: instance-public

--- a/integ/aws/compute/apps/autoscaling.update-policy.ts
+++ b/integ/aws/compute/apps/autoscaling.update-policy.ts
@@ -1,0 +1,79 @@
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/@aws-cdk-testing/framework-integ/test/aws-autoscaling/test/integ.asg-update-policy.ts
+
+import { CloudinitProvider } from "@cdktn/provider-cloudinit/lib/provider";
+import { App, LocalBackend } from "cdktn";
+import { aws, Duration } from "../../../../src";
+
+const environmentName = process.env.ENVIRONMENT_NAME ?? "test";
+const region = process.env.AWS_REGION ?? "us-east-1";
+const outdir = process.env.OUT_DIR ?? "cdktf.out";
+const stackName = process.env.STACK_NAME ?? "autoscaling.update-policy";
+
+// Stands in for the baked AMI of https://github.com/TerraConstructs/base/issues/129.
+// `TestAutoscalingUpdatePolicy` deploys once with the default marker, then re-synths
+// with a different one and applies again. Either way the change lands in the launch
+// template, which is what an instance refresh triggers on - baking a second AMI just
+// to move `image_id` would cost the test an EC2 Image Builder run for the same signal.
+const launchTemplateRevision = process.env.LAUNCH_TEMPLATE_REVISION ?? "v1";
+
+const app = new App({
+  outdir,
+});
+
+const stack = new aws.AwsStack(app, stackName, {
+  gridUUID: "g12345678-1234",
+  environmentName,
+  providerConfig: {
+    region,
+  },
+});
+new CloudinitProvider(stack, "CloudInit");
+new LocalBackend(stack, {
+  path: `${stackName}.tfstate`,
+});
+
+// Terraform deviation: upstream uses `maxAzs: 2` with the default subnet layout,
+// which provisions a NAT Gateway per AZ. Instance refresh doesn't care about the
+// network, so this uses the cheapest network that still lets an instance reach
+// the EC2 Auto Scaling endpoint: single AZ, public subnets only.
+const vpc = new aws.compute.Vpc(stack, "VPC", {
+  maxAzs: 1,
+  natGateways: 0,
+  subnetConfiguration: [
+    {
+      name: "public",
+      subnetType: aws.compute.SubnetType.PUBLIC,
+      cidrMask: 24,
+    },
+  ],
+});
+
+const asg = new aws.compute.autoscaling.AutoScalingGroup(stack, "ASG", {
+  vpc,
+  instanceType: aws.compute.InstanceType.of(
+    aws.compute.InstanceClass.BURSTABLE3,
+    aws.compute.InstanceSize.MICRO,
+  ),
+  machineImage: new aws.compute.AmazonLinuxImage({
+    generation: aws.compute.AmazonLinuxGeneration.AMAZON_LINUX_2023,
+  }),
+  // Terraform deviation: upstream configures `UpdatePolicy.rollingUpdate()`, which
+  // is CloudFormation replacing the instances itself. The provider has no such
+  // mechanism - `instance_refresh` hands the rollout to EC2 Auto Scaling instead -
+  // so the equivalent policy here is `instanceRefresh()`.
+  updatePolicy: aws.compute.autoscaling.UpdatePolicy.instanceRefresh({
+    strategy: aws.compute.autoscaling.InstanceRefreshStrategy.ROLLING,
+    // The group runs a single instance, so it has to go out of service for the
+    // replacement to happen at all. `instanceWarmup: 0` keeps the refresh from
+    // idling once the replacement reports InService.
+    minHealthyPercentage: 0,
+    maxHealthyPercentage: 100,
+    instanceWarmup: Duration.seconds(0),
+  }),
+  registerOutputs: true,
+  outputName: "asg",
+});
+
+asg.addUserData(`echo "launch template revision: ${launchTemplateRevision}"`);
+
+app.synth();

--- a/integ/aws/compute/autoscaling_test.go
+++ b/integ/aws/compute/autoscaling_test.go
@@ -1,13 +1,18 @@
 package test
 
 import (
+	"fmt"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling/types"
 	ec2types "github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/terraconstructs/go-synth/executors"
 
+	"github.com/gruntwork-io/terratest/modules/retry"
 	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 	util "github.com/terraconstructs/base/integ/aws"
 )
@@ -160,4 +165,103 @@ func validateAutoscalingCustomScaling(t *testing.T, tfWorkingDir, awsRegion stri
 	)
 	require.NotNil(t, cpuPolicy.TargetTrackingConfiguration.TargetValue)
 	assert.Equal(t, float64(50), *cpuPolicy.TargetTrackingConfiguration.TargetValue)
+}
+
+// Test the autoscaling.update-policy app
+//
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/@aws-cdk-testing/framework-integ/test/aws-autoscaling/test/integ.asg-update-policy.ts
+//
+// Structural port of the upstream update-policy fixture. Upstream deploys an
+// AutoScalingGroup with `UpdatePolicy.rollingUpdate()`, a CloudFormation-driven
+// replacement CloudFormation performs itself; this port configures
+// `UpdatePolicy.instanceRefresh()` instead, which is the only update policy the
+// `aws_autoscaling_group` resource can back (see the deviation note on
+// CommonAutoScalingGroupProps).
+//
+// https://github.com/TerraConstructs/base/issues/129 - the whole point of the
+// policy is that a launch template change reaches the instances already running,
+// so validation deploys, changes the launch template, applies again, and checks
+// that EC2 Auto Scaling actually started a refresh.
+func TestAutoscalingUpdatePolicy(t *testing.T) {
+	options := integrationTestOptions{
+		Region: region,
+	}
+	runComputeIntegrationTest(t, "autoscaling.update-policy", options, validateAutoscalingUpdatePolicy)
+}
+
+func validateAutoscalingUpdatePolicy(t *testing.T, tfWorkingDir, awsRegion string) {
+	opts := test_structure.LoadTerraformOptions(t, tfWorkingDir)
+	asgName := util.LoadOutputAttribute(t, opts, "asg", "autoScalingGroupName")
+
+	// (a) The freshly deployed group runs its single instance off a launch
+	// template. `instance_refresh` is not an Auto Scaling API attribute - it only
+	// tells the provider what to do on a subsequent apply - so there is nothing to
+	// assert about it on the group itself yet, and no refresh has run.
+	group := util.GetAutoScalingGroup(t, awsRegion, asgName)
+	require.NotNil(t, group.DesiredCapacity)
+	assert.Equal(t, int32(1), *group.DesiredCapacity)
+	require.NotNil(t, group.LaunchTemplate, "expected the group to launch from a launch template")
+
+	require.Empty(t,
+		util.GetAsgInstanceRefreshes(t, awsRegion, asgName),
+		"expected no instance refresh before the launch template changes",
+	)
+
+	// (b) Change the launch template and apply again.
+	//
+	// This second synth+apply lives inside the validate stage rather than in stages
+	// of its own so the `%-synth-only` / `%-validate-only` make targets (which only
+	// know the four standard stage names) keep behaving sensibly.
+	envVars := executors.EnvMap(os.Environ())
+	envVars["AWS_REGION"] = awsRegion
+	envVars["ENVIRONMENT_NAME"] = "test"
+	envVars["STACK_NAME"] = "autoscaling.update-policy"
+	envVars["LAUNCH_TEMPLATE_REVISION"] = "v2"
+
+	util.SynthApp(t, "autoscaling.update-policy", tfWorkingDir, envVars, "handlers")
+	util.DeployUsingTerraform(t, tfWorkingDir, nil)
+
+	// (c) The apply hands the rollout to EC2 Auto Scaling and returns without
+	// waiting for it, so poll until the refresh shows up.
+	refresh, err := retry.DoWithRetryInterfaceE(
+		t,
+		fmt.Sprintf("Waiting for an instance refresh on Auto Scaling group %s", asgName),
+		30, // 30 * 10s = 5 minutes
+		10*time.Second,
+		func() (interface{}, error) {
+			refreshes := util.GetAsgInstanceRefreshes(t, awsRegion, asgName)
+			if len(refreshes) == 0 {
+				return nil, fmt.Errorf(
+					"Auto Scaling group %s has no instance refresh after the launch template changed",
+					asgName,
+				)
+			}
+			return refreshes[0], nil
+		},
+	)
+	require.NoError(t, err)
+
+	instanceRefresh := refresh.(types.InstanceRefresh)
+	assert.NotContains(t,
+		[]types.InstanceRefreshStatus{
+			types.InstanceRefreshStatusFailed,
+			types.InstanceRefreshStatusCancelled,
+			types.InstanceRefreshStatusCancelling,
+			types.InstanceRefreshStatusRollbackInProgress,
+			types.InstanceRefreshStatusRollbackFailed,
+			types.InstanceRefreshStatusRollbackSuccessful,
+		},
+		instanceRefresh.Status,
+		"instance refresh went wrong: %v", instanceRefresh.StatusReason,
+	)
+
+	// The preferences configured through `UpdatePolicy.instanceRefresh()` must have
+	// reached the StartInstanceRefresh call, not just the Terraform config.
+	require.NotNil(t, instanceRefresh.Preferences)
+	require.NotNil(t, instanceRefresh.Preferences.MinHealthyPercentage)
+	assert.Equal(t, int32(0), *instanceRefresh.Preferences.MinHealthyPercentage)
+	require.NotNil(t, instanceRefresh.Preferences.MaxHealthyPercentage)
+	assert.Equal(t, int32(100), *instanceRefresh.Preferences.MaxHealthyPercentage)
+	require.NotNil(t, instanceRefresh.Preferences.InstanceWarmup)
+	assert.Equal(t, int32(0), *instanceRefresh.Preferences.InstanceWarmup)
 }

--- a/src/aws/compute/auto-scaling/auto-scaling-group.ts
+++ b/src/aws/compute/auto-scaling/auto-scaling-group.ts
@@ -929,6 +929,11 @@ export interface InstanceRefreshOptions {
   /**
    * What to do with instances that are protected from scale in.
    *
+   * Terraform deviation: the Auto Scaling API - and therefore CloudFormation - defaults this
+   * to `WAIT`, which stalls the refresh for an hour and then fails it. The AWS provider
+   * schema defaults the argument to `Ignore` and always sends it, so the API default never
+   * applies and leaving this unset means `IGNORE` here.
+   *
    * @default ScaleInProtectedInstances.IGNORE
    */
   readonly scaleInProtectedInstances?: ScaleInProtectedInstances;
@@ -942,6 +947,10 @@ export interface InstanceRefreshOptions {
 
   /**
    * What to do with instances that are in the `Standby` state.
+   *
+   * Terraform deviation: as with `scaleInProtectedInstances`, the API and CloudFormation
+   * default to `WAIT` but the provider schema defaults the argument to `Ignore` and always
+   * sends it, so leaving this unset means `IGNORE` here.
    *
    * @default StandbyInstances.IGNORE
    */
@@ -984,6 +993,11 @@ function renderInstanceRefreshPreferences(
       );
     }
     checkpointPercentages.forEach((percentage, i) => {
+      if (!Number.isInteger(percentage)) {
+        throw new UnscopedValidationError(
+          `checkpointPercentages must be whole numbers, got ${percentage}`,
+        );
+      }
       if (percentage < 1 || percentage > 100) {
         throw new UnscopedValidationError(
           `checkpointPercentages must be between 1 and 100, got ${percentage}`,
@@ -1016,21 +1030,29 @@ function renderInstanceRefreshPreferences(
       "minHealthyPercentage must be specified when maxHealthyPercentage is specified",
     );
   }
-  if (
-    minHealthyPercentage !== undefined &&
-    (minHealthyPercentage < 0 || minHealthyPercentage > 100)
-  ) {
-    throw new UnscopedValidationError(
-      `minHealthyPercentage must be between 0 and 100, got ${minHealthyPercentage}`,
-    );
+  if (minHealthyPercentage !== undefined) {
+    if (!Number.isInteger(minHealthyPercentage)) {
+      throw new UnscopedValidationError(
+        `minHealthyPercentage must be a whole number, got ${minHealthyPercentage}`,
+      );
+    }
+    if (minHealthyPercentage < 0 || minHealthyPercentage > 100) {
+      throw new UnscopedValidationError(
+        `minHealthyPercentage must be between 0 and 100, got ${minHealthyPercentage}`,
+      );
+    }
   }
-  if (
-    maxHealthyPercentage !== undefined &&
-    (maxHealthyPercentage < 100 || maxHealthyPercentage > 200)
-  ) {
-    throw new UnscopedValidationError(
-      `maxHealthyPercentage must be between 100 and 200, got ${maxHealthyPercentage}`,
-    );
+  if (maxHealthyPercentage !== undefined) {
+    if (!Number.isInteger(maxHealthyPercentage)) {
+      throw new UnscopedValidationError(
+        `maxHealthyPercentage must be a whole number, got ${maxHealthyPercentage}`,
+      );
+    }
+    if (maxHealthyPercentage < 100 || maxHealthyPercentage > 200) {
+      throw new UnscopedValidationError(
+        `maxHealthyPercentage must be between 100 and 200, got ${maxHealthyPercentage}`,
+      );
+    }
   }
   if (
     minHealthyPercentage !== undefined &&
@@ -1044,9 +1066,12 @@ function renderInstanceRefreshPreferences(
 
   const preferences: autoscalingGroup.AutoscalingGroupInstanceRefreshPreferences =
     {
-      alarmSpecification: alarms
-        ? { alarms: alarms.map((alarm) => alarm.alarmName) }
-        : undefined,
+      // an empty list is not "monitor no alarms", it is an alarm specification the
+      // API rejects - omit the block entirely, the way `triggers: []` is omitted
+      alarmSpecification:
+        alarms && alarms.length > 0
+          ? { alarms: alarms.map((alarm) => alarm.alarmName) }
+          : undefined,
       autoRollback,
       // Terraform deviation: the provider types these two as strings even though the API takes
       // a number of seconds, so render the seconds instead of an ISO-8601 duration.
@@ -1074,6 +1099,8 @@ function validateDurationSeconds(
   if (duration.isUnresolved()) {
     return;
   }
+  // `toSeconds()` itself rejects a duration that is not a whole number of seconds,
+  // which is what the API requires - no separate integer check is needed here.
   const seconds = duration.toSeconds();
   if (seconds < min || seconds > max) {
     throw new UnscopedValidationError(

--- a/src/aws/compute/auto-scaling/auto-scaling-group.ts
+++ b/src/aws/compute/auto-scaling/auto-scaling-group.ts
@@ -82,10 +82,17 @@ export enum Monitoring {
  * `CreationPolicy`/`UpdatePolicy` attribute pair (surfaced on this construct via the deprecated
  * `updateType`/`rollingUpdateConfiguration`/`resourceSignalCount`/`resourceSignalTimeout`/
  * `replacingUpdateMinSuccessfulInstancesPercent` properties and their `Signals`/`UpdatePolicy`
- * replacements) plus a CloudFormation-Init integration (`init`/`initOptions`). Both are
- * CloudFormation-template concepts with no Terraform resource attribute or provider behavior to
- * back them - `aws_autoscaling_group` has no creation/update-policy or init equivalent - so none
- * of that surface is ported here.
+ * replacements) plus a CloudFormation-Init integration (`init`/`initOptions`). Most of that is
+ * CloudFormation-template machinery with no Terraform resource attribute or provider behavior to
+ * back it - `aws_autoscaling_group` has no creation-policy, resource-signal or init equivalent -
+ * so `signals`, `init`/`initOptions` and the deprecated `updateType` family are not ported.
+ *
+ * The one exception is CloudFormation's `UpdatePolicy.AutoScalingInstanceRefresh`, which does have
+ * a direct Terraform counterpart in the `instance_refresh` block. It is ported here as
+ * `updatePolicy: UpdatePolicy.instanceRefresh(...)` - see `UpdatePolicy`. CloudFormation's other
+ * two update policies (`AutoScalingReplacingUpdate` and `AutoScalingRollingUpdate`) orchestrate
+ * instance replacement from the CloudFormation side and have no provider equivalent, so
+ * `UpdatePolicy.replacingUpdate()` / `UpdatePolicy.rollingUpdate()` are deliberately absent.
  */
 export interface CommonAutoScalingGroupProps {
   /**
@@ -358,6 +365,17 @@ export interface CommonAutoScalingGroupProps {
    * @default None
    */
   readonly azCapacityDistributionStrategy?: CapacityDistributionStrategy;
+
+  /**
+   * How existing instances are updated when the Auto Scaling group's configuration changes.
+   *
+   * Without an update policy a change to the launch template (a new baked AMI, for example)
+   * only applies to instances launched from then on - the instances already running keep the
+   * old configuration until something else replaces them.
+   *
+   * @default - No update policy. Running instances are left untouched when the group changes.
+   */
+  readonly updatePolicy?: UpdatePolicy;
 }
 
 /**
@@ -708,6 +726,360 @@ export interface AutoScalingGroupProps
    * @default - No instance maintenance policy.
    */
   readonly minHealthyPercentage?: number;
+}
+
+/**
+ * How existing instances should be updated when the Auto Scaling group changes.
+ *
+ * Terraform deviation: upstream AWS CDK renders this to the CloudFormation `UpdatePolicy`
+ * attribute and offers `replacingUpdate()` and `rollingUpdate()`, both of which are driven by
+ * CloudFormation itself and have no `aws_autoscaling_group` counterpart. Only
+ * `AutoScalingInstanceRefresh` maps onto a real provider feature (the `instance_refresh` block),
+ * so `instanceRefresh()` is the only policy available here.
+ */
+export abstract class UpdatePolicy {
+  /**
+   * Replace the instances in the Auto Scaling group by starting an instance refresh.
+   *
+   * A refresh is always triggered by a change to the group's launch template or mixed instances
+   * policy; `triggers` adds further attributes to watch.
+   *
+   * @see https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-instance-refresh.html
+   */
+  public static instanceRefresh(
+    options: InstanceRefreshOptions = {},
+  ): UpdatePolicy {
+    const preferences = renderInstanceRefreshPreferences(options);
+
+    return new (class extends UpdatePolicy {
+      public _renderInstanceRefresh(): autoscalingGroup.AutoscalingGroupInstanceRefresh {
+        return {
+          strategy: options.strategy ?? InstanceRefreshStrategy.ROLLING,
+          triggers:
+            options.triggers && options.triggers.length > 0
+              ? options.triggers
+              : undefined,
+          preferences,
+        };
+      }
+    })();
+  }
+
+  /**
+   * Render the `instance_refresh` block of the underlying `aws_autoscaling_group`.
+   *
+   * @internal
+   */
+  public abstract _renderInstanceRefresh(): autoscalingGroup.AutoscalingGroupInstanceRefresh;
+}
+
+/**
+ * The strategy an instance refresh uses to replace instances.
+ */
+export enum InstanceRefreshStrategy {
+  /**
+   * Replace instances a batch at a time, respecting the configured healthy percentages.
+   *
+   * Terraform deviation: CloudFormation additionally accepts `ReplaceRootVolume`, but the
+   * AWS provider rejects any `strategy` other than `Rolling`.
+   */
+  ROLLING = "Rolling",
+}
+
+/**
+ * What an instance refresh does with instances that are protected from scale in.
+ */
+export enum ScaleInProtectedInstances {
+  /**
+   * Replace instances that are protected from scale in.
+   */
+  REFRESH = "Refresh",
+
+  /**
+   * Leave instances that are protected from scale in alone and keep replacing the rest.
+   */
+  IGNORE = "Ignore",
+
+  /**
+   * Wait one hour for scale-in protection to be removed, then fail the refresh.
+   */
+  WAIT = "Wait",
+}
+
+/**
+ * What an instance refresh does with instances that are in the `Standby` state.
+ */
+export enum StandbyInstances {
+  /**
+   * Terminate instances that are in `Standby`.
+   */
+  TERMINATE = "Terminate",
+
+  /**
+   * Leave instances that are in `Standby` alone and keep replacing the `InService` ones.
+   */
+  IGNORE = "Ignore",
+
+  /**
+   * Wait one hour for the instances to be returned to service, then fail the refresh.
+   */
+  WAIT = "Wait",
+}
+
+/**
+ * Options for customizing the instance refresh.
+ *
+ * These map onto the `instance_refresh` block of `aws_autoscaling_group`, which in turn mirrors
+ * the `Preferences` of CloudFormation's `AutoScalingInstanceRefresh` update policy.
+ *
+ * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-instancerefresh
+ */
+export interface InstanceRefreshOptions {
+  /**
+   * The strategy to use for the instance refresh.
+   *
+   * @default InstanceRefreshStrategy.ROLLING
+   */
+  readonly strategy?: InstanceRefreshStrategy;
+
+  /**
+   * Additional Auto Scaling group attributes whose change should trigger an instance refresh.
+   *
+   * Terraform deviation: this has no CloudFormation equivalent. CloudFormation refreshes on a
+   * fixed set of property changes, whereas the provider always refreshes on `launch_template` /
+   * `mixed_instances_policy` changes and lets you opt into more. Values are
+   * `aws_autoscaling_group` attribute names, for example `tag`, `desired_capacity` or
+   * `vpc_zone_identifier`.
+   *
+   * @default - Only launch template and mixed instances policy changes trigger a refresh.
+   */
+  readonly triggers?: string[];
+
+  /**
+   * CloudWatch alarms to monitor while the instance refresh runs.
+   *
+   * If any of them goes into `ALARM` state the instance refresh fails. At most 10 alarms
+   * may be specified.
+   *
+   * @default - No alarms are monitored.
+   */
+  readonly alarms?: cloudwatch.IAlarm[];
+
+  /**
+   * Whether to roll the group back to its previous configuration if the instance refresh fails.
+   *
+   * Terraform deviation: CloudFormation has no `AutoRollback` preference because it rolls the
+   * whole stack back instead. The provider exposes the underlying Auto Scaling API option
+   * directly.
+   *
+   * @default false
+   */
+  readonly autoRollback?: boolean;
+
+  /**
+   * How long to wait at each checkpoint before continuing.
+   *
+   * Only meaningful together with `checkpointPercentages`.
+   *
+   * @default - AWS default of 1 hour when `checkpointPercentages` is set.
+   */
+  readonly checkpointDelay?: Duration;
+
+  /**
+   * Threshold percentages at which the instance refresh pauses, in ascending order.
+   *
+   * Each value must be unique. To replace every instance in the group the last value must
+   * be `100`.
+   *
+   * @see https://docs.aws.amazon.com/autoscaling/ec2/userguide/asg-adding-checkpoints-instance-refresh.html
+   *
+   * @default - The refresh runs to completion without checkpoints.
+   */
+  readonly checkpointPercentages?: number[];
+
+  /**
+   * How long the refresh waits after a new instance enters the `InService` state before
+   * moving on to the next one.
+   *
+   * @default - The group's `defaultInstanceWarmup`, or its health check grace period.
+   */
+  readonly instanceWarmup?: Duration;
+
+  /**
+   * The maximum percentage of the desired capacity that may be in service and healthy, or
+   * pending, while instances are being replaced.
+   *
+   * Value range is 100 to 200. If specified, `minHealthyPercentage` must be specified too and
+   * the difference between them cannot be greater than 100.
+   *
+   * @default - The group's instance maintenance policy if set, otherwise the AWS default.
+   */
+  readonly maxHealthyPercentage?: number;
+
+  /**
+   * The minimum percentage of the desired capacity that must stay in service, healthy and
+   * ready to use for the refresh to continue.
+   *
+   * Value range is 0 to 100.
+   *
+   * @default - The group's instance maintenance policy if set, otherwise the AWS default.
+   */
+  readonly minHealthyPercentage?: number;
+
+  /**
+   * What to do with instances that are protected from scale in.
+   *
+   * @default ScaleInProtectedInstances.IGNORE
+   */
+  readonly scaleInProtectedInstances?: ScaleInProtectedInstances;
+
+  /**
+   * Whether to skip replacing instances that already match the desired configuration.
+   *
+   * @default false
+   */
+  readonly skipMatching?: boolean;
+
+  /**
+   * What to do with instances that are in the `Standby` state.
+   *
+   * @default StandbyInstances.IGNORE
+   */
+  readonly standbyInstances?: StandbyInstances;
+}
+
+/**
+ * Validate the instance refresh options and render them into the provider's `preferences` block.
+ *
+ * Validation happens eagerly in `UpdatePolicy.instanceRefresh()` so mistakes surface where the
+ * options are written rather than at synth time, which is why this throws
+ * `UnscopedValidationError` - there is no construct in scope yet.
+ */
+function renderInstanceRefreshPreferences(
+  options: InstanceRefreshOptions,
+): autoscalingGroup.AutoscalingGroupInstanceRefreshPreferences | undefined {
+  const {
+    alarms,
+    autoRollback,
+    checkpointDelay,
+    checkpointPercentages,
+    instanceWarmup,
+    maxHealthyPercentage,
+    minHealthyPercentage,
+    scaleInProtectedInstances,
+    skipMatching,
+    standbyInstances,
+  } = options;
+
+  if (alarms && alarms.length > 10) {
+    throw new UnscopedValidationError(
+      `Up to 10 alarms may be monitored during an instance refresh, got ${alarms.length}`,
+    );
+  }
+
+  if (checkpointPercentages !== undefined) {
+    if (checkpointPercentages.length === 0) {
+      throw new UnscopedValidationError(
+        "checkpointPercentages must contain at least one value",
+      );
+    }
+    checkpointPercentages.forEach((percentage, i) => {
+      if (percentage < 1 || percentage > 100) {
+        throw new UnscopedValidationError(
+          `checkpointPercentages must be between 1 and 100, got ${percentage}`,
+        );
+      }
+      if (i > 0 && percentage <= checkpointPercentages[i - 1]) {
+        throw new UnscopedValidationError(
+          `checkpointPercentages must be unique and in ascending order, got ${JSON.stringify(checkpointPercentages)}`,
+        );
+      }
+    });
+  } else if (checkpointDelay !== undefined) {
+    throw new UnscopedValidationError(
+      "checkpointDelay can only be specified together with checkpointPercentages",
+    );
+  }
+
+  if (checkpointDelay !== undefined) {
+    validateDurationSeconds("checkpointDelay", checkpointDelay, 0, 172800);
+  }
+  if (instanceWarmup !== undefined) {
+    validateDurationSeconds("instanceWarmup", instanceWarmup, 0, 21600);
+  }
+
+  if (
+    maxHealthyPercentage !== undefined &&
+    minHealthyPercentage === undefined
+  ) {
+    throw new UnscopedValidationError(
+      "minHealthyPercentage must be specified when maxHealthyPercentage is specified",
+    );
+  }
+  if (
+    minHealthyPercentage !== undefined &&
+    (minHealthyPercentage < 0 || minHealthyPercentage > 100)
+  ) {
+    throw new UnscopedValidationError(
+      `minHealthyPercentage must be between 0 and 100, got ${minHealthyPercentage}`,
+    );
+  }
+  if (
+    maxHealthyPercentage !== undefined &&
+    (maxHealthyPercentage < 100 || maxHealthyPercentage > 200)
+  ) {
+    throw new UnscopedValidationError(
+      `maxHealthyPercentage must be between 100 and 200, got ${maxHealthyPercentage}`,
+    );
+  }
+  if (
+    minHealthyPercentage !== undefined &&
+    maxHealthyPercentage !== undefined &&
+    maxHealthyPercentage - minHealthyPercentage > 100
+  ) {
+    throw new UnscopedValidationError(
+      `The difference between minHealthyPercentage and maxHealthyPercentage cannot be greater than 100, got ${maxHealthyPercentage - minHealthyPercentage}`,
+    );
+  }
+
+  const preferences: autoscalingGroup.AutoscalingGroupInstanceRefreshPreferences =
+    {
+      alarmSpecification: alarms
+        ? { alarms: alarms.map((alarm) => alarm.alarmName) }
+        : undefined,
+      autoRollback,
+      // Terraform deviation: the provider types these two as strings even though the API takes
+      // a number of seconds, so render the seconds instead of an ISO-8601 duration.
+      checkpointDelay: checkpointDelay?.toSeconds().toString(),
+      checkpointPercentages,
+      instanceWarmup: instanceWarmup?.toSeconds().toString(),
+      maxHealthyPercentage,
+      minHealthyPercentage,
+      scaleInProtectedInstances,
+      skipMatching,
+      standbyInstances,
+    };
+
+  return Object.values(preferences).every((value) => value === undefined)
+    ? undefined
+    : preferences;
+}
+
+function validateDurationSeconds(
+  name: string,
+  duration: Duration,
+  min: number,
+  max: number,
+): void {
+  if (duration.isUnresolved()) {
+    return;
+  }
+  const seconds = duration.toSeconds();
+  if (seconds < min || seconds > max) {
+    throw new UnscopedValidationError(
+      `${name} must be between ${min} and ${max} seconds, got ${seconds}`,
+    );
+  }
 }
 
 /**
@@ -1436,6 +1808,7 @@ export class AutoScalingGroup
         props.minHealthyPercentage,
         props.maxHealthyPercentage,
       ),
+      instanceRefresh: props.updatePolicy?._renderInstanceRefresh(),
       ...this.getLaunchSettings(
         props.launchTemplate ?? launchTemplateFromConfig,
         props.mixedInstancesPolicy,

--- a/src/aws/compute/ecs/cluster.ts
+++ b/src/aws/compute/ecs/cluster.ts
@@ -688,11 +688,12 @@ export class Cluster extends AwsConstructBase implements ICluster {
         ? MachineImageType.BOTTLEROCKET
         : MachineImageType.AMAZON_LINUX_2);
 
-    // TERRACONSTRUCTS DEVIATION: upstream additionally threads `updateType`/`updatePolicy`
-    // into the created AutoScalingGroup here (CloudFormation `UpdatePolicy`/`CreationPolicy`).
-    // This repo's `autoscaling.CommonAutoScalingGroupProps` has no update-policy surface --
-    // `aws_autoscaling_group` has no equivalent Terraform attribute -- so that plumbing is
-    // omitted (see `auto-scaling-group.ts` `CommonAutoScalingGroupProps` doc comment).
+    // TERRACONSTRUCTS DEVIATION: upstream additionally defaults the deprecated `updateType` to
+    // `UpdateType.REPLACING_UPDATE` here, a CloudFormation `UpdatePolicy`/`CreationPolicy`
+    // concept with no `aws_autoscaling_group` attribute behind it, so that default is omitted
+    // (see the `CommonAutoScalingGroupProps` doc comment in `auto-scaling-group.ts`). An
+    // explicit `updatePolicy: UpdatePolicy.instanceRefresh(...)` does reach the group - it
+    // rides along in the `...options` spread below.
     const autoScalingGroup = new autoscaling.AutoScalingGroup(this, id, {
       vpc: this.vpc,
       machineImage,

--- a/test/aws/compute/auto-scaling/auto-scaling-group.test.ts
+++ b/test/aws/compute/auto-scaling/auto-scaling-group.test.ts
@@ -3142,13 +3142,325 @@ describe("InstanceMaintenancePolicy", () => {
   });
 });
 
-// Not supported by Terraform Provider: `migrateToLaunchTemplate` /
-// `updatePolicy` (AutoScalingReplacingUpdate / AutoScalingRollingUpdate) are
-// CloudFormation UpdatePolicy concepts with no aws_autoscaling_group
-// equivalent - see the deviation note on CommonAutoScalingGroupProps in
-// src/aws/compute/auto-scaling/auto-scaling-group.ts. Neither
-// `migrateToLaunchTemplate` nor `updatePolicy` is a property of
-// AutoScalingGroupProps in this port.
+describe("UpdatePolicy", () => {
+  test("no update policy by default", () => {
+    // GIVEN
+    const stack = new AwsStack(Testing.app());
+    const vpc = mockVpc(stack);
+
+    // WHEN
+    new autoscaling.AutoScalingGroup(stack, "ASG", {
+      vpc,
+      instanceType: new InstanceType("t2.micro"),
+      machineImage: MachineImage.latestAmazonLinux2(),
+    });
+
+    // THEN
+    expect(synthAsg(stack).instance_refresh).toBeUndefined();
+  });
+
+  test("instanceRefresh() renders the Rolling strategy with no preferences", () => {
+    // GIVEN
+    const stack = new AwsStack(Testing.app());
+    const vpc = mockVpc(stack);
+
+    // WHEN
+    new autoscaling.AutoScalingGroup(stack, "ASG", {
+      vpc,
+      instanceType: new InstanceType("t2.micro"),
+      machineImage: MachineImage.latestAmazonLinux2(),
+      updatePolicy: autoscaling.UpdatePolicy.instanceRefresh(),
+    });
+
+    // THEN
+    const asg = synthAsg(stack);
+    expect(asg.instance_refresh).toEqual({ strategy: "Rolling" });
+  });
+
+  test("updatePolicy is part of CommonAutoScalingGroupProps", () => {
+    // GIVEN
+    const stack = new AwsStack(Testing.app());
+    const vpc = mockVpc(stack);
+
+    // WHEN
+    // constructs that compose an AutoScalingGroup (ecs.Cluster#addCapacity,
+    // AsgCapacityProvider, ...) accept CommonAutoScalingGroupProps and spread it
+    // onto the group, so the policy has to live on the common interface to reach
+    // them.
+    const common: autoscaling.CommonAutoScalingGroupProps = {
+      updatePolicy: autoscaling.UpdatePolicy.instanceRefresh(),
+    };
+    new autoscaling.AutoScalingGroup(stack, "ASG", {
+      vpc,
+      instanceType: new InstanceType("t2.micro"),
+      machineImage: MachineImage.latestAmazonLinux2(),
+      ...common,
+    });
+
+    // THEN
+    expect(synthAsg(stack).instance_refresh).toEqual({ strategy: "Rolling" });
+  });
+
+  test("instanceRefresh() renders every supported preference", () => {
+    // GIVEN
+    const stack = new AwsStack(Testing.app());
+    const vpc = mockVpc(stack);
+    const alarm = new cloudwatch.Alarm(stack, "RefreshAlarm", {
+      metric: new cloudwatch.Metric({
+        namespace: "Test",
+        metricName: "Metric",
+      }),
+      threshold: 1,
+      evaluationPeriods: 1,
+    });
+
+    // WHEN
+    new autoscaling.AutoScalingGroup(stack, "ASG", {
+      vpc,
+      instanceType: new InstanceType("t2.micro"),
+      machineImage: MachineImage.latestAmazonLinux2(),
+      updatePolicy: autoscaling.UpdatePolicy.instanceRefresh({
+        strategy: autoscaling.InstanceRefreshStrategy.ROLLING,
+        triggers: ["tag", "desired_capacity"],
+        alarms: [alarm],
+        autoRollback: true,
+        checkpointPercentages: [25, 50, 100],
+        checkpointDelay: Duration.minutes(10),
+        instanceWarmup: Duration.minutes(5),
+        minHealthyPercentage: 90,
+        maxHealthyPercentage: 110,
+        scaleInProtectedInstances:
+          autoscaling.ScaleInProtectedInstances.REFRESH,
+        skipMatching: true,
+        standbyInstances: autoscaling.StandbyInstances.TERMINATE,
+      }),
+    });
+
+    // THEN
+    Template.synth(stack).toHaveResourceWithProperties(
+      autoscalingGroup.AutoscalingGroup,
+      {
+        instance_refresh: {
+          strategy: "Rolling",
+          triggers: ["tag", "desired_capacity"],
+          preferences: {
+            alarm_specification: {
+              alarms: [stack.resolve(alarm.alarmName)],
+            },
+            auto_rollback: true,
+            // Terraform deviation: the provider types checkpoint_delay and
+            // instance_warmup as strings even though the API takes seconds.
+            checkpoint_delay: "600",
+            checkpoint_percentages: [25, 50, 100],
+            instance_warmup: "300",
+            max_healthy_percentage: 110,
+            min_healthy_percentage: 90,
+            scale_in_protected_instances: "Refresh",
+            skip_matching: true,
+            standby_instances: "Terminate",
+          },
+        },
+      },
+    );
+  });
+
+  test("an instance refresh and an instance maintenance policy are independent", () => {
+    // GIVEN
+    const stack = new AwsStack(Testing.app());
+    const vpc = mockVpc(stack);
+
+    // WHEN
+    new autoscaling.AutoScalingGroup(stack, "ASG", {
+      vpc,
+      instanceType: new InstanceType("t2.micro"),
+      machineImage: MachineImage.latestAmazonLinux2(),
+      // the group-level instance maintenance policy...
+      minHealthyPercentage: 100,
+      maxHealthyPercentage: 200,
+      // ...and the refresh-scoped preferences of the same name are separate
+      // fields: the preferences only apply while a refresh is running.
+      updatePolicy: autoscaling.UpdatePolicy.instanceRefresh({
+        minHealthyPercentage: 50,
+        maxHealthyPercentage: 150,
+      }),
+    });
+
+    // THEN
+    const asg = synthAsg(stack);
+    expect(asg.instance_maintenance_policy).toEqual({
+      min_healthy_percentage: 100,
+      max_healthy_percentage: 200,
+    });
+    expect(asg.instance_refresh.preferences).toEqual({
+      min_healthy_percentage: 50,
+      max_healthy_percentage: 150,
+    });
+  });
+
+  test("minHealthyPercentage/maxHealthyPercentage alone do not trigger a refresh", () => {
+    // GIVEN
+    const stack = new AwsStack(Testing.app());
+    const vpc = mockVpc(stack);
+
+    // WHEN
+    new autoscaling.AutoScalingGroup(stack, "ASG", {
+      vpc,
+      instanceType: new InstanceType("t2.micro"),
+      machineImage: MachineImage.latestAmazonLinux2(),
+      minHealthyPercentage: 100,
+      maxHealthyPercentage: 200,
+    });
+
+    // THEN
+    // https://github.com/TerraConstructs/base/issues/129 - the instance
+    // maintenance policy governs replacements the group performs anyway; only
+    // `instance_refresh` makes a launch template change roll out.
+    const asg = synthAsg(stack);
+    expect(asg.instance_maintenance_policy).toBeDefined();
+    expect(asg.instance_refresh).toBeUndefined();
+  });
+
+  test("empty triggers are omitted", () => {
+    // GIVEN
+    const stack = new AwsStack(Testing.app());
+    const vpc = mockVpc(stack);
+
+    // WHEN
+    new autoscaling.AutoScalingGroup(stack, "ASG", {
+      vpc,
+      instanceType: new InstanceType("t2.micro"),
+      machineImage: MachineImage.latestAmazonLinux2(),
+      updatePolicy: autoscaling.UpdatePolicy.instanceRefresh({ triggers: [] }),
+    });
+
+    // THEN
+    expect(synthAsg(stack).instance_refresh).toEqual({ strategy: "Rolling" });
+  });
+
+  test("throws if more than 10 alarms are specified", () => {
+    // GIVEN
+    const stack = new AwsStack(Testing.app());
+    const metric = new cloudwatch.Metric({
+      namespace: "Test",
+      metricName: "Metric",
+    });
+    const alarms = Array.from(
+      { length: 11 },
+      (_, i) =>
+        new cloudwatch.Alarm(stack, `Alarm${i}`, {
+          metric,
+          threshold: 1,
+          evaluationPeriods: 1,
+        }),
+    );
+
+    // THEN
+    expect(() => autoscaling.UpdatePolicy.instanceRefresh({ alarms })).toThrow(
+      /Up to 10 alarms may be monitored during an instance refresh, got 11/,
+    );
+  });
+
+  test("throws if checkpointDelay is set without checkpointPercentages", () => {
+    expect(() =>
+      autoscaling.UpdatePolicy.instanceRefresh({
+        checkpointDelay: Duration.minutes(5),
+      }),
+    ).toThrow(
+      /checkpointDelay can only be specified together with checkpointPercentages/,
+    );
+  });
+
+  test("throws if checkpointPercentages are empty", () => {
+    expect(() =>
+      autoscaling.UpdatePolicy.instanceRefresh({ checkpointPercentages: [] }),
+    ).toThrow(/checkpointPercentages must contain at least one value/);
+  });
+
+  test("throws if checkpointPercentages are not ascending and unique", () => {
+    expect(() =>
+      autoscaling.UpdatePolicy.instanceRefresh({
+        checkpointPercentages: [50, 25, 100],
+      }),
+    ).toThrow(/checkpointPercentages must be unique and in ascending order/);
+
+    expect(() =>
+      autoscaling.UpdatePolicy.instanceRefresh({
+        checkpointPercentages: [50, 50, 100],
+      }),
+    ).toThrow(/checkpointPercentages must be unique and in ascending order/);
+  });
+
+  test("throws if a checkpoint percentage is out of range", () => {
+    expect(() =>
+      autoscaling.UpdatePolicy.instanceRefresh({
+        checkpointPercentages: [0, 100],
+      }),
+    ).toThrow(/checkpointPercentages must be between 1 and 100, got 0/);
+  });
+
+  test("throws if checkpointDelay is out of range", () => {
+    expect(() =>
+      autoscaling.UpdatePolicy.instanceRefresh({
+        checkpointPercentages: [100],
+        checkpointDelay: Duration.days(3),
+      }),
+    ).toThrow(
+      /checkpointDelay must be between 0 and 172800 seconds, got 259200/,
+    );
+  });
+
+  test("throws if instanceWarmup is out of range", () => {
+    expect(() =>
+      autoscaling.UpdatePolicy.instanceRefresh({
+        instanceWarmup: Duration.hours(7),
+      }),
+    ).toThrow(/instanceWarmup must be between 0 and 21600 seconds, got 25200/);
+  });
+
+  test("throws if maxHealthyPercentage is specified without minHealthyPercentage", () => {
+    expect(() =>
+      autoscaling.UpdatePolicy.instanceRefresh({ maxHealthyPercentage: 110 }),
+    ).toThrow(
+      /minHealthyPercentage must be specified when maxHealthyPercentage is specified/,
+    );
+  });
+
+  test("throws if minHealthyPercentage is out of range", () => {
+    expect(() =>
+      autoscaling.UpdatePolicy.instanceRefresh({ minHealthyPercentage: 101 }),
+    ).toThrow(/minHealthyPercentage must be between 0 and 100, got 101/);
+  });
+
+  test("throws if maxHealthyPercentage is out of range", () => {
+    expect(() =>
+      autoscaling.UpdatePolicy.instanceRefresh({
+        minHealthyPercentage: 100,
+        maxHealthyPercentage: 250,
+      }),
+    ).toThrow(/maxHealthyPercentage must be between 100 and 200, got 250/);
+  });
+
+  test("throws if the healthy percentage range is greater than 100", () => {
+    expect(() =>
+      autoscaling.UpdatePolicy.instanceRefresh({
+        minHealthyPercentage: 0,
+        maxHealthyPercentage: 200,
+      }),
+    ).toThrow(
+      /The difference between minHealthyPercentage and maxHealthyPercentage cannot be greater than 100, got 200/,
+    );
+  });
+});
+
+// Not supported by Terraform Provider: `migrateToLaunchTemplate` is a
+// launch-configuration migration knob for a resource shape this port never
+// synthesizes, and `UpdatePolicy.replacingUpdate()` /
+// `UpdatePolicy.rollingUpdate()` are CloudFormation-driven policies with no
+// aws_autoscaling_group equivalent - see the deviation note on
+// CommonAutoScalingGroupProps in
+// src/aws/compute/auto-scaling/auto-scaling-group.ts. `updatePolicy` does exist
+// on AutoScalingGroupProps in this port, but only carries
+// `UpdatePolicy.instanceRefresh()` (see the "UpdatePolicy" describe block).
 test.skip("throws if updatePolicy is not set when migrateToLaunchTemplate is true", () => {
   // migrateToLaunchTemplate / updatePolicy not ported.
 });
@@ -3159,6 +3471,18 @@ test.skip("throws if updatePolicy is set with AutoScalingReplacingUpdate when mi
 
 function mockSecurityGroup(stack: AwsStack) {
   return SecurityGroup.fromSecurityGroupId(stack, "MySG", "most-secure");
+}
+
+/**
+ * The single synthesized `aws_autoscaling_group` object, for assertions on
+ * blocks that are expected to be absent (which `toHaveResourceWithProperties`
+ * cannot express).
+ */
+function synthAsg(stack: AwsStack): any {
+  const [asg] = Object.values(
+    Template.resourceObjects(stack, autoscalingGroup.AutoscalingGroup),
+  ) as any[];
+  return asg;
 }
 
 function getTestStack(): AwsStack {

--- a/test/aws/compute/auto-scaling/auto-scaling-group.test.ts
+++ b/test/aws/compute/auto-scaling/auto-scaling-group.test.ts
@@ -3337,6 +3337,55 @@ describe("UpdatePolicy", () => {
     expect(synthAsg(stack).instance_refresh).toEqual({ strategy: "Rolling" });
   });
 
+  test("an empty alarm list is omitted rather than rendered", () => {
+    // GIVEN
+    const stack = new AwsStack(Testing.app());
+    const vpc = mockVpc(stack);
+
+    // WHEN
+    new autoscaling.AutoScalingGroup(stack, "ASG", {
+      vpc,
+      instanceType: new InstanceType("t2.micro"),
+      machineImage: MachineImage.latestAmazonLinux2(),
+      updatePolicy: autoscaling.UpdatePolicy.instanceRefresh({ alarms: [] }),
+    });
+
+    // THEN
+    // `alarm_specification.alarms` takes one or more alarm names, so an empty
+    // list is not "monitor nothing" - it is a specification the API rejects.
+    expect(synthAsg(stack).instance_refresh).toEqual({ strategy: "Rolling" });
+  });
+
+  test("protected and standby instance behavior is left to the provider default", () => {
+    // GIVEN
+    const stack = new AwsStack(Testing.app());
+    const vpc = mockVpc(stack);
+
+    // WHEN
+    new autoscaling.AutoScalingGroup(stack, "ASG", {
+      vpc,
+      instanceType: new InstanceType("t2.micro"),
+      machineImage: MachineImage.latestAmazonLinux2(),
+      updatePolicy: autoscaling.UpdatePolicy.instanceRefresh({
+        minHealthyPercentage: 90,
+      }),
+    });
+
+    // THEN
+    // Terraform deviation: the API (and CloudFormation) default both settings to
+    // `Wait`, but the AWS provider schema defaults the arguments to `Ignore` and
+    // always sends them, which is why `InstanceRefreshOptions` documents IGNORE.
+    // Synth cannot show that - the provider fills it in at plan time - so what is
+    // pinned here is that the construct emits neither key and lets the provider
+    // default stand. `tofu plan` on the autoscaling.update-policy integ fixture
+    // renders `scale_in_protected_instances = "Ignore"` / `standby_instances =
+    // "Ignore"` for exactly this config.
+    const preferences = synthAsg(stack).instance_refresh.preferences;
+    expect(preferences).toEqual({ min_healthy_percentage: 90 });
+    expect(preferences).not.toHaveProperty("scale_in_protected_instances");
+    expect(preferences).not.toHaveProperty("standby_instances");
+  });
+
   test("throws if more than 10 alarms are specified", () => {
     // GIVEN
     const stack = new AwsStack(Testing.app());
@@ -3449,6 +3498,42 @@ describe("UpdatePolicy", () => {
     ).toThrow(
       /The difference between minHealthyPercentage and maxHealthyPercentage cannot be greater than 100, got 200/,
     );
+  });
+
+  // the Auto Scaling API takes integer percentages and an integer number of
+  // seconds; a decimal is in range but renders as `90.5` / `"1.5"` and is
+  // rejected on apply, so it has to fail here where the options are written.
+  test("throws if minHealthyPercentage is not a whole number", () => {
+    expect(() =>
+      autoscaling.UpdatePolicy.instanceRefresh({ minHealthyPercentage: 90.5 }),
+    ).toThrow(/minHealthyPercentage must be a whole number, got 90.5/);
+  });
+
+  test("throws if maxHealthyPercentage is not a whole number", () => {
+    expect(() =>
+      autoscaling.UpdatePolicy.instanceRefresh({
+        minHealthyPercentage: 90,
+        maxHealthyPercentage: 110.5,
+      }),
+    ).toThrow(/maxHealthyPercentage must be a whole number, got 110.5/);
+  });
+
+  test("throws if a checkpoint percentage is not a whole number", () => {
+    expect(() =>
+      autoscaling.UpdatePolicy.instanceRefresh({
+        checkpointPercentages: [12.5, 100],
+      }),
+    ).toThrow(/checkpointPercentages must be whole numbers, got 12.5/);
+  });
+
+  test("throws if a duration is not a whole number of seconds", () => {
+    // this one comes from Duration#toSeconds rather than the factory, which is
+    // why the option validation does not repeat the check.
+    expect(() =>
+      autoscaling.UpdatePolicy.instanceRefresh({
+        instanceWarmup: Duration.seconds(1.5),
+      }),
+    ).toThrow(/1.5 must be a whole number of seconds/);
   });
 });
 


### PR DESCRIPTION
Fixes #129.

## The gap

`aws_autoscaling_group` has an `instance_refresh` block, but the v2.233.0 port never rendered one. A launch template change — a freshly baked AMI, say — only reached instances launched from then on; the instances already running kept the old configuration until something else replaced them. `min`/`maxHealthyPercentage` looks like the knob for this but maps to the *instance maintenance policy*, a different field that governs replacements the group performs anyway.

## Approach

Following @sakul-learning's option 2: an AWS-CDK-shaped update policy rather than the raw Terraform argument.

`updatePolicy` goes on `CommonAutoScalingGroupProps` (matching upstream, and so `ecs.Cluster#addCapacity` / `AsgCapacityProvider` inherit it), carrying the sole factory `UpdatePolicy.instanceRefresh(...)`. It renders to the provider's typed `instanceRefresh` argument behind an `@internal` method, so `AutoscalingGroupInstanceRefresh` stays out of the jsii manifest.

```ts
new autoscaling.AutoScalingGroup(this, 'ASG', {
  vpc, instanceType, machineImage,
  updatePolicy: autoscaling.UpdatePolicy.instanceRefresh({
    minHealthyPercentage: 90,
    instanceWarmup: Duration.minutes(5),
  }),
});
```

`InstanceRefreshOptions` covers the provider's full surface: `strategy`, `triggers`, `alarms` (as `cloudwatch.IAlarm[]`), `autoRollback`, `checkpointDelay`/`checkpointPercentages`, `instanceWarmup`, `min`/`maxHealthyPercentage`, `scaleInProtectedInstances`, `skipMatching`, `standbyInstances`. Options validate eagerly in the factory so mistakes surface where they're written rather than at synth time. `Duration` at the L2 boundary, second-strings internally — matching how the provider types `checkpoint_delay` and `instance_warmup`.

`asg.resource.addOverride` stays available as the escape hatch.

### On the constraints from the issue

- **`rollingUpdate()` is not equated with `instance_refresh`.** `AutoScalingReplacingUpdate` and `AutoScalingRollingUpdate` orchestrate replacement from the CloudFormation side and have no `aws_autoscaling_group` equivalent, so `UpdatePolicy.replacingUpdate()` / `.rollingUpdate()` are deliberately absent.
- **Mutual-exclusion validation has nothing to catch** as a consequence — there is no rolling-update policy in this port to combine an instance refresh with. Worth a look if you disagree.
- **Resource signals / CFN init remain unported**, and the `CommonAutoScalingGroupProps` deviation note now says exactly which parts of the CFN surface are and aren't backed by the provider.

### Terraform deviations flagged in the JSDoc

| | |
|---|---|
| `strategy` | only `Rolling`; the provider rejects CloudFormation's `ReplaceRootVolume` |
| `triggers`, `autoRollback` | no CloudFormation counterpart |
| CloudFormation `BakeTime` | no provider counterpart |

## Tests

18 unit cases in `test/aws/compute/auto-scaling/auto-scaling-group.test.ts`: rendering with no preferences and with every preference, `triggers` omission, a negative case per validation rule, that `updatePolicy` reaches the group through `CommonAutoScalingGroupProps`, and two that keep the two concepts distinct — maintenance policy and refresh preferences render independently, and a maintenance policy alone emits no `instance_refresh`.

The v2.233.0 port's skipped CFN-`UpdatePolicy` tests stay skipped; the comment above them now distinguishes the two policies that remain unported from `updatePolicy`, which exists. Per @so0k, cfn-signal unit tests are left for a follow-up pending SQS-based signal counting or a cfncompat signal resource.

## Integ

`integ/aws/compute/apps/autoscaling.update-policy.ts` is a structural port of upstream [`integ.asg-update-policy.ts`](https://github.com/aws/aws-cdk/blob/main/packages/%40aws-cdk-testing/framework-integ/test/aws-autoscaling/test/integ.asg-update-policy.ts), with `UpdatePolicy.rollingUpdate()` → `instanceRefresh()` and the cheap single-AZ public-subnet network the other compute fixtures use.

`TestAutoscalingUpdatePolicy` deploys, asserts no refresh has run, changes the launch template, applies again, then polls `DescribeInstanceRefreshes` and asserts the configured preferences reached `StartInstanceRefresh` — not just the Terraform config. That second apply lives inside the `validate` stage because the `%-synth-only` / `%-validate-only` make patterns only know the four standard stage names.

The fixture moves a user-data marker rather than baking a second AMI: either way the change lands in the launch template, which is what a refresh triggers on, and baking would cost the test an Image Builder run for the same signal. Happy to switch it to a real AMI swap if you'd rather the test mirror the reported scenario literally.

`make autoscaling.update-policy` runs it (45m timeout).

## Verification

`tsc` clean · jsii compiles, 6 warnings all pre-existing · 152 compute+ecs suites / 2857 tests pass · prettier clean · `go vet` clean.

**`make autoscaling.update-policy` passes against AWS** (us-east-1, 185s, `12 destroyed` — no orphans):

```
--- PASS: TestAutoscalingUpdatePolicy (185.11s)
```

First apply — `12 added` — renders the block as expected:

```hcl
+ instance_refresh {
    + strategy = "Rolling"
    + preferences {
        + instance_warmup              = "0"
        + max_healthy_percentage       = 100
        + min_healthy_percentage       = 0
        + scale_in_protected_instances = "Ignore"
        + skip_matching                = false
        + standby_instances            = "Ignore"
      }
  }
```

Second apply, after the launch template changes — `0 added, 2 changed` (launch template, then the ASG in-place) — and EC2 Auto Scaling starts the refresh. `DescribeInstanceRefreshes` returned one on the first poll a second after apply, so the provider starts it synchronously rather than leaving it queued. The assertions confirm the preferences reached `StartInstanceRefresh` itself, not merely the Terraform config: `MinHealthyPercentage=0`, `MaxHealthyPercentage=100`, `InstanceWarmup=0`.

That closes out the end-to-end behavior the issue reported missing: a launch template change now reaches the instances already running.
