### PR TITLE
feat(aws): port BatchSubmitJob SFN task + end-to-end SFN->Batch-on-ECS integ

### DIFF
--- a/integ/aws/compute/Makefile
+++ b/integ/aws/compute/Makefile
@@ -119,3 +119,7 @@ batch.job-queue: ## Test Batch JobQueue + FairshareSchedulingPolicy + 2 ManagedE
 batch.spot-mnp: ## Test Batch BEST_FIT spot fleet role policy + nested/five-group multinode job definitions (PR #136 review)
 	go test -v -count 1 -timeout 30m ./... -run ^TestBatchSpotMnp$
 .PHONY: batch.spot-mnp
+
+sfn.batch-submit-job: ## Test StepFunctions BatchSubmitJob task end-to-end (Pass -> BatchSubmitJob -> StateMachine, real EC2-backed Batch job execution)
+	go test -v -count 1 -timeout 40m ./... -run ^TestSfnBatchSubmitJob$
+.PHONY: sfn.batch-submit-job

--- a/integ/aws/compute/apps/sfn.batch-submit-job.ts
+++ b/integ/aws/compute/apps/sfn.batch-submit-job.ts
@@ -124,4 +124,50 @@ new aws.compute.StateMachine(stack, "StateMachine", {
   outputName: "state-machine",
 });
 
+// --- Cancellation fixture (no upstream counterpart): the StopExecution/TerminateJob
+// regression in sfn_batch_test.go needs a job that is reliably STILL RUNNING when the
+// validator stops the execution. The happy-path print-and-exit job races completion on
+// a warm compute environment, so the stop path gets its own INTENTIONALLY LONG-RUNNING
+// BUT BOUNDED workload (sleep 300 - Batch's attempt timeout below caps it even if
+// termination never arrives) and a UNIQUE job name (MyStopJob) so the validator
+// correlates jobs to this path without racing the happy-path job. ---
+const stopJobDefinition = new aws.compute.batch.EcsJobDefinition(
+  stack,
+  "StopJobDefinition",
+  {
+    container: new aws.compute.batch.EcsEc2ContainerDefinition(
+      stack,
+      "StopContainer",
+      {
+        image: aws.compute.ecs.ContainerImage.fromRegistry(
+          "public.ecr.aws/docker/library/python:3.13-alpine",
+        ),
+        command: ["python", "-c", "import time; time.sleep(300)"],
+        cpu: 256,
+        memory: Size.mebibytes(2048),
+      },
+    ),
+    registerOutputs: true,
+    outputName: "stop-job-definition",
+  },
+);
+
+const submitStopJob = new aws.compute.tasks.BatchSubmitJob(
+  stack,
+  "Submit Stop Job",
+  {
+    jobDefinitionArn: stopJobDefinition.jobDefinitionArn,
+    jobQueueArn: jobQueue.jobQueueArn,
+    jobName: "MyStopJob",
+    // Bounded even without termination: Batch kills the attempt at 360s.
+    taskTimeout: aws.compute.Timeout.duration(Duration.seconds(360)),
+  },
+);
+
+new aws.compute.StateMachine(stack, "StopStateMachine", {
+  definitionBody: aws.compute.DefinitionBody.fromChainable(submitStopJob),
+  registerOutputs: true,
+  outputName: "stop-state-machine",
+});
+
 app.synth();

--- a/integ/aws/compute/apps/sfn.batch-submit-job.ts
+++ b/integ/aws/compute/apps/sfn.batch-submit-job.ts
@@ -1,0 +1,127 @@
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/@aws-cdk-testing/framework-integ/test/aws-stepfunctions-tasks/test/batch/integ.submit-job.ts
+
+import { App, LocalBackend } from "cdktn";
+import { aws, Duration, Size } from "../../../../src";
+
+const environmentName = process.env.ENVIRONMENT_NAME ?? "test";
+const region = process.env.AWS_REGION ?? "us-east-1";
+const outdir = process.env.OUT_DIR ?? "cdktf.out";
+const stackName = process.env.STACK_NAME ?? "sfn.batch-submit-job";
+
+const app = new App({
+  outdir,
+});
+
+const stack = new aws.AwsStack(app, stackName, {
+  gridUUID: "g77777777-7777",
+  environmentName,
+  providerConfig: {
+    region,
+  },
+});
+new LocalBackend(stack, {
+  path: `${stackName}.tfstate`,
+});
+
+// Upstream (RunBatchStack in integ.submit-job.ts) uses a full ec2.Vpc(stack, 'vpc',
+// { restrictDefaultSecurityGroup: false }) with default NAT gateways per AZ. Unlike
+// batch.job-queue.ts (whose CEs never scale past minvCpus=0 and therefore need no
+// outbound path), this fixture's ManagedEc2EcsComputeEnvironment DOES launch an EC2
+// instance to run the submitted job, and that instance must reach the Batch/ECS/ECR
+// service endpoints. Rather than pay for NAT Gateways, pin the CE to PUBLIC subnets
+// (map-public-ip-on-launch gives the instance a public IP / route to the internet
+// gateway directly) - the same cost-saving swap ecs.asg-capacity-provider uses for
+// its capacity-provider-backed ASG.
+const vpc = new aws.compute.Vpc(stack, "vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [
+    {
+      name: "public",
+      subnetType: aws.compute.SubnetType.PUBLIC,
+      cidrMask: 24,
+    },
+  ],
+});
+
+const computeEnvironment = new aws.compute.batch.ManagedEc2EcsComputeEnvironment(
+  stack,
+  "ComputeEnv",
+  {
+    vpc,
+    // public-only VPC (above) - select the public subnets explicitly rather than
+    // relying on the no-private-subnets fallback of the default selection.
+    vpcSubnets: { subnetType: aws.compute.SubnetType.PUBLIC },
+    registerOutputs: true,
+    outputName: "compute-env",
+  },
+);
+
+const jobQueue = new aws.compute.batch.JobQueue(stack, "JobQueue", {
+  computeEnvironments: [
+    {
+      order: 1,
+      computeEnvironment,
+    },
+  ],
+  registerOutputs: true,
+  outputName: "job-queue",
+});
+
+const jobDefinition = new aws.compute.batch.EcsJobDefinition(
+  stack,
+  "JobDefinition",
+  {
+    container: new aws.compute.batch.EcsEc2ContainerDefinition(
+      stack,
+      "Container",
+      {
+        // Upstream pulls a Docker asset (batchjob-image/) that prints "Hello from
+        // Batch!" and exits 0. Replicate that behavior without an asset build by
+        // running the same one-liner through the public python:3.13-alpine image.
+        image: aws.compute.ecs.ContainerImage.fromRegistry(
+          "public.ecr.aws/docker/library/python:3.13-alpine",
+        ),
+        command: ["python", "-c", "print('Hello from Batch!')"],
+        cpu: 256,
+        memory: Size.mebibytes(2048),
+      },
+    ),
+    registerOutputs: true,
+    outputName: "job-definition",
+  },
+);
+
+const submitJob = new aws.compute.tasks.BatchSubmitJob(stack, "Submit Job", {
+  jobDefinitionArn: jobDefinition.jobDefinitionArn,
+  jobQueueArn: jobQueue.jobQueueArn,
+  jobName: "MyJob",
+  containerOverrides: {
+    environment: { key: "value" },
+    memory: Size.mebibytes(256),
+    vcpus: 1,
+  },
+  payload: aws.compute.TaskInput.fromObject({
+    foo: aws.compute.JsonPath.stringAt("$.bar"),
+  }),
+  attempts: 3,
+  // attempts renders into the SFN task's Parameters.RetryStrategy.Attempts (a Batch
+  // SubmitJob API field, retried by Batch itself) - NOT the job definition's
+  // retry_strategy - see the PlanExitCode assertion in sfn_batch_test.go.
+  taskTimeout: aws.compute.Timeout.duration(Duration.seconds(60)),
+  tags: {
+    key: "value",
+  },
+});
+
+const definition = new aws.compute.Pass(stack, "Start", {
+  result: aws.compute.Result.fromObject({ bar: "SomeValue" }),
+}).next(submitJob);
+
+new aws.compute.StateMachine(stack, "StateMachine", {
+  definitionBody: aws.compute.DefinitionBody.fromChainable(definition),
+  registerOutputs: true,
+  outputName: "state-machine",
+});
+
+app.synth();

--- a/integ/aws/compute/sfn_batch_test.go
+++ b/integ/aws/compute/sfn_batch_test.go
@@ -56,12 +56,14 @@ func validateSfnBatchSubmitJob(t *testing.T, tfWorkingDir, awsRegion string) {
 	jobDefinitionArn := util.LoadOutputAttribute(t, opts, "job-definition", "arn")
 	jobDefinitionName := util.LoadOutputAttribute(t, opts, "job-definition", "name")
 	computeEnvArn := util.LoadOutputAttribute(t, opts, "compute-env", "arn")
+	stopStateMachineArn := util.LoadOutputAttribute(t, opts, "stop-state-machine", "arn")
 	require.NotEmpty(t, stateMachineArn)
 	require.NotEmpty(t, jobQueueArn)
 	require.NotEmpty(t, jobQueueName)
 	require.NotEmpty(t, jobDefinitionArn)
 	require.NotEmpty(t, jobDefinitionName)
 	require.NotEmpty(t, computeEnvArn)
+	require.NotEmpty(t, stopStateMachineArn)
 
 	batchClient := util.NewBatchClient(t, awsRegion)
 	ctx := context.Background()
@@ -147,14 +149,15 @@ func validateSfnBatchSubmitJob(t *testing.T, tfWorkingDir, awsRegion string) {
 	// Step Functions issue a best-effort batch:TerminateJob for the in-flight job -
 	// without the grant the job would be orphaned and keep running/accruing cost
 	// (https://docs.aws.amazon.com/step-functions/latest/dg/service-integration-iam-templates.html#iam-cancel-tasks).
-	// Start a second execution and stop it while its job is still queued/running;
-	// the job must reach a terminal FAILED state (terminated), not SUCCEEDED. The
-	// CE is already warm from (3)-(5), so the job would otherwise complete within
-	// seconds - stop immediately after the job appears. ---
-	stopExecArn := util.StartSfnExecution(t, awsRegion, stateMachineArn, map[string]string{"bar": "StopMe"})
+	// The stop path has its own state machine + job definition running an
+	// INTENTIONALLY LONG-RUNNING BUT BOUNDED workload (sleep 300, Batch attempt
+	// timeout 360s) under the UNIQUE job name MyStopJob, so this check never races
+	// job completion on the (now warm) compute environment and never collides with
+	// the happy path's MyJob. ---
+	stopExecArn := util.StartSfnExecution(t, awsRegion, stopStateMachineArn, map[string]string{})
 
-	// Wait for the submitted job to exist (execution enters the task state and
-	// SubmitJob returns), then stop the execution right away.
+	// Wait for the submitted MyStopJob to exist (execution enters the task state and
+	// SubmitJob returns) - the sleep workload guarantees it stays active afterwards.
 	var stopJobId string
 	for i := 0; i < 40 && stopJobId == ""; i++ {
 		for _, status := range []batchtypes.JobStatus{
@@ -168,7 +171,7 @@ func validateSfnBatchSubmitJob(t *testing.T, tfWorkingDir, awsRegion string) {
 			})
 			require.NoError(t, listErr)
 			for _, job := range listOut2.JobSummaryList {
-				if job.JobName != nil && strings.HasSuffix(*job.JobName, "MyJob") && job.JobId != nil {
+				if job.JobName != nil && strings.HasSuffix(*job.JobName, "MyStopJob") && job.JobId != nil {
 					stopJobId = *job.JobId
 					break
 				}
@@ -181,16 +184,14 @@ func validateSfnBatchSubmitJob(t *testing.T, tfWorkingDir, awsRegion string) {
 			time.Sleep(3 * time.Second)
 		}
 	}
-	require.NotEmpty(t, stopJobId, "expected the second execution to submit a Batch job within the polling budget")
-	t.Logf("stop-test: second execution %s submitted job %s - stopping the execution now", *stopExecArn, stopJobId)
+	require.NotEmpty(t, stopJobId, "expected the stop-path execution to submit MyStopJob within the polling budget")
+	t.Logf("stop-test: execution %s submitted job %s (MyStopJob) - stopping the execution now", *stopExecArn, stopJobId)
 
 	util.StopSfnExecution(t, awsRegion, *stopExecArn)
 
 	// The stopped execution must go ABORTED, and Step Functions' cancellation must
-	// drive the job to FAILED (terminated) - a SUCCEEDED job here means the
-	// TerminateJob attempt was not made or not permitted. If the job happened to
-	// finish in the race window before the stop landed, fail loudly so the flake
-	// is visible rather than silently passing.
+	// drive the sleeping job to FAILED (terminated) - it cannot SUCCEED inside the
+	// assertion window because the workload sleeps for 300s.
 	_, stopWaitErr := util.WaitForSfnExecutionStatusE(t, awsRegion, *stopExecArn, sfntypes.ExecutionStatusAborted, 20, 6*time.Second)
 	require.NoError(t, stopWaitErr, "expected the stopped execution to reach ABORTED")
 
@@ -206,5 +207,5 @@ func validateSfnBatchSubmitJob(t *testing.T, tfWorkingDir, awsRegion string) {
 		time.Sleep(6 * time.Second)
 	}
 	assert.Equal(t, batchtypes.JobStatusFailed, stoppedJobStatus,
-		"expected the Batch job %s to be terminated (FAILED) after StopExecution - SUCCEEDED means the stop raced job completion, any other status means the TerminateJob grant did not take effect", stopJobId)
+		"expected the sleeping Batch job %s (MyStopJob) to be terminated (FAILED) after StopExecution - any other outcome means the TerminateJob grant did not take effect", stopJobId)
 }

--- a/integ/aws/compute/sfn_batch_test.go
+++ b/integ/aws/compute/sfn_batch_test.go
@@ -1,0 +1,146 @@
+package test
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/batch"
+	batchtypes "github.com/aws/aws-sdk-go-v2/service/batch/types"
+	sfntypes "github.com/aws/aws-sdk-go-v2/service/sfn/types"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+	util "github.com/terraconstructs/base/integ/aws"
+)
+
+// Test the sfn.batch-submit-job app
+//
+// Ports aws-stepfunctions-tasks' integ.submit-job.ts: a Pass state (Result.fromObject
+// {bar: "SomeValue"}) chained into a BatchSubmitJob task (jobName "MyJob",
+// containerOverrides, JsonPath payload, attempts:3, taskTimeout, tags), wired into a
+// StateMachine, submitting against a JobQueue backed by a single
+// ManagedEc2EcsComputeEnvironment / EcsJobDefinition(EcsEc2ContainerDefinition running
+// public.ecr.aws/docker/library/python:3.13-alpine). Unlike batch.job-queue.ts, this
+// fixture's compute environment DOES launch an EC2 instance to actually run the
+// submitted job end-to-end.
+//
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/@aws-cdk-testing/framework-integ/test/aws-stepfunctions-tasks/test/batch/integ.submit-job.ts
+func TestSfnBatchSubmitJob(t *testing.T) {
+	options := integrationTestOptions{
+		Region: region,
+	}
+	runComputeIntegrationTest(t, "sfn.batch-submit-job", options, validateSfnBatchSubmitJob)
+}
+
+// sfnBatchOutput is the subset of the BatchSubmitJob .sync integration's execution
+// output (the Batch DescribeJobs-shaped JSON Step Functions returns once the job
+// reaches a terminal state) that this validator needs.
+type sfnBatchOutput struct {
+	JobId string
+}
+
+func validateSfnBatchSubmitJob(t *testing.T, tfWorkingDir, awsRegion string) {
+	opts := test_structure.LoadTerraformOptions(t, tfWorkingDir)
+
+	// --- (1) Outputs: never assert exact names - gridUUID g77777777-7777 prefix /
+	// MyJob suffix match only (asserted later against the live job name). ---
+	stateMachineArn := util.LoadOutputAttribute(t, opts, "state-machine", "arn")
+	jobQueueArn := util.LoadOutputAttribute(t, opts, "job-queue", "arn")
+	jobQueueName := util.LoadOutputAttribute(t, opts, "job-queue", "name")
+	jobDefinitionArn := util.LoadOutputAttribute(t, opts, "job-definition", "arn")
+	jobDefinitionName := util.LoadOutputAttribute(t, opts, "job-definition", "name")
+	computeEnvArn := util.LoadOutputAttribute(t, opts, "compute-env", "arn")
+	require.NotEmpty(t, stateMachineArn)
+	require.NotEmpty(t, jobQueueArn)
+	require.NotEmpty(t, jobQueueName)
+	require.NotEmpty(t, jobDefinitionArn)
+	require.NotEmpty(t, jobDefinitionName)
+	require.NotEmpty(t, computeEnvArn)
+
+	batchClient := util.NewBatchClient(t, awsRegion)
+	ctx := context.Background()
+
+	// --- (2) Compute environment reaches VALID/ENABLED before we submit anything
+	// through the state machine (waitForComputeEnvironmentsValid is defined in
+	// batch_test.go, same `test` package - reused directly). ---
+	waitForComputeEnvironmentsValid(t, batchClient, ctx, []string{computeEnvArn}, 30, 15*time.Second)
+
+	ceOut, err := batchClient.DescribeComputeEnvironments(ctx, &batch.DescribeComputeEnvironmentsInput{
+		ComputeEnvironments: []string{computeEnvArn},
+	})
+	require.NoError(t, err)
+	require.Len(t, ceOut.ComputeEnvironments, 1)
+	assert.Equal(t, batchtypes.CEStatusValid, ceOut.ComputeEnvironments[0].Status)
+	assert.Equal(t, batchtypes.CEStateEnabled, ceOut.ComputeEnvironments[0].State)
+
+	// --- (3) Drive the state machine: Pass({bar:"SomeValue"}) -> BatchSubmitJob.
+	// The task's `payload` (TaskInput.fromObject({foo: JsonPath.stringAt("$.bar")}))
+	// reads $.bar from the execution input, so start the execution with that shape. ---
+	executionArn := util.StartSfnExecution(t, awsRegion, stateMachineArn, map[string]string{"bar": "SomeValue"})
+
+	// 80 x 15s ~= 20 minutes: budget for a cold EC2 instance to spin up under the
+	// managed compute environment, pull the python:3.13-alpine image, and run the
+	// job to completion. The Makefile target's `go test -timeout 40m` gives headroom
+	// above this budget for synth/deploy/cleanup around the wait.
+	res, waitErr := util.WaitForSfnExecutionStatusE(t, awsRegion, *executionArn, sfntypes.ExecutionStatusSucceeded, 80, 15*time.Second)
+	if waitErr != nil {
+		require.FailNowf(t, "state machine execution did not succeed",
+			"status=%s error=%s cause=%s (waitErr=%v)", res.Status, res.Error, res.Cause, waitErr)
+	}
+
+	// --- (4) HEADLINE ORACLE: re-planning the already-applied (and now-exercised)
+	// stack must show zero changes. This is the live answer to PR #136's open
+	// question: does the aws_batch_job_definition's empty `retry_strategy {}` block
+	// (rendered because EcsJobDefinition is constructed with no retryStrategies/
+	// retryAttempts of its own) cause perpetual drift against the provider's
+	// read-back? It does not - `attempts: 3` on BatchSubmitJob renders into the SFN
+	// task's Parameters.RetryStrategy.Attempts (a Batch SubmitJob API request field,
+	// retried by the Batch service on that submitted job), NOT into the job
+	// definition's retry_strategy, so the job definition's empty block is exactly
+	// what both the config and the provider agree on. Run this AFTER exercising the
+	// task (rather than immediately after apply) so a submission-time side effect
+	// that mutates the job definition/queue/compute-env would also be caught. ---
+	planExitCode := terraform.PlanExitCode(t, opts)
+	assert.Equal(t, terraform.DefaultSuccessExitCode, planExitCode,
+		"expected `tofu plan -detailed-exitcode` to report no drift after apply+execution (got exit code %d) - "+
+			"a non-zero exit here would mean the job definition's empty retry_strategy block (or some other "+
+			"attribute) drifts against the provider's read-back", planExitCode)
+
+	// --- (5) Parse the execution output for the Batch JobId, then confirm the job
+	// itself reports SUCCEEDED. ---
+	var out sfnBatchOutput
+	require.NoError(t, json.Unmarshal([]byte(res.Output), &out), "failed to parse execution output JSON: %s", res.Output)
+
+	if out.JobId != "" {
+		jobOut, err := batchClient.DescribeJobs(ctx, &batch.DescribeJobsInput{Jobs: []string{out.JobId}})
+		require.NoError(t, err)
+		require.Len(t, jobOut.Jobs, 1, "expected DescribeJobs to return exactly one job for id %s", out.JobId)
+		assert.Equal(t, batchtypes.JobStatusSucceeded, jobOut.Jobs[0].Status,
+			"expected batch job %s to have SUCCEEDED, got %s (%s)",
+			out.JobId, jobOut.Jobs[0].Status, aws.ToString(jobOut.Jobs[0].StatusReason))
+		return
+	}
+
+	// Fallback: no JobId parsed from the execution output - list SUCCEEDED jobs on
+	// the queue and suffix-match the MyJob name (never assert the exact
+	// gridUUID-prefixed name).
+	listOut, err := batchClient.ListJobs(ctx, &batch.ListJobsInput{
+		JobQueue:  &jobQueueArn,
+		JobStatus: batchtypes.JobStatusSucceeded,
+	})
+	require.NoError(t, err)
+	var found bool
+	for _, job := range listOut.JobSummaryList {
+		if job.JobName != nil && strings.HasSuffix(*job.JobName, "MyJob") {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected a SUCCEEDED job on queue %s with a name ending in MyJob", jobQueueName)
+}

--- a/integ/aws/compute/sfn_batch_test.go
+++ b/integ/aws/compute/sfn_batch_test.go
@@ -124,23 +124,87 @@ func validateSfnBatchSubmitJob(t *testing.T, tfWorkingDir, awsRegion string) {
 		assert.Equal(t, batchtypes.JobStatusSucceeded, jobOut.Jobs[0].Status,
 			"expected batch job %s to have SUCCEEDED, got %s (%s)",
 			out.JobId, jobOut.Jobs[0].Status, aws.ToString(jobOut.Jobs[0].StatusReason))
-		return
+	} else {
+		// Fallback: no JobId parsed from the execution output - list SUCCEEDED jobs on
+		// the queue and suffix-match the MyJob name (never assert the exact
+		// gridUUID-prefixed name).
+		listOut, err := batchClient.ListJobs(ctx, &batch.ListJobsInput{
+			JobQueue:  &jobQueueArn,
+			JobStatus: batchtypes.JobStatusSucceeded,
+		})
+		require.NoError(t, err)
+		var found bool
+		for _, job := range listOut.JobSummaryList {
+			if job.JobName != nil && strings.HasSuffix(*job.JobName, "MyJob") {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "expected a SUCCEEDED job on queue %s with a name ending in MyJob", jobQueueName)
 	}
 
-	// Fallback: no JobId parsed from the execution output - list SUCCEEDED jobs on
-	// the queue and suffix-match the MyJob name (never assert the exact
-	// gridUUID-prefixed name).
-	listOut, err := batchClient.ListJobs(ctx, &batch.ListJobsInput{
-		JobQueue:  &jobQueueArn,
-		JobStatus: batchtypes.JobStatusSucceeded,
-	})
-	require.NoError(t, err)
-	var found bool
-	for _, job := range listOut.JobSummaryList {
-		if job.JobName != nil && strings.HasSuffix(*job.JobName, "MyJob") {
-			found = true
-			break
+	// --- (6) TerminateJob grant (PR #137 review): stopping a .sync execution makes
+	// Step Functions issue a best-effort batch:TerminateJob for the in-flight job -
+	// without the grant the job would be orphaned and keep running/accruing cost
+	// (https://docs.aws.amazon.com/step-functions/latest/dg/service-integration-iam-templates.html#iam-cancel-tasks).
+	// Start a second execution and stop it while its job is still queued/running;
+	// the job must reach a terminal FAILED state (terminated), not SUCCEEDED. The
+	// CE is already warm from (3)-(5), so the job would otherwise complete within
+	// seconds - stop immediately after the job appears. ---
+	stopExecArn := util.StartSfnExecution(t, awsRegion, stateMachineArn, map[string]string{"bar": "StopMe"})
+
+	// Wait for the submitted job to exist (execution enters the task state and
+	// SubmitJob returns), then stop the execution right away.
+	var stopJobId string
+	for i := 0; i < 40 && stopJobId == ""; i++ {
+		for _, status := range []batchtypes.JobStatus{
+			batchtypes.JobStatusSubmitted, batchtypes.JobStatusPending,
+			batchtypes.JobStatusRunnable, batchtypes.JobStatusStarting,
+			batchtypes.JobStatusRunning,
+		} {
+			listOut2, listErr := batchClient.ListJobs(ctx, &batch.ListJobsInput{
+				JobQueue:  &jobQueueArn,
+				JobStatus: status,
+			})
+			require.NoError(t, listErr)
+			for _, job := range listOut2.JobSummaryList {
+				if job.JobName != nil && strings.HasSuffix(*job.JobName, "MyJob") && job.JobId != nil {
+					stopJobId = *job.JobId
+					break
+				}
+			}
+			if stopJobId != "" {
+				break
+			}
+		}
+		if stopJobId == "" {
+			time.Sleep(3 * time.Second)
 		}
 	}
-	assert.True(t, found, "expected a SUCCEEDED job on queue %s with a name ending in MyJob", jobQueueName)
+	require.NotEmpty(t, stopJobId, "expected the second execution to submit a Batch job within the polling budget")
+	t.Logf("stop-test: second execution %s submitted job %s - stopping the execution now", *stopExecArn, stopJobId)
+
+	util.StopSfnExecution(t, awsRegion, *stopExecArn)
+
+	// The stopped execution must go ABORTED, and Step Functions' cancellation must
+	// drive the job to FAILED (terminated) - a SUCCEEDED job here means the
+	// TerminateJob attempt was not made or not permitted. If the job happened to
+	// finish in the race window before the stop landed, fail loudly so the flake
+	// is visible rather than silently passing.
+	_, stopWaitErr := util.WaitForSfnExecutionStatusE(t, awsRegion, *stopExecArn, sfntypes.ExecutionStatusAborted, 20, 6*time.Second)
+	require.NoError(t, stopWaitErr, "expected the stopped execution to reach ABORTED")
+
+	var stoppedJobStatus batchtypes.JobStatus
+	for i := 0; i < 40; i++ {
+		jobOut2, descErr := batchClient.DescribeJobs(ctx, &batch.DescribeJobsInput{Jobs: []string{stopJobId}})
+		require.NoError(t, descErr)
+		require.Len(t, jobOut2.Jobs, 1)
+		stoppedJobStatus = jobOut2.Jobs[0].Status
+		if stoppedJobStatus == batchtypes.JobStatusFailed || stoppedJobStatus == batchtypes.JobStatusSucceeded {
+			break
+		}
+		time.Sleep(6 * time.Second)
+	}
+	assert.Equal(t, batchtypes.JobStatusFailed, stoppedJobStatus,
+		"expected the Batch job %s to be terminated (FAILED) after StopExecution - SUCCEEDED means the stop raced job completion, any other status means the TerminateJob grant did not take effect", stopJobId)
 }

--- a/src/aws/compute/tasks/batch/submit-job.ts
+++ b/src/aws/compute/tasks/batch/submit-job.ts
@@ -1,0 +1,447 @@
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/aws-cdk-lib/aws-stepfunctions-tasks/lib/batch/submit-job.ts
+
+import { Token } from "cdktn";
+import { Construct } from "constructs";
+import * as compute from "../../";
+import { ValidationError } from "../../../../errors";
+import { Size } from "../../../../size";
+import { withResolved } from "../../../../token";
+import { AwsStack } from "../../../aws-stack";
+import * as iam from "../../../iam";
+import {
+  integrationResourceArn,
+  validatePatternSupported,
+} from "../private/task-utils";
+
+/**
+ * The overrides that should be sent to a container.
+ */
+export interface BatchContainerOverrides {
+  /**
+   * The command to send to the container that overrides
+   * the default command from the Docker image or the job definition.
+   *
+   * @default - No command overrides
+   */
+  readonly command?: string[];
+
+  /**
+   * The environment variables to send to the container.
+   * You can add new environment variables, which are added to the container
+   * at launch, or you can override the existing environment variables from
+   * the Docker image or the job definition.
+   *
+   * @default - No environment overrides
+   */
+  readonly environment?: { [key: string]: string };
+
+  /**
+   * The instance type to use for a multi-node parallel job.
+   * This parameter is not valid for single-node container jobs.
+   *
+   * @default - No instance type overrides
+   */
+  readonly instanceType?: compute.InstanceType;
+
+  /**
+   * Memory reserved for the job.
+   *
+   * @default - No memory overrides. The memory supplied in the job definition will be used.
+   */
+  readonly memory?: Size;
+
+  /**
+   * The number of physical GPUs to reserve for the container.
+   * The number of GPUs reserved for all containers in a job
+   * should not exceed the number of available GPUs on the compute
+   * resource that the job is launched on.
+   *
+   * @default - No GPU reservation
+   */
+  readonly gpuCount?: number;
+
+  /**
+   * The number of vCPUs to reserve for the container.
+   * This value overrides the value set in the job definition.
+   *
+   * @default - No vCPUs overrides
+   */
+  readonly vcpus?: number;
+}
+
+/**
+ * An object representing an AWS Batch job dependency.
+ */
+export interface BatchJobDependency {
+  /**
+   * The job ID of the AWS Batch job associated with this dependency.
+   *
+   * @default - No jobId
+   */
+  readonly jobId?: string;
+
+  /**
+   * The type of the job dependency.
+   *
+   * @default - No type
+   */
+  readonly type?: string;
+}
+
+interface BatchSubmitJobOptions {
+  /**
+   * The arn of the job definition used by this job.
+   */
+  readonly jobDefinitionArn: string;
+
+  /**
+   * The name of the job.
+   * The first character must be alphanumeric, and up to 128 letters (uppercase and lowercase),
+   * numbers, hyphens, and underscores are allowed.
+   */
+  readonly jobName: string;
+
+  /**
+   * The arn of the job queue into which the job is submitted.
+   */
+  readonly jobQueueArn: string;
+
+  /**
+   * The array size can be between 2 and 10,000.
+   * If you specify array properties for a job, it becomes an array job.
+   * For more information, see Array Jobs in the AWS Batch User Guide.
+   *
+   * @default - No array size
+   */
+  readonly arraySize?: number;
+
+  /**
+   * A list of container overrides in JSON format that specify the name of a container
+   * in the specified job definition and the overrides it should receive.
+   *
+   * @see https://docs.aws.amazon.com/batch/latest/APIReference/API_SubmitJob.html#Batch-SubmitJob-request-containerOverrides
+   *
+   * @default - No container overrides
+   */
+  readonly containerOverrides?: BatchContainerOverrides;
+
+  /**
+   * A list of dependencies for the job.
+   * A job can depend upon a maximum of 20 jobs.
+   *
+   * @see https://docs.aws.amazon.com/batch/latest/APIReference/API_SubmitJob.html#Batch-SubmitJob-request-dependsOn
+   *
+   * @default - No dependencies
+   */
+  readonly dependsOn?: BatchJobDependency[];
+
+  /**
+   * The payload to be passed as parameters to the batch job
+   *
+   * @default - No parameters are passed
+   */
+  readonly payload?: compute.TaskInput;
+
+  /**
+   * The number of times to move a job to the RUNNABLE status.
+   * You may specify between 1 and 10 attempts.
+   * If the value of attempts is greater than one,
+   * the job is retried on failure the same number of attempts as the value.
+   *
+   * @default 1
+   */
+  readonly attempts?: number;
+
+  /**
+   * The tags applied to the job request.
+   *
+   * @default {} - no tags
+   */
+  readonly tags?: { [key: string]: string };
+}
+
+/**
+ * Properties for BatchSubmitJob
+ */
+export interface BatchSubmitJobProps
+  extends compute.TaskStateBaseProps,
+    BatchSubmitJobOptions {}
+
+/**
+ * Task to submits an AWS Batch job from a job definition.
+ *
+ * @see https://docs.aws.amazon.com/step-functions/latest/dg/connect-batch.html
+ */
+export class BatchSubmitJob extends compute.TaskStateBase {
+  private static readonly SUPPORTED_INTEGRATION_PATTERNS: compute.IntegrationPattern[] =
+    [
+      compute.IntegrationPattern.REQUEST_RESPONSE,
+      compute.IntegrationPattern.RUN_JOB,
+    ];
+
+  // protected readonly taskMetrics?: compute.TaskMetricsConfig;
+  protected readonly taskPolicies?: iam.PolicyStatement[];
+
+  private readonly integrationPattern: compute.IntegrationPattern;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    private readonly props: BatchSubmitJobProps,
+  ) {
+    super(scope, id, props);
+
+    this.integrationPattern =
+      props.integrationPattern ?? compute.IntegrationPattern.RUN_JOB;
+    validatePatternSupported(
+      this.integrationPattern,
+      BatchSubmitJob.SUPPORTED_INTEGRATION_PATTERNS,
+    );
+
+    // validate arraySize limits
+    withResolved(props.arraySize, (arraySize) => {
+      if (arraySize !== undefined && (arraySize < 2 || arraySize > 10_000)) {
+        throw new ValidationError(
+          `arraySize must be between 2 and 10,000. Received ${arraySize}.`,
+          this,
+        );
+      }
+    });
+
+    // validate dependency size
+    if (props.dependsOn && props.dependsOn.length > 20) {
+      throw new ValidationError(
+        `dependencies must be 20 or less. Received ${props.dependsOn.length}.`,
+        this,
+      );
+    }
+
+    // validate attempts
+    withResolved(props.attempts, (attempts) => {
+      if (attempts !== undefined && (attempts < 1 || attempts > 10)) {
+        throw new ValidationError(
+          `attempts must be between 1 and 10. Received ${attempts}.`,
+          this,
+        );
+      }
+    });
+
+    // validate timeout
+    (props.timeout !== undefined || props.taskTimeout !== undefined) &&
+      withResolved(
+        props.timeout?.toSeconds(),
+        props.taskTimeout?.seconds,
+        (timeout, taskTimeout) => {
+          const definedTimeout = timeout ?? taskTimeout;
+          if (definedTimeout && definedTimeout < 60) {
+            throw new ValidationError(
+              `attempt duration must be greater than 60 seconds. Received ${definedTimeout} seconds.`,
+              this,
+            );
+          }
+        },
+      );
+
+    // This is required since environment variables must not start with AWS_BATCH;
+    // this naming convention is reserved for variables that are set by the AWS Batch service.
+    if (props.containerOverrides?.environment) {
+      Object.keys(props.containerOverrides.environment).forEach((key) => {
+        if (key.match(/^AWS_BATCH/)) {
+          throw new ValidationError(
+            `Invalid environment variable name: ${key}. Environment variable names starting with 'AWS_BATCH' are reserved.`,
+            this,
+          );
+        }
+      });
+    }
+
+    this.validateTags(props.tags);
+
+    this.taskPolicies = this.configurePolicyStatements();
+  }
+
+  /**
+   * @internal
+   */
+  protected _renderTask(): any {
+    let timeout: number | undefined = undefined;
+    if (this.props.timeout) {
+      timeout = this.props.timeout.toSeconds();
+    } else if (this.props.taskTimeout?.seconds) {
+      timeout = this.props.taskTimeout.seconds;
+    } else if (this.props.taskTimeout?.path) {
+      timeout = compute.JsonPath.numberAt(this.props.taskTimeout.path);
+    }
+
+    return {
+      Resource: integrationResourceArn(
+        this,
+        "batch",
+        "submitJob",
+        this.integrationPattern,
+      ),
+      Parameters: compute.FieldUtils.renderObject({
+        JobDefinition: this.props.jobDefinitionArn,
+        JobName: this.props.jobName,
+        JobQueue: this.props.jobQueueArn,
+        Parameters: this.props.payload?.value,
+        ArrayProperties:
+          this.props.arraySize !== undefined
+            ? { Size: this.props.arraySize }
+            : undefined,
+
+        ContainerOverrides: this.props.containerOverrides
+          ? this.configureContainerOverrides(this.props.containerOverrides)
+          : undefined,
+
+        DependsOn: this.props.dependsOn
+          ? this.props.dependsOn.map((jobDependency) => ({
+              JobId: jobDependency.jobId,
+              Type: jobDependency.type,
+            }))
+          : undefined,
+
+        RetryStrategy:
+          this.props.attempts !== undefined
+            ? { Attempts: this.props.attempts }
+            : undefined,
+        Tags: this.props.tags,
+        Timeout: timeout ? { AttemptDurationSeconds: timeout } : undefined,
+      }),
+      // BatchSubmitJob repurposes timeout/taskTimeout to mean the Batch
+      // AttemptDurationSeconds (rendered above, nested in Parameters.Timeout).
+      // renderTaskBase() (invoked before _renderTask() in toStateJson()) already
+      // emitted a (spurious) SFN-level TimeoutSeconds/TimeoutSecondsPath from
+      // those same props; overriding them back to undefined here strips that,
+      // matching upstream aws-cdk behavior.
+      TimeoutSeconds: undefined,
+      TimeoutSecondsPath: undefined,
+    };
+  }
+
+  private configurePolicyStatements(): iam.PolicyStatement[] {
+    return [
+      // Resource level access control for job-definition requires revision which batch does not support yet
+      // Using the alternative permissions as mentioned here:
+      // https://docs.aws.amazon.com/batch/latest/userguide/batch-supported-iam-actions-resources.html
+      new iam.PolicyStatement({
+        resources: compute.JsonPath.isEncodedJsonPath(this.props.jobQueueArn)
+          ? ["*"]
+          : [
+              AwsStack.ofAwsConstruct(this).formatArn({
+                service: "batch",
+                resource: "job-definition",
+                resourceName: "*",
+              }),
+              this.props.jobQueueArn,
+            ],
+        // upstream also branches on isValidJsonataExpression(jobQueueArn); base compute
+        // has no JSONata support, so only the JsonPath check applies here.
+        //
+        // TERRACONSTRUCTS DEVIATION: SubmitJob calls that carry tags additionally
+        // require batch:TagResource (AWS returns AccessDeniedException on the
+        // job-definition otherwise - caught by the sfn.batch-submit-job live integ
+        // test). Upstream aws-cdk grants only batch:SubmitJob and has the same
+        // runtime failure.
+        actions: this.props.tags
+          ? ["batch:SubmitJob", "batch:TagResource"]
+          : ["batch:SubmitJob"],
+      }),
+      new iam.PolicyStatement({
+        resources: [
+          AwsStack.ofAwsConstruct(this).formatArn({
+            service: "events",
+            resource: "rule",
+            resourceName: "StepFunctionsGetEventsForBatchJobsRule",
+          }),
+        ],
+        actions: ["events:PutTargets", "events:PutRule", "events:DescribeRule"],
+      }),
+    ];
+  }
+
+  private configureContainerOverrides(
+    containerOverrides: BatchContainerOverrides,
+  ) {
+    let environment;
+    if (containerOverrides.environment) {
+      environment = Object.entries(containerOverrides.environment).map(
+        ([key, value]) => ({
+          Name: key,
+          Value: value,
+        }),
+      );
+    }
+
+    let resources: Array<any> = [];
+    if (containerOverrides.gpuCount) {
+      resources.push({
+        Type: "GPU",
+        Value: this.renderResourceRequirementValue(containerOverrides.gpuCount),
+      });
+    }
+    if (containerOverrides.memory) {
+      resources.push({
+        Type: "MEMORY",
+        Value: this.renderResourceRequirementValue(
+          containerOverrides.memory.toMebibytes(),
+        ),
+      });
+    }
+    if (containerOverrides.vcpus) {
+      resources.push({
+        Type: "VCPU",
+        Value: this.renderResourceRequirementValue(containerOverrides.vcpus),
+      });
+    }
+
+    return {
+      Command: containerOverrides.command,
+      Environment: environment,
+      InstanceType: containerOverrides.instanceType?.toString(),
+      ResourceRequirements: resources.length ? resources : undefined,
+    };
+  }
+
+  // TERRACONSTRUCTS DEVIATION: upstream stringifies unconditionally (`` `${value}` ``)
+  // because the Batch SubmitJob API requires ResourceRequirements[].Value to be a string
+  // even for literal numbers. Upstream's Token system can reverse a JsonPath-derived
+  // number token that has been coerced through JS string interpolation (its
+  // STRING_TOKEN_REGEX also matches the stringified-number sentinel pattern - see
+  // aws-cdk-lib/core/lib/private/encoding.ts STRINGIFIED_NUMBER_PATTERN). cdktn's
+  // equivalent (node_modules/cdktn/lib/tokens/private/encoding.js STRING_TOKEN_REGEX)
+  // has no such alternation, so a JsonPath number token stringified this way would
+  // resolve to a dead literal string instead of a Parameters `.$` path (verified: fails
+  // the "container overrides are tokens" unit test otherwise). Passing the raw token
+  // through undisguised lets FieldUtils.renderObject's handleNumber path detect it via
+  // Tokenization.reverseNumber() (which IS supported), while literal numbers are still
+  // stringified to match the upstream/API-required string shape.
+  private renderResourceRequirementValue(value: number): string | number {
+    return Token.isUnresolved(value) ? value : `${value}`;
+  }
+
+  private validateTags(tags?: { [key: string]: string }) {
+    if (tags === undefined) return;
+    const tagEntries = Object.entries(tags);
+    if (tagEntries.length > 50) {
+      throw new ValidationError(
+        `Maximum tag number of entries is 50. Received ${tagEntries.length}.`,
+        this,
+      );
+    }
+    for (const [key, value] of tagEntries) {
+      if (key.length < 1 || key.length > 128) {
+        throw new ValidationError(
+          `Tag key size must be between 1 and 128, but got ${key.length}.`,
+          this,
+        );
+      }
+      if (value.length > 256) {
+        throw new ValidationError(
+          `Tag value maximum size is 256, but got ${value.length}.`,
+          this,
+        );
+      }
+    }
+  }
+}

--- a/src/aws/compute/tasks/batch/submit-job.ts
+++ b/src/aws/compute/tasks/batch/submit-job.ts
@@ -233,7 +233,9 @@ export class BatchSubmitJob extends compute.TaskStateBase {
         props.taskTimeout?.seconds,
         (timeout, taskTimeout) => {
           const definedTimeout = timeout ?? taskTimeout;
-          if (definedTimeout && definedTimeout < 60) {
+          // `!== undefined` (not truthiness): a literal 0-second timeout must be
+          // rejected here, not silently skipped (upstream has the truthiness bug).
+          if (definedTimeout !== undefined && definedTimeout < 60) {
             throw new ValidationError(
               `attempt duration must be greater than 60 seconds. Received ${definedTimeout} seconds.`,
               this,
@@ -264,10 +266,13 @@ export class BatchSubmitJob extends compute.TaskStateBase {
    * @internal
    */
   protected _renderTask(): any {
+    // `!== undefined` (not truthiness) so a 0-second value cannot silently vanish
+    // from the rendered Parameters (upstream has the truthiness bug; 0 is rejected
+    // by the constructor validation above regardless).
     let timeout: number | undefined = undefined;
-    if (this.props.timeout) {
+    if (this.props.timeout !== undefined) {
       timeout = this.props.timeout.toSeconds();
-    } else if (this.props.taskTimeout?.seconds) {
+    } else if (this.props.taskTimeout?.seconds !== undefined) {
       timeout = this.props.taskTimeout.seconds;
     } else if (this.props.taskTimeout?.path) {
       timeout = compute.JsonPath.numberAt(this.props.taskTimeout.path);
@@ -306,7 +311,10 @@ export class BatchSubmitJob extends compute.TaskStateBase {
             ? { Attempts: this.props.attempts }
             : undefined,
         Tags: this.props.tags,
-        Timeout: timeout ? { AttemptDurationSeconds: timeout } : undefined,
+        Timeout:
+          timeout !== undefined
+            ? { AttemptDurationSeconds: timeout }
+            : undefined,
       }),
       // BatchSubmitJob repurposes timeout/taskTimeout to mean the Batch
       // AttemptDurationSeconds (rendered above, nested in Parameters.Timeout).
@@ -320,7 +328,7 @@ export class BatchSubmitJob extends compute.TaskStateBase {
   }
 
   private configurePolicyStatements(): iam.PolicyStatement[] {
-    return [
+    const statements = [
       // Resource level access control for job-definition requires revision which batch does not support yet
       // Using the alternative permissions as mentioned here:
       // https://docs.aws.amazon.com/batch/latest/userguide/batch-supported-iam-actions-resources.html
@@ -347,17 +355,42 @@ export class BatchSubmitJob extends compute.TaskStateBase {
           ? ["batch:SubmitJob", "batch:TagResource"]
           : ["batch:SubmitJob"],
       }),
-      new iam.PolicyStatement({
-        resources: [
-          AwsStack.ofAwsConstruct(this).formatArn({
-            service: "events",
-            resource: "rule",
-            resourceName: "StepFunctionsGetEventsForBatchJobsRule",
-          }),
-        ],
-        actions: ["events:PutTargets", "events:PutRule", "events:DescribeRule"],
-      }),
     ];
+
+    // TERRACONSTRUCTS DEVIATION: upstream grants only batch:SubmitJob plus the (unconditional)
+    // EventBridge managed-rule statement. Per AWS's IAM policy template for the Batch
+    // integration (https://docs.aws.amazon.com/step-functions/latest/dg/connect-batch.html),
+    // the Run a Job (.sync) pattern additionally requires batch:DescribeJobs (the polling
+    // fallback - without it an execution can get STUCK if the EventBridge completion event
+    // is missed or incomplete) and batch:TerminateJob (Step Functions' best-effort job
+    // cancellation when an execution is stopped - without it a stopped execution leaves the
+    // Batch job running and accruing cost). Job ids are generated at runtime, so AWS
+    // documents Resource "*" for these. Request Response gets neither statement: it does
+    // not poll, cancel, or use the EventBridge managed rule.
+    if (this.integrationPattern === compute.IntegrationPattern.RUN_JOB) {
+      statements.push(
+        new iam.PolicyStatement({
+          resources: ["*"],
+          actions: ["batch:DescribeJobs", "batch:TerminateJob"],
+        }),
+        new iam.PolicyStatement({
+          resources: [
+            AwsStack.ofAwsConstruct(this).formatArn({
+              service: "events",
+              resource: "rule",
+              resourceName: "StepFunctionsGetEventsForBatchJobsRule",
+            }),
+          ],
+          actions: [
+            "events:PutTargets",
+            "events:PutRule",
+            "events:DescribeRule",
+          ],
+        }),
+      );
+    }
+
+    return statements;
   }
 
   private configureContainerOverrides(

--- a/src/aws/compute/tasks/index.ts
+++ b/src/aws/compute/tasks/index.ts
@@ -14,7 +14,7 @@ export * from "./http/invoke";
 // export * from "./ecs/run-ecs-fargate-task";
 // export * from "./ecs/run-task";
 // export * from "./batch/run-batch-job";
-// export * from "./batch/submit-job";
+export * from "./batch/submit-job";
 // export * from "./dynamodb/get-item";
 // export * from "./dynamodb/put-item";
 // export * from "./dynamodb/update-item";

--- a/test/aws/compute/tasks/batch/__snapshots__/submit-job.test.ts.snap
+++ b/test/aws/compute/tasks/batch/__snapshots__/submit-job.test.ts.snap
@@ -1,0 +1,613 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BatchSubmitJob synth BatchSubmitJob synthesizes and matches snapshot 1`] = `
+"{
+  "data": {
+    "aws_availability_zones": {
+      "AvailabilityZones": {
+        "provider": "aws"
+      }
+    },
+    "aws_caller_identity": {
+      "CallerIdentity": {
+        "provider": "aws"
+      }
+    },
+    "aws_iam_policy_document": {
+      "ComputeEnv_InstanceProfileRole_AssumeRolePolicy_B1C16A1D": {
+        "statement": [
+          {
+            "actions": [
+              "sts:AssumeRole"
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "\${data.aws_service_principal.aws_svcp_default_region_ec2.name}"
+                ],
+                "type": "Service"
+              }
+            ]
+          }
+        ]
+      },
+      "Container_ExecutionRole_AssumeRolePolicy_FBB2FE98": {
+        "statement": [
+          {
+            "actions": [
+              "sts:AssumeRole"
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "\${data.aws_service_principal.aws_svcp_default_region_ecs-tasks.name}"
+                ],
+                "type": "Service"
+              }
+            ]
+          }
+        ]
+      },
+      "Container_ExecutionRole_DefaultPolicy_16BEB772": {
+        "statement": [
+          {
+            "actions": [
+              "logs:CreateLogStream",
+              "logs:PutLogEvents"
+            ],
+            "effect": "Allow",
+            "resources": [
+              "arn:\${data.aws_partition.Partitition.partition}:logs:\${data.aws_region.Region.name}:\${data.aws_caller_identity.CallerIdentity.account_id}:log-group:/aws/batch/job:*"
+            ]
+          }
+        ]
+      },
+      "StateMachine_Role_AssumeRolePolicy_8578B18E": {
+        "statement": [
+          {
+            "actions": [
+              "sts:AssumeRole"
+            ],
+            "effect": "Allow",
+            "principals": [
+              {
+                "identifiers": [
+                  "\${data.aws_service_principal.aws_svcp_default_region_states.name}"
+                ],
+                "type": "Service"
+              }
+            ]
+          }
+        ]
+      },
+      "StateMachine_Role_DefaultPolicy_536E7ACB": {
+        "statement": [
+          {
+            "actions": [
+              "batch:SubmitJob"
+            ],
+            "effect": "Allow",
+            "resources": [
+              "arn:\${data.aws_partition.Partitition.partition}:batch:\${data.aws_region.Region.name}:\${data.aws_caller_identity.CallerIdentity.account_id}:job-definition/*",
+              "\${aws_batch_job_queue.JobQueue_EE3AD499.arn}"
+            ]
+          },
+          {
+            "actions": [
+              "events:PutTargets",
+              "events:PutRule",
+              "events:DescribeRule"
+            ],
+            "effect": "Allow",
+            "resources": [
+              "arn:\${data.aws_partition.Partitition.partition}:events:\${data.aws_region.Region.name}:\${data.aws_caller_identity.CallerIdentity.account_id}:rule/StepFunctionsGetEventsForBatchJobsRule"
+            ]
+          }
+        ]
+      }
+    },
+    "aws_partition": {
+      "Partitition": {
+        "provider": "aws"
+      }
+    },
+    "aws_region": {
+      "Region": {
+        "provider": "aws"
+      }
+    },
+    "aws_service_principal": {
+      "aws_svcp_default_region_ec2": {
+        "service_name": "ec2"
+      },
+      "aws_svcp_default_region_ecs-tasks": {
+        "service_name": "ecs-tasks"
+      },
+      "aws_svcp_default_region_states": {
+        "service_name": "states"
+      }
+    }
+  },
+  "provider": {
+    "aws": [
+      {
+      }
+    ]
+  },
+  "resource": {
+    "aws_batch_compute_environment": {
+      "ComputeEnv_2C40ACC2": {
+        "compute_resources": {
+          "allocation_strategy": "BEST_FIT_PROGRESSIVE",
+          "instance_role": "\${aws_iam_instance_profile.ComputeEnv_InstanceProfile_250EDF20.arn}",
+          "instance_type": [
+            "optimal"
+          ],
+          "max_vcpus": 256,
+          "min_vcpus": 0,
+          "security_group_ids": [
+            "\${aws_security_group.ComputeEnv_SecurityGroup_1946AFCC.id}"
+          ],
+          "subnets": [
+            "\${aws_subnet.vpc_PrivateSubnet1_D641CC73.id}",
+            "\${aws_subnet.vpc_PrivateSubnet2_5BC02ADB.id}",
+            "\${aws_subnet.vpc_PrivateSubnet3_EF7C29AE.id}"
+          ],
+          "type": "EC2"
+        },
+        "name_prefix": "gTestStack553BDD39-TestStackComputeEnv",
+        "state": "ENABLED",
+        "tags": {
+          "Name": "Default-ComputeEnv",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        },
+        "type": "MANAGED"
+      }
+    },
+    "aws_batch_job_definition": {
+      "JobDefinition_24FFE3ED": {
+        "container_properties": "{\\"image\\":\\"public.ecr.aws/docker/library/python:3.13-alpine\\",\\"environment\\":[],\\"executionRoleArn\\":\\"\${aws_iam_role.Container_ExecutionRole_65F36CD2.arn}\\",\\"readonlyRootFilesystem\\":false,\\"resourceRequirements\\":[{\\"type\\":\\"MEMORY\\",\\"value\\":\\"2048\\"},{\\"type\\":\\"VCPU\\",\\"value\\":\\"256\\"}]}",
+        "name": "gTestStack553BDD39-TestStackJobDefinition5BE605DD",
+        "platform_capabilities": [
+          "EC2"
+        ],
+        "tags": {
+          "Name": "Default-JobDefinition",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        },
+        "type": "container"
+      }
+    },
+    "aws_batch_job_queue": {
+      "JobQueue_EE3AD499": {
+        "compute_environment_order": [
+          {
+            "compute_environment": "\${aws_batch_compute_environment.ComputeEnv_2C40ACC2.arn}",
+            "order": 1
+          }
+        ],
+        "name": "gTestStack553BDD39-TestStackJobQueue62A38B47",
+        "priority": 1,
+        "state": "ENABLED",
+        "tags": {
+          "Name": "Default-JobQueue",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        }
+      }
+    },
+    "aws_eip": {
+      "vpc_PublicSubnet1_EIP_DA49DCBE": {
+        "domain": "vpc",
+        "tags": {
+          "Name": "TestStack/vpc/PublicSubnet1",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        }
+      },
+      "vpc_PublicSubnet2_EIP_9B3743B1": {
+        "domain": "vpc",
+        "tags": {
+          "Name": "TestStack/vpc/PublicSubnet2",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        }
+      },
+      "vpc_PublicSubnet3_EIP_2C3B9D91": {
+        "domain": "vpc",
+        "tags": {
+          "Name": "TestStack/vpc/PublicSubnet3",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        }
+      }
+    },
+    "aws_iam_instance_profile": {
+      "ComputeEnv_InstanceProfile_250EDF20": {
+        "name": "gTestStack553BDD39TestStackComputeEnvInstanceProfileE351E318",
+        "role": "\${aws_iam_role.ComputeEnv_InstanceProfileRole_7000C8A9.name}",
+        "tags": {
+          "Name": "Default-ComputeEnv",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        }
+      }
+    },
+    "aws_iam_role": {
+      "ComputeEnv_InstanceProfileRole_7000C8A9": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.ComputeEnv_InstanceProfileRole_AssumeRolePolicy_B1C16A1D.json}",
+        "name_prefix": "gTestStack553BDD39-InstanceProfileRole",
+        "tags": {
+          "Name": "Default-ComputeEnv",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        }
+      },
+      "Container_ExecutionRole_65F36CD2": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.Container_ExecutionRole_AssumeRolePolicy_FBB2FE98.json}",
+        "name_prefix": "gTestStack553BDD39-tainerExecutionRole",
+        "tags": {
+          "Name": "Default-ExecutionRole",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        }
+      },
+      "StateMachine_Role_B840431D": {
+        "assume_role_policy": "\${data.aws_iam_policy_document.StateMachine_Role_AssumeRolePolicy_8578B18E.json}",
+        "name_prefix": "gTestStack553BDD39-ackStateMachineRole",
+        "tags": {
+          "Name": "Default-StateMachine",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        }
+      }
+    },
+    "aws_iam_role_policy": {
+      "Container_ExecutionRole_DefaultPolicy_ResourceRoles0_AF9A8628": {
+        "name": "TestStackContainerExecutionRoleDefaultPolicy59D076EB",
+        "policy": "\${data.aws_iam_policy_document.Container_ExecutionRole_DefaultPolicy_16BEB772.json}",
+        "role": "\${aws_iam_role.Container_ExecutionRole_65F36CD2.name}"
+      },
+      "StateMachine_Role_DefaultPolicy_ResourceRoles0_0500EB10": {
+        "name": "TestStackStateMachineRoleDefaultPolicyB6697D4B",
+        "policy": "\${data.aws_iam_policy_document.StateMachine_Role_DefaultPolicy_536E7ACB.json}",
+        "role": "\${aws_iam_role.StateMachine_Role_B840431D.name}"
+      }
+    },
+    "aws_iam_role_policy_attachment": {
+      "ComputeEnv_AmazonEC2ContainerServiceforEC2Role_Roles0_BE80E292": {
+        "policy_arn": "arn:\${data.aws_partition.Partitition.partition}:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role",
+        "role": "\${aws_iam_role.ComputeEnv_InstanceProfileRole_7000C8A9.name}"
+      }
+    },
+    "aws_internet_gateway": {
+      "vpc_IGW_E57CBDCA": {
+        "tags": {
+          "Name": "TestStack/vpc",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        }
+      }
+    },
+    "aws_internet_gateway_attachment": {
+      "vpc_VPCGW_7984C166": {
+        "internet_gateway_id": "\${aws_internet_gateway.vpc_IGW_E57CBDCA.id}",
+        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
+      }
+    },
+    "aws_nat_gateway": {
+      "vpc_PublicSubnet1_NATGateway_9C16659E": {
+        "allocation_id": "\${aws_eip.vpc_PublicSubnet1_EIP_DA49DCBE.allocation_id}",
+        "depends_on": [
+          "aws_route_table_association.vpc_PublicSubnet1_RouteTableAssociation_5D3F4579",
+          "aws_route.vpc_PublicSubnet1_DefaultRoute_10708846"
+        ],
+        "subnet_id": "\${aws_subnet.vpc_PublicSubnet1_97C7DB44.id}",
+        "tags": {
+          "Name": "TestStack/vpc/PublicSubnet1",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        }
+      },
+      "vpc_PublicSubnet2_NATGateway_9B8AE11A": {
+        "allocation_id": "\${aws_eip.vpc_PublicSubnet2_EIP_9B3743B1.allocation_id}",
+        "depends_on": [
+          "aws_route_table_association.vpc_PublicSubnet2_RouteTableAssociation_21F81B59",
+          "aws_route.vpc_PublicSubnet2_DefaultRoute_A1EC0F60"
+        ],
+        "subnet_id": "\${aws_subnet.vpc_PublicSubnet2_95A217D1.id}",
+        "tags": {
+          "Name": "TestStack/vpc/PublicSubnet2",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        }
+      },
+      "vpc_PublicSubnet3_NATGateway_82F6CA9E": {
+        "allocation_id": "\${aws_eip.vpc_PublicSubnet3_EIP_2C3B9D91.allocation_id}",
+        "depends_on": [
+          "aws_route_table_association.vpc_PublicSubnet3_RouteTableAssociation_D102D1C4",
+          "aws_route.vpc_PublicSubnet3_DefaultRoute_3F356A11"
+        ],
+        "subnet_id": "\${aws_subnet.vpc_PublicSubnet3_68F3A03C.id}",
+        "tags": {
+          "Name": "TestStack/vpc/PublicSubnet3",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        }
+      }
+    },
+    "aws_route": {
+      "vpc_PrivateSubnet1_DefaultRoute_1AA8E2E5": {
+        "destination_cidr_block": "0.0.0.0/0",
+        "nat_gateway_id": "\${aws_nat_gateway.vpc_PublicSubnet1_NATGateway_9C16659E.id}",
+        "route_table_id": "\${aws_route_table.vpc_PrivateSubnet1_RouteTable_B41A48CC.id}"
+      },
+      "vpc_PrivateSubnet2_DefaultRoute_B0E07F99": {
+        "destination_cidr_block": "0.0.0.0/0",
+        "nat_gateway_id": "\${aws_nat_gateway.vpc_PublicSubnet2_NATGateway_9B8AE11A.id}",
+        "route_table_id": "\${aws_route_table.vpc_PrivateSubnet2_RouteTable_7280F23E.id}"
+      },
+      "vpc_PrivateSubnet3_DefaultRoute_30C45F47": {
+        "destination_cidr_block": "0.0.0.0/0",
+        "nat_gateway_id": "\${aws_nat_gateway.vpc_PublicSubnet3_NATGateway_82F6CA9E.id}",
+        "route_table_id": "\${aws_route_table.vpc_PrivateSubnet3_RouteTable_24DA79A0.id}"
+      },
+      "vpc_PublicSubnet1_DefaultRoute_10708846": {
+        "depends_on": [
+          "aws_internet_gateway_attachment.vpc_VPCGW_7984C166"
+        ],
+        "destination_cidr_block": "0.0.0.0/0",
+        "gateway_id": "\${aws_internet_gateway.vpc_IGW_E57CBDCA.id}",
+        "route_table_id": "\${aws_route_table.vpc_PublicSubnet1_RouteTable_48A2DF9B.id}"
+      },
+      "vpc_PublicSubnet2_DefaultRoute_A1EC0F60": {
+        "depends_on": [
+          "aws_internet_gateway_attachment.vpc_VPCGW_7984C166"
+        ],
+        "destination_cidr_block": "0.0.0.0/0",
+        "gateway_id": "\${aws_internet_gateway.vpc_IGW_E57CBDCA.id}",
+        "route_table_id": "\${aws_route_table.vpc_PublicSubnet2_RouteTable_EB40D4CB.id}"
+      },
+      "vpc_PublicSubnet3_DefaultRoute_3F356A11": {
+        "depends_on": [
+          "aws_internet_gateway_attachment.vpc_VPCGW_7984C166"
+        ],
+        "destination_cidr_block": "0.0.0.0/0",
+        "gateway_id": "\${aws_internet_gateway.vpc_IGW_E57CBDCA.id}",
+        "route_table_id": "\${aws_route_table.vpc_PublicSubnet3_RouteTable_A3C00665.id}"
+      }
+    },
+    "aws_route_table": {
+      "vpc_PrivateSubnet1_RouteTable_B41A48CC": {
+        "tags": {
+          "Name": "TestStack/vpc/PrivateSubnet1",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        },
+        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
+      },
+      "vpc_PrivateSubnet2_RouteTable_7280F23E": {
+        "tags": {
+          "Name": "TestStack/vpc/PrivateSubnet2",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        },
+        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
+      },
+      "vpc_PrivateSubnet3_RouteTable_24DA79A0": {
+        "tags": {
+          "Name": "TestStack/vpc/PrivateSubnet3",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        },
+        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
+      },
+      "vpc_PublicSubnet1_RouteTable_48A2DF9B": {
+        "tags": {
+          "Name": "TestStack/vpc/PublicSubnet1",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        },
+        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
+      },
+      "vpc_PublicSubnet2_RouteTable_EB40D4CB": {
+        "tags": {
+          "Name": "TestStack/vpc/PublicSubnet2",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        },
+        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
+      },
+      "vpc_PublicSubnet3_RouteTable_A3C00665": {
+        "tags": {
+          "Name": "TestStack/vpc/PublicSubnet3",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        },
+        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
+      }
+    },
+    "aws_route_table_association": {
+      "vpc_PrivateSubnet1_RouteTableAssociation_67945127": {
+        "route_table_id": "\${aws_route_table.vpc_PrivateSubnet1_RouteTable_B41A48CC.id}",
+        "subnet_id": "\${aws_subnet.vpc_PrivateSubnet1_D641CC73.id}"
+      },
+      "vpc_PrivateSubnet2_RouteTableAssociation_007E94D3": {
+        "route_table_id": "\${aws_route_table.vpc_PrivateSubnet2_RouteTable_7280F23E.id}",
+        "subnet_id": "\${aws_subnet.vpc_PrivateSubnet2_5BC02ADB.id}"
+      },
+      "vpc_PrivateSubnet3_RouteTableAssociation_C58B3C2C": {
+        "route_table_id": "\${aws_route_table.vpc_PrivateSubnet3_RouteTable_24DA79A0.id}",
+        "subnet_id": "\${aws_subnet.vpc_PrivateSubnet3_EF7C29AE.id}"
+      },
+      "vpc_PublicSubnet1_RouteTableAssociation_5D3F4579": {
+        "route_table_id": "\${aws_route_table.vpc_PublicSubnet1_RouteTable_48A2DF9B.id}",
+        "subnet_id": "\${aws_subnet.vpc_PublicSubnet1_97C7DB44.id}"
+      },
+      "vpc_PublicSubnet2_RouteTableAssociation_21F81B59": {
+        "route_table_id": "\${aws_route_table.vpc_PublicSubnet2_RouteTable_EB40D4CB.id}",
+        "subnet_id": "\${aws_subnet.vpc_PublicSubnet2_95A217D1.id}"
+      },
+      "vpc_PublicSubnet3_RouteTableAssociation_D102D1C4": {
+        "route_table_id": "\${aws_route_table.vpc_PublicSubnet3_RouteTable_A3C00665.id}",
+        "subnet_id": "\${aws_subnet.vpc_PublicSubnet3_68F3A03C.id}"
+      }
+    },
+    "aws_security_group": {
+      "ComputeEnv_SecurityGroup_1946AFCC": {
+        "description": "TestStack/ComputeEnv/SecurityGroup",
+        "egress": [
+          {
+            "cidr_blocks": [
+              "0.0.0.0/0"
+            ],
+            "description": "Allow all outbound traffic by default",
+            "from_port": 0,
+            "ipv6_cidr_blocks": null,
+            "prefix_list_ids": null,
+            "protocol": "-1",
+            "security_groups": null,
+            "self": null,
+            "to_port": 0
+          }
+        ],
+        "name": "gTestStack553BDD39TestStackComputeEnvSecurityGroupF3E0F68F",
+        "tags": {
+          "Name": "Default-ComputeEnv",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        },
+        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
+      }
+    },
+    "aws_sfn_state_machine": {
+      "StateMachine_2E01A3A5": {
+        "definition": "{\\"StartAt\\":\\"Task\\",\\"States\\":{\\"Task\\":{\\"End\\":true,\\"Type\\":\\"Task\\",\\"Resource\\":\\"arn:\${data.aws_partition.Partitition.partition}:states:::batch:submitJob.sync\\",\\"Parameters\\":{\\"JobDefinition\\":\\"\${aws_batch_job_definition.JobDefinition_24FFE3ED.arn}\\",\\"JobName\\":\\"JobName\\",\\"JobQueue\\":\\"\${aws_batch_job_queue.JobQueue_EE3AD499.arn}\\"}}}}",
+        "depends_on": [
+          "data.aws_iam_policy_document.StateMachine_Role_AssumeRolePolicy_8578B18E",
+          "aws_iam_role.StateMachine_Role_B840431D",
+          "data.aws_iam_policy_document.StateMachine_Role_DefaultPolicy_536E7ACB",
+          "aws_iam_role_policy.StateMachine_Role_DefaultPolicy_ResourceRoles0_0500EB10"
+        ],
+        "name_prefix": "gTestStack553BDD39-TestStackStateMachine",
+        "role_arn": "\${aws_iam_role.StateMachine_Role_B840431D.arn}",
+        "tags": {
+          "Name": "Default-StateMachine",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        }
+      }
+    },
+    "aws_subnet": {
+      "vpc_PrivateSubnet1_D641CC73": {
+        "availability_zone": "\${element(data.aws_availability_zones.AvailabilityZones.names, 0)}",
+        "cidr_block": "10.0.96.0/19",
+        "map_public_ip_on_launch": false,
+        "tags": {
+          "Name": "TestStack/vpc/PrivateSubnet1",
+          "aws-cdk:subnet-name": "Private",
+          "aws-cdk:subnet-type": "Private",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        },
+        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
+      },
+      "vpc_PrivateSubnet2_5BC02ADB": {
+        "availability_zone": "\${element(data.aws_availability_zones.AvailabilityZones.names, 1)}",
+        "cidr_block": "10.0.128.0/19",
+        "map_public_ip_on_launch": false,
+        "tags": {
+          "Name": "TestStack/vpc/PrivateSubnet2",
+          "aws-cdk:subnet-name": "Private",
+          "aws-cdk:subnet-type": "Private",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        },
+        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
+      },
+      "vpc_PrivateSubnet3_EF7C29AE": {
+        "availability_zone": "\${element(data.aws_availability_zones.AvailabilityZones.names, 2)}",
+        "cidr_block": "10.0.160.0/19",
+        "map_public_ip_on_launch": false,
+        "tags": {
+          "Name": "TestStack/vpc/PrivateSubnet3",
+          "aws-cdk:subnet-name": "Private",
+          "aws-cdk:subnet-type": "Private",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        },
+        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
+      },
+      "vpc_PublicSubnet1_97C7DB44": {
+        "availability_zone": "\${element(data.aws_availability_zones.AvailabilityZones.names, 0)}",
+        "cidr_block": "10.0.0.0/19",
+        "map_public_ip_on_launch": true,
+        "tags": {
+          "Name": "TestStack/vpc/PublicSubnet1",
+          "aws-cdk:subnet-name": "Public",
+          "aws-cdk:subnet-type": "Public",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        },
+        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
+      },
+      "vpc_PublicSubnet2_95A217D1": {
+        "availability_zone": "\${element(data.aws_availability_zones.AvailabilityZones.names, 1)}",
+        "cidr_block": "10.0.32.0/19",
+        "map_public_ip_on_launch": true,
+        "tags": {
+          "Name": "TestStack/vpc/PublicSubnet2",
+          "aws-cdk:subnet-name": "Public",
+          "aws-cdk:subnet-type": "Public",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        },
+        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
+      },
+      "vpc_PublicSubnet3_68F3A03C": {
+        "availability_zone": "\${element(data.aws_availability_zones.AvailabilityZones.names, 2)}",
+        "cidr_block": "10.0.64.0/19",
+        "map_public_ip_on_launch": true,
+        "tags": {
+          "Name": "TestStack/vpc/PublicSubnet3",
+          "aws-cdk:subnet-name": "Public",
+          "aws-cdk:subnet-type": "Public",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        },
+        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
+      }
+    },
+    "aws_vpc": {
+      "vpc_A2121C38": {
+        "cidr_block": "10.0.0.0/16",
+        "enable_dns_hostnames": true,
+        "enable_dns_support": true,
+        "instance_tenancy": "default",
+        "tags": {
+          "Name": "TestStack/vpc",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "gTestStack553BDD39"
+        }
+      }
+    }
+  },
+  "terraform": {
+    "backend": {
+      "http": {
+        "address": "http://localhost:3000"
+      }
+    },
+    "required_providers": {
+      "aws": {
+        "source": "hashicorp/aws",
+        "version": "6.52.0"
+      }
+    }
+  }
+}"
+`;

--- a/test/aws/compute/tasks/batch/__snapshots__/submit-job.test.ts.snap
+++ b/test/aws/compute/tasks/batch/__snapshots__/submit-job.test.ts.snap
@@ -1,613 +1,141 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`BatchSubmitJob synth BatchSubmitJob synthesizes and matches snapshot 1`] = `
-"{
-  "data": {
-    "aws_availability_zones": {
-      "AvailabilityZones": {
-        "provider": "aws"
-      }
-    },
-    "aws_caller_identity": {
-      "CallerIdentity": {
-        "provider": "aws"
-      }
-    },
-    "aws_iam_policy_document": {
-      "ComputeEnv_InstanceProfileRole_AssumeRolePolicy_B1C16A1D": {
-        "statement": [
-          {
-            "actions": [
-              "sts:AssumeRole"
-            ],
-            "effect": "Allow",
-            "principals": [
-              {
-                "identifiers": [
-                  "\${data.aws_service_principal.aws_svcp_default_region_ec2.name}"
-                ],
-                "type": "Service"
-              }
-            ]
-          }
-        ]
-      },
-      "Container_ExecutionRole_AssumeRolePolicy_FBB2FE98": {
-        "statement": [
-          {
-            "actions": [
-              "sts:AssumeRole"
-            ],
-            "effect": "Allow",
-            "principals": [
-              {
-                "identifiers": [
-                  "\${data.aws_service_principal.aws_svcp_default_region_ecs-tasks.name}"
-                ],
-                "type": "Service"
-              }
-            ]
-          }
-        ]
-      },
-      "Container_ExecutionRole_DefaultPolicy_16BEB772": {
-        "statement": [
-          {
-            "actions": [
-              "logs:CreateLogStream",
-              "logs:PutLogEvents"
-            ],
-            "effect": "Allow",
-            "resources": [
-              "arn:\${data.aws_partition.Partitition.partition}:logs:\${data.aws_region.Region.name}:\${data.aws_caller_identity.CallerIdentity.account_id}:log-group:/aws/batch/job:*"
-            ]
-          }
-        ]
-      },
-      "StateMachine_Role_AssumeRolePolicy_8578B18E": {
-        "statement": [
-          {
-            "actions": [
-              "sts:AssumeRole"
-            ],
-            "effect": "Allow",
-            "principals": [
-              {
-                "identifiers": [
-                  "\${data.aws_service_principal.aws_svcp_default_region_states.name}"
-                ],
-                "type": "Service"
-              }
-            ]
-          }
-        ]
-      },
-      "StateMachine_Role_DefaultPolicy_536E7ACB": {
-        "statement": [
-          {
-            "actions": [
-              "batch:SubmitJob"
-            ],
-            "effect": "Allow",
-            "resources": [
-              "arn:\${data.aws_partition.Partitition.partition}:batch:\${data.aws_region.Region.name}:\${data.aws_caller_identity.CallerIdentity.account_id}:job-definition/*",
-              "\${aws_batch_job_queue.JobQueue_EE3AD499.arn}"
-            ]
-          },
-          {
-            "actions": [
-              "events:PutTargets",
-              "events:PutRule",
-              "events:DescribeRule"
-            ],
-            "effect": "Allow",
-            "resources": [
-              "arn:\${data.aws_partition.Partitition.partition}:events:\${data.aws_region.Region.name}:\${data.aws_caller_identity.CallerIdentity.account_id}:rule/StepFunctionsGetEventsForBatchJobsRule"
-            ]
-          }
-        ]
-      }
-    },
-    "aws_partition": {
-      "Partitition": {
-        "provider": "aws"
-      }
-    },
-    "aws_region": {
-      "Region": {
-        "provider": "aws"
-      }
-    },
-    "aws_service_principal": {
-      "aws_svcp_default_region_ec2": {
-        "service_name": "ec2"
-      },
-      "aws_svcp_default_region_ecs-tasks": {
-        "service_name": "ecs-tasks"
-      },
-      "aws_svcp_default_region_states": {
-        "service_name": "states"
-      }
-    }
-  },
-  "provider": {
-    "aws": [
-      {
-      }
-    ]
-  },
-  "resource": {
-    "aws_batch_compute_environment": {
-      "ComputeEnv_2C40ACC2": {
-        "compute_resources": {
-          "allocation_strategy": "BEST_FIT_PROGRESSIVE",
-          "instance_role": "\${aws_iam_instance_profile.ComputeEnv_InstanceProfile_250EDF20.arn}",
-          "instance_type": [
-            "optimal"
+{
+  "policyDocuments": {
+    "ComputeEnv_InstanceProfileRole_AssumeRolePolicy_B1C16A1D": {
+      "statement": [
+        {
+          "actions": [
+            "sts:AssumeRole",
           ],
-          "max_vcpus": 256,
-          "min_vcpus": 0,
-          "security_group_ids": [
-            "\${aws_security_group.ComputeEnv_SecurityGroup_1946AFCC.id}"
+          "effect": "Allow",
+          "principals": [
+            {
+              "identifiers": [
+                "\${data.aws_service_principal.aws_svcp_default_region_ec2.name}",
+              ],
+              "type": "Service",
+            },
           ],
-          "subnets": [
-            "\${aws_subnet.vpc_PrivateSubnet1_D641CC73.id}",
-            "\${aws_subnet.vpc_PrivateSubnet2_5BC02ADB.id}",
-            "\${aws_subnet.vpc_PrivateSubnet3_EF7C29AE.id}"
+        },
+      ],
+    },
+    "Container_ExecutionRole_AssumeRolePolicy_FBB2FE98": {
+      "statement": [
+        {
+          "actions": [
+            "sts:AssumeRole",
           ],
-          "type": "EC2"
+          "effect": "Allow",
+          "principals": [
+            {
+              "identifiers": [
+                "\${data.aws_service_principal.aws_svcp_default_region_ecs-tasks.name}",
+              ],
+              "type": "Service",
+            },
+          ],
         },
-        "name_prefix": "gTestStack553BDD39-TestStackComputeEnv",
-        "state": "ENABLED",
-        "tags": {
-          "Name": "Default-ComputeEnv",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
+      ],
+    },
+    "Container_ExecutionRole_DefaultPolicy_16BEB772": {
+      "statement": [
+        {
+          "actions": [
+            "logs:CreateLogStream",
+            "logs:PutLogEvents",
+          ],
+          "effect": "Allow",
+          "resources": [
+            "arn:\${data.aws_partition.Partitition.partition}:logs:\${data.aws_region.Region.name}:\${data.aws_caller_identity.CallerIdentity.account_id}:log-group:/aws/batch/job:*",
+          ],
         },
-        "type": "MANAGED"
-      }
+      ],
     },
-    "aws_batch_job_definition": {
-      "JobDefinition_24FFE3ED": {
-        "container_properties": "{\\"image\\":\\"public.ecr.aws/docker/library/python:3.13-alpine\\",\\"environment\\":[],\\"executionRoleArn\\":\\"\${aws_iam_role.Container_ExecutionRole_65F36CD2.arn}\\",\\"readonlyRootFilesystem\\":false,\\"resourceRequirements\\":[{\\"type\\":\\"MEMORY\\",\\"value\\":\\"2048\\"},{\\"type\\":\\"VCPU\\",\\"value\\":\\"256\\"}]}",
-        "name": "gTestStack553BDD39-TestStackJobDefinition5BE605DD",
-        "platform_capabilities": [
-          "EC2"
-        ],
-        "tags": {
-          "Name": "Default-JobDefinition",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
+    "StateMachine_Role_AssumeRolePolicy_8578B18E": {
+      "statement": [
+        {
+          "actions": [
+            "sts:AssumeRole",
+          ],
+          "effect": "Allow",
+          "principals": [
+            {
+              "identifiers": [
+                "\${data.aws_service_principal.aws_svcp_default_region_states.name}",
+              ],
+              "type": "Service",
+            },
+          ],
         },
-        "type": "container"
-      }
+      ],
     },
-    "aws_batch_job_queue": {
-      "JobQueue_EE3AD499": {
-        "compute_environment_order": [
-          {
-            "compute_environment": "\${aws_batch_compute_environment.ComputeEnv_2C40ACC2.arn}",
-            "order": 1
-          }
-        ],
-        "name": "gTestStack553BDD39-TestStackJobQueue62A38B47",
-        "priority": 1,
-        "state": "ENABLED",
-        "tags": {
-          "Name": "Default-JobQueue",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        }
-      }
-    },
-    "aws_eip": {
-      "vpc_PublicSubnet1_EIP_DA49DCBE": {
-        "domain": "vpc",
-        "tags": {
-          "Name": "TestStack/vpc/PublicSubnet1",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        }
-      },
-      "vpc_PublicSubnet2_EIP_9B3743B1": {
-        "domain": "vpc",
-        "tags": {
-          "Name": "TestStack/vpc/PublicSubnet2",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        }
-      },
-      "vpc_PublicSubnet3_EIP_2C3B9D91": {
-        "domain": "vpc",
-        "tags": {
-          "Name": "TestStack/vpc/PublicSubnet3",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        }
-      }
-    },
-    "aws_iam_instance_profile": {
-      "ComputeEnv_InstanceProfile_250EDF20": {
-        "name": "gTestStack553BDD39TestStackComputeEnvInstanceProfileE351E318",
-        "role": "\${aws_iam_role.ComputeEnv_InstanceProfileRole_7000C8A9.name}",
-        "tags": {
-          "Name": "Default-ComputeEnv",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        }
-      }
-    },
-    "aws_iam_role": {
-      "ComputeEnv_InstanceProfileRole_7000C8A9": {
-        "assume_role_policy": "\${data.aws_iam_policy_document.ComputeEnv_InstanceProfileRole_AssumeRolePolicy_B1C16A1D.json}",
-        "name_prefix": "gTestStack553BDD39-InstanceProfileRole",
-        "tags": {
-          "Name": "Default-ComputeEnv",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        }
-      },
-      "Container_ExecutionRole_65F36CD2": {
-        "assume_role_policy": "\${data.aws_iam_policy_document.Container_ExecutionRole_AssumeRolePolicy_FBB2FE98.json}",
-        "name_prefix": "gTestStack553BDD39-tainerExecutionRole",
-        "tags": {
-          "Name": "Default-ExecutionRole",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        }
-      },
-      "StateMachine_Role_B840431D": {
-        "assume_role_policy": "\${data.aws_iam_policy_document.StateMachine_Role_AssumeRolePolicy_8578B18E.json}",
-        "name_prefix": "gTestStack553BDD39-ackStateMachineRole",
-        "tags": {
-          "Name": "Default-StateMachine",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        }
-      }
-    },
-    "aws_iam_role_policy": {
-      "Container_ExecutionRole_DefaultPolicy_ResourceRoles0_AF9A8628": {
-        "name": "TestStackContainerExecutionRoleDefaultPolicy59D076EB",
-        "policy": "\${data.aws_iam_policy_document.Container_ExecutionRole_DefaultPolicy_16BEB772.json}",
-        "role": "\${aws_iam_role.Container_ExecutionRole_65F36CD2.name}"
-      },
-      "StateMachine_Role_DefaultPolicy_ResourceRoles0_0500EB10": {
-        "name": "TestStackStateMachineRoleDefaultPolicyB6697D4B",
-        "policy": "\${data.aws_iam_policy_document.StateMachine_Role_DefaultPolicy_536E7ACB.json}",
-        "role": "\${aws_iam_role.StateMachine_Role_B840431D.name}"
-      }
-    },
-    "aws_iam_role_policy_attachment": {
-      "ComputeEnv_AmazonEC2ContainerServiceforEC2Role_Roles0_BE80E292": {
-        "policy_arn": "arn:\${data.aws_partition.Partitition.partition}:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role",
-        "role": "\${aws_iam_role.ComputeEnv_InstanceProfileRole_7000C8A9.name}"
-      }
-    },
-    "aws_internet_gateway": {
-      "vpc_IGW_E57CBDCA": {
-        "tags": {
-          "Name": "TestStack/vpc",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        }
-      }
-    },
-    "aws_internet_gateway_attachment": {
-      "vpc_VPCGW_7984C166": {
-        "internet_gateway_id": "\${aws_internet_gateway.vpc_IGW_E57CBDCA.id}",
-        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
-      }
-    },
-    "aws_nat_gateway": {
-      "vpc_PublicSubnet1_NATGateway_9C16659E": {
-        "allocation_id": "\${aws_eip.vpc_PublicSubnet1_EIP_DA49DCBE.allocation_id}",
-        "depends_on": [
-          "aws_route_table_association.vpc_PublicSubnet1_RouteTableAssociation_5D3F4579",
-          "aws_route.vpc_PublicSubnet1_DefaultRoute_10708846"
-        ],
-        "subnet_id": "\${aws_subnet.vpc_PublicSubnet1_97C7DB44.id}",
-        "tags": {
-          "Name": "TestStack/vpc/PublicSubnet1",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        }
-      },
-      "vpc_PublicSubnet2_NATGateway_9B8AE11A": {
-        "allocation_id": "\${aws_eip.vpc_PublicSubnet2_EIP_9B3743B1.allocation_id}",
-        "depends_on": [
-          "aws_route_table_association.vpc_PublicSubnet2_RouteTableAssociation_21F81B59",
-          "aws_route.vpc_PublicSubnet2_DefaultRoute_A1EC0F60"
-        ],
-        "subnet_id": "\${aws_subnet.vpc_PublicSubnet2_95A217D1.id}",
-        "tags": {
-          "Name": "TestStack/vpc/PublicSubnet2",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        }
-      },
-      "vpc_PublicSubnet3_NATGateway_82F6CA9E": {
-        "allocation_id": "\${aws_eip.vpc_PublicSubnet3_EIP_2C3B9D91.allocation_id}",
-        "depends_on": [
-          "aws_route_table_association.vpc_PublicSubnet3_RouteTableAssociation_D102D1C4",
-          "aws_route.vpc_PublicSubnet3_DefaultRoute_3F356A11"
-        ],
-        "subnet_id": "\${aws_subnet.vpc_PublicSubnet3_68F3A03C.id}",
-        "tags": {
-          "Name": "TestStack/vpc/PublicSubnet3",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        }
-      }
-    },
-    "aws_route": {
-      "vpc_PrivateSubnet1_DefaultRoute_1AA8E2E5": {
-        "destination_cidr_block": "0.0.0.0/0",
-        "nat_gateway_id": "\${aws_nat_gateway.vpc_PublicSubnet1_NATGateway_9C16659E.id}",
-        "route_table_id": "\${aws_route_table.vpc_PrivateSubnet1_RouteTable_B41A48CC.id}"
-      },
-      "vpc_PrivateSubnet2_DefaultRoute_B0E07F99": {
-        "destination_cidr_block": "0.0.0.0/0",
-        "nat_gateway_id": "\${aws_nat_gateway.vpc_PublicSubnet2_NATGateway_9B8AE11A.id}",
-        "route_table_id": "\${aws_route_table.vpc_PrivateSubnet2_RouteTable_7280F23E.id}"
-      },
-      "vpc_PrivateSubnet3_DefaultRoute_30C45F47": {
-        "destination_cidr_block": "0.0.0.0/0",
-        "nat_gateway_id": "\${aws_nat_gateway.vpc_PublicSubnet3_NATGateway_82F6CA9E.id}",
-        "route_table_id": "\${aws_route_table.vpc_PrivateSubnet3_RouteTable_24DA79A0.id}"
-      },
-      "vpc_PublicSubnet1_DefaultRoute_10708846": {
-        "depends_on": [
-          "aws_internet_gateway_attachment.vpc_VPCGW_7984C166"
-        ],
-        "destination_cidr_block": "0.0.0.0/0",
-        "gateway_id": "\${aws_internet_gateway.vpc_IGW_E57CBDCA.id}",
-        "route_table_id": "\${aws_route_table.vpc_PublicSubnet1_RouteTable_48A2DF9B.id}"
-      },
-      "vpc_PublicSubnet2_DefaultRoute_A1EC0F60": {
-        "depends_on": [
-          "aws_internet_gateway_attachment.vpc_VPCGW_7984C166"
-        ],
-        "destination_cidr_block": "0.0.0.0/0",
-        "gateway_id": "\${aws_internet_gateway.vpc_IGW_E57CBDCA.id}",
-        "route_table_id": "\${aws_route_table.vpc_PublicSubnet2_RouteTable_EB40D4CB.id}"
-      },
-      "vpc_PublicSubnet3_DefaultRoute_3F356A11": {
-        "depends_on": [
-          "aws_internet_gateway_attachment.vpc_VPCGW_7984C166"
-        ],
-        "destination_cidr_block": "0.0.0.0/0",
-        "gateway_id": "\${aws_internet_gateway.vpc_IGW_E57CBDCA.id}",
-        "route_table_id": "\${aws_route_table.vpc_PublicSubnet3_RouteTable_A3C00665.id}"
-      }
-    },
-    "aws_route_table": {
-      "vpc_PrivateSubnet1_RouteTable_B41A48CC": {
-        "tags": {
-          "Name": "TestStack/vpc/PrivateSubnet1",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
+    "StateMachine_Role_DefaultPolicy_536E7ACB": {
+      "statement": [
+        {
+          "actions": [
+            "batch:SubmitJob",
+          ],
+          "effect": "Allow",
+          "resources": [
+            "arn:\${data.aws_partition.Partitition.partition}:batch:\${data.aws_region.Region.name}:\${data.aws_caller_identity.CallerIdentity.account_id}:job-definition/*",
+            "\${aws_batch_job_queue.JobQueue_EE3AD499.arn}",
+          ],
         },
-        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
-      },
-      "vpc_PrivateSubnet2_RouteTable_7280F23E": {
-        "tags": {
-          "Name": "TestStack/vpc/PrivateSubnet2",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
+        {
+          "actions": [
+            "batch:DescribeJobs",
+            "batch:TerminateJob",
+          ],
+          "effect": "Allow",
+          "resources": [
+            "*",
+          ],
         },
-        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
-      },
-      "vpc_PrivateSubnet3_RouteTable_24DA79A0": {
-        "tags": {
-          "Name": "TestStack/vpc/PrivateSubnet3",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
+        {
+          "actions": [
+            "events:PutTargets",
+            "events:PutRule",
+            "events:DescribeRule",
+          ],
+          "effect": "Allow",
+          "resources": [
+            "arn:\${data.aws_partition.Partitition.partition}:events:\${data.aws_region.Region.name}:\${data.aws_caller_identity.CallerIdentity.account_id}:rule/StepFunctionsGetEventsForBatchJobsRule",
+          ],
         },
-        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
-      },
-      "vpc_PublicSubnet1_RouteTable_48A2DF9B": {
-        "tags": {
-          "Name": "TestStack/vpc/PublicSubnet1",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        },
-        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
-      },
-      "vpc_PublicSubnet2_RouteTable_EB40D4CB": {
-        "tags": {
-          "Name": "TestStack/vpc/PublicSubnet2",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        },
-        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
-      },
-      "vpc_PublicSubnet3_RouteTable_A3C00665": {
-        "tags": {
-          "Name": "TestStack/vpc/PublicSubnet3",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        },
-        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
-      }
+      ],
     },
-    "aws_route_table_association": {
-      "vpc_PrivateSubnet1_RouteTableAssociation_67945127": {
-        "route_table_id": "\${aws_route_table.vpc_PrivateSubnet1_RouteTable_B41A48CC.id}",
-        "subnet_id": "\${aws_subnet.vpc_PrivateSubnet1_D641CC73.id}"
-      },
-      "vpc_PrivateSubnet2_RouteTableAssociation_007E94D3": {
-        "route_table_id": "\${aws_route_table.vpc_PrivateSubnet2_RouteTable_7280F23E.id}",
-        "subnet_id": "\${aws_subnet.vpc_PrivateSubnet2_5BC02ADB.id}"
-      },
-      "vpc_PrivateSubnet3_RouteTableAssociation_C58B3C2C": {
-        "route_table_id": "\${aws_route_table.vpc_PrivateSubnet3_RouteTable_24DA79A0.id}",
-        "subnet_id": "\${aws_subnet.vpc_PrivateSubnet3_EF7C29AE.id}"
-      },
-      "vpc_PublicSubnet1_RouteTableAssociation_5D3F4579": {
-        "route_table_id": "\${aws_route_table.vpc_PublicSubnet1_RouteTable_48A2DF9B.id}",
-        "subnet_id": "\${aws_subnet.vpc_PublicSubnet1_97C7DB44.id}"
-      },
-      "vpc_PublicSubnet2_RouteTableAssociation_21F81B59": {
-        "route_table_id": "\${aws_route_table.vpc_PublicSubnet2_RouteTable_EB40D4CB.id}",
-        "subnet_id": "\${aws_subnet.vpc_PublicSubnet2_95A217D1.id}"
-      },
-      "vpc_PublicSubnet3_RouteTableAssociation_D102D1C4": {
-        "route_table_id": "\${aws_route_table.vpc_PublicSubnet3_RouteTable_A3C00665.id}",
-        "subnet_id": "\${aws_subnet.vpc_PublicSubnet3_68F3A03C.id}"
-      }
-    },
-    "aws_security_group": {
-      "ComputeEnv_SecurityGroup_1946AFCC": {
-        "description": "TestStack/ComputeEnv/SecurityGroup",
-        "egress": [
-          {
-            "cidr_blocks": [
-              "0.0.0.0/0"
-            ],
-            "description": "Allow all outbound traffic by default",
-            "from_port": 0,
-            "ipv6_cidr_blocks": null,
-            "prefix_list_ids": null,
-            "protocol": "-1",
-            "security_groups": null,
-            "self": null,
-            "to_port": 0
-          }
-        ],
-        "name": "gTestStack553BDD39TestStackComputeEnvSecurityGroupF3E0F68F",
-        "tags": {
-          "Name": "Default-ComputeEnv",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        },
-        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
-      }
-    },
-    "aws_sfn_state_machine": {
-      "StateMachine_2E01A3A5": {
-        "definition": "{\\"StartAt\\":\\"Task\\",\\"States\\":{\\"Task\\":{\\"End\\":true,\\"Type\\":\\"Task\\",\\"Resource\\":\\"arn:\${data.aws_partition.Partitition.partition}:states:::batch:submitJob.sync\\",\\"Parameters\\":{\\"JobDefinition\\":\\"\${aws_batch_job_definition.JobDefinition_24FFE3ED.arn}\\",\\"JobName\\":\\"JobName\\",\\"JobQueue\\":\\"\${aws_batch_job_queue.JobQueue_EE3AD499.arn}\\"}}}}",
-        "depends_on": [
-          "data.aws_iam_policy_document.StateMachine_Role_AssumeRolePolicy_8578B18E",
-          "aws_iam_role.StateMachine_Role_B840431D",
-          "data.aws_iam_policy_document.StateMachine_Role_DefaultPolicy_536E7ACB",
-          "aws_iam_role_policy.StateMachine_Role_DefaultPolicy_ResourceRoles0_0500EB10"
-        ],
-        "name_prefix": "gTestStack553BDD39-TestStackStateMachine",
-        "role_arn": "\${aws_iam_role.StateMachine_Role_B840431D.arn}",
-        "tags": {
-          "Name": "Default-StateMachine",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        }
-      }
-    },
-    "aws_subnet": {
-      "vpc_PrivateSubnet1_D641CC73": {
-        "availability_zone": "\${element(data.aws_availability_zones.AvailabilityZones.names, 0)}",
-        "cidr_block": "10.0.96.0/19",
-        "map_public_ip_on_launch": false,
-        "tags": {
-          "Name": "TestStack/vpc/PrivateSubnet1",
-          "aws-cdk:subnet-name": "Private",
-          "aws-cdk:subnet-type": "Private",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        },
-        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
-      },
-      "vpc_PrivateSubnet2_5BC02ADB": {
-        "availability_zone": "\${element(data.aws_availability_zones.AvailabilityZones.names, 1)}",
-        "cidr_block": "10.0.128.0/19",
-        "map_public_ip_on_launch": false,
-        "tags": {
-          "Name": "TestStack/vpc/PrivateSubnet2",
-          "aws-cdk:subnet-name": "Private",
-          "aws-cdk:subnet-type": "Private",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        },
-        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
-      },
-      "vpc_PrivateSubnet3_EF7C29AE": {
-        "availability_zone": "\${element(data.aws_availability_zones.AvailabilityZones.names, 2)}",
-        "cidr_block": "10.0.160.0/19",
-        "map_public_ip_on_launch": false,
-        "tags": {
-          "Name": "TestStack/vpc/PrivateSubnet3",
-          "aws-cdk:subnet-name": "Private",
-          "aws-cdk:subnet-type": "Private",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        },
-        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
-      },
-      "vpc_PublicSubnet1_97C7DB44": {
-        "availability_zone": "\${element(data.aws_availability_zones.AvailabilityZones.names, 0)}",
-        "cidr_block": "10.0.0.0/19",
-        "map_public_ip_on_launch": true,
-        "tags": {
-          "Name": "TestStack/vpc/PublicSubnet1",
-          "aws-cdk:subnet-name": "Public",
-          "aws-cdk:subnet-type": "Public",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        },
-        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
-      },
-      "vpc_PublicSubnet2_95A217D1": {
-        "availability_zone": "\${element(data.aws_availability_zones.AvailabilityZones.names, 1)}",
-        "cidr_block": "10.0.32.0/19",
-        "map_public_ip_on_launch": true,
-        "tags": {
-          "Name": "TestStack/vpc/PublicSubnet2",
-          "aws-cdk:subnet-name": "Public",
-          "aws-cdk:subnet-type": "Public",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        },
-        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
-      },
-      "vpc_PublicSubnet3_68F3A03C": {
-        "availability_zone": "\${element(data.aws_availability_zones.AvailabilityZones.names, 2)}",
-        "cidr_block": "10.0.64.0/19",
-        "map_public_ip_on_launch": true,
-        "tags": {
-          "Name": "TestStack/vpc/PublicSubnet3",
-          "aws-cdk:subnet-name": "Public",
-          "aws-cdk:subnet-type": "Public",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        },
-        "vpc_id": "\${aws_vpc.vpc_A2121C38.id}"
-      }
-    },
-    "aws_vpc": {
-      "vpc_A2121C38": {
-        "cidr_block": "10.0.0.0/16",
-        "enable_dns_hostnames": true,
-        "enable_dns_support": true,
-        "instance_tenancy": "default",
-        "tags": {
-          "Name": "TestStack/vpc",
-          "grid:EnvironmentName": "Default",
-          "grid:UUID": "gTestStack553BDD39"
-        }
-      }
-    }
   },
-  "terraform": {
-    "backend": {
-      "http": {
-        "address": "http://localhost:3000"
-      }
+  "rolePolicies": {
+    "Container_ExecutionRole_DefaultPolicy_ResourceRoles0_AF9A8628": {
+      "name": "TestStackContainerExecutionRoleDefaultPolicy59D076EB",
+      "policy": "\${data.aws_iam_policy_document.Container_ExecutionRole_DefaultPolicy_16BEB772.json}",
+      "role": "\${aws_iam_role.Container_ExecutionRole_65F36CD2.name}",
     },
-    "required_providers": {
-      "aws": {
-        "source": "hashicorp/aws",
-        "version": "6.52.0"
-      }
-    }
-  }
-}"
+    "StateMachine_Role_DefaultPolicy_ResourceRoles0_0500EB10": {
+      "name": "TestStackStateMachineRoleDefaultPolicyB6697D4B",
+      "policy": "\${data.aws_iam_policy_document.StateMachine_Role_DefaultPolicy_536E7ACB.json}",
+      "role": "\${aws_iam_role.StateMachine_Role_B840431D.name}",
+    },
+  },
+  "stateMachine": {
+    "StateMachine_2E01A3A5": {
+      "definition": "{"StartAt":"Task","States":{"Task":{"End":true,"Type":"Task","Resource":"arn:\${data.aws_partition.Partitition.partition}:states:::batch:submitJob.sync","Parameters":{"JobDefinition":"\${aws_batch_job_definition.JobDefinition_24FFE3ED.arn}","JobName":"JobName","JobQueue":"\${aws_batch_job_queue.JobQueue_EE3AD499.arn}"}}}}",
+      "depends_on": [
+        "data.aws_iam_policy_document.StateMachine_Role_AssumeRolePolicy_8578B18E",
+        "aws_iam_role.StateMachine_Role_B840431D",
+        "data.aws_iam_policy_document.StateMachine_Role_DefaultPolicy_536E7ACB",
+        "aws_iam_role_policy.StateMachine_Role_DefaultPolicy_ResourceRoles0_0500EB10",
+      ],
+      "name_prefix": "gTestStack553BDD39-TestStackStateMachine",
+      "role_arn": "\${aws_iam_role.StateMachine_Role_B840431D.arn}",
+      "tags": {
+        "Name": "Default-StateMachine",
+        "grid:EnvironmentName": "Default",
+        "grid:UUID": "gTestStack553BDD39",
+      },
+    },
+  },
+}
 `;

--- a/test/aws/compute/tasks/batch/submit-job.test.ts
+++ b/test/aws/compute/tasks/batch/submit-job.test.ts
@@ -1,0 +1,664 @@
+// https://github.com/aws/aws-cdk/blob/v2.233.0/packages/aws-cdk-lib/aws-stepfunctions-tasks/test/batch/submit-job.test.ts
+
+import { dataAwsIamPolicyDocument, iamRolePolicy } from "@cdktn/provider-aws";
+import { HttpBackend, Testing } from "cdktn";
+import "cdktn/lib/testing/adapters/jest";
+import { AwsStack } from "../../../../../src/aws/aws-stack";
+import * as compute from "../../../../../src/aws/compute";
+import * as batch from "../../../../../src/aws/compute/batch";
+import * as ecs from "../../../../../src/aws/compute/ecs";
+import { BatchSubmitJob } from "../../../../../src/aws/compute/tasks/batch/submit-job";
+import { Duration } from "../../../../../src/duration";
+import { Size } from "../../../../../src/size";
+import { Template } from "../../../../assertions";
+
+describe("BatchSubmitJob", () => {
+  let stack: AwsStack;
+  let batchJobDefinition: batch.IJobDefinition;
+  let batchJobQueue: batch.IJobQueue;
+
+  beforeEach(() => {
+    // GIVEN
+    const app = Testing.app();
+    stack = new AwsStack(app);
+
+    batchJobDefinition = new batch.EcsJobDefinition(stack, "JobDefinition", {
+      container: new batch.EcsEc2ContainerDefinition(stack, "Container", {
+        // ContainerImage.fromRegistry avoids the batchjob-image asset upstream
+        // uses (ContainerImage.fromAsset), which has no equivalent fixture here.
+        image: ecs.ContainerImage.fromRegistry(
+          "public.ecr.aws/docker/library/python:3.13-alpine",
+        ),
+        cpu: 256,
+        memory: Size.mebibytes(2048),
+      }),
+    });
+
+    batchJobQueue = new batch.JobQueue(stack, "JobQueue", {
+      computeEnvironments: [
+        {
+          order: 1,
+          computeEnvironment: new batch.ManagedEc2EcsComputeEnvironment(
+            stack,
+            "ComputeEnv",
+            {
+              vpc: new compute.Vpc(stack, "vpc"),
+            },
+          ),
+        },
+      ],
+    });
+  });
+
+  test("Task with only the required parameters", () => {
+    // WHEN
+    const task = new BatchSubmitJob(stack, "Task", {
+      jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+      jobName: "JobName",
+      jobQueueArn: batchJobQueue.jobQueueArn,
+    });
+
+    // THEN
+    expect(stack.resolve(task.toStateJson())).toEqual({
+      Type: "Task",
+      Resource:
+        "arn:${data.aws_partition.Partitition.partition}:states:::batch:submitJob.sync",
+      // Resource: {
+      //   "Fn::Join": [
+      //     "",
+      //     [
+      //       "arn:",
+      //       {
+      //         Ref: "AWS::Partition",
+      //       },
+      //       ":states:::batch:submitJob.sync",
+      //     ],
+      //   ],
+      // },
+      End: true,
+      Parameters: {
+        JobDefinition: stack.resolve(batchJobDefinition.jobDefinitionArn),
+        // JobDefinition: { Ref: "JobDefinition24FFE3ED" },
+        JobName: "JobName",
+        JobQueue: stack.resolve(batchJobQueue.jobQueueArn),
+        // JobQueue: {
+        //   "Fn::GetAtt": [
+        //     "JobQueueEE3AD499",
+        //     "JobQueueArn",
+        //   ],
+        // },
+      },
+    });
+  });
+
+  test("Task with all the parameters", () => {
+    // WHEN
+    const task = new BatchSubmitJob(stack, "Task", {
+      jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+      jobName: "JobName",
+      jobQueueArn: batchJobQueue.jobQueueArn,
+      arraySize: 15,
+      containerOverrides: {
+        command: ["sudo", "rm"],
+        environment: { key: "value" },
+        instanceType: new compute.InstanceType("MULTI"),
+        memory: Size.mebibytes(1024),
+        gpuCount: 1,
+        vcpus: 10,
+      },
+      dependsOn: [{ jobId: "1234", type: "some_type" }],
+      payload: compute.TaskInput.fromObject({
+        foo: compute.JsonPath.stringAt("$.bar"),
+      }),
+      attempts: 3,
+      taskTimeout: compute.Timeout.duration(Duration.seconds(60)),
+      integrationPattern: compute.IntegrationPattern.REQUEST_RESPONSE,
+    });
+
+    // THEN
+    expect(stack.resolve(task.toStateJson())).toEqual({
+      Type: "Task",
+      Resource:
+        "arn:${data.aws_partition.Partitition.partition}:states:::batch:submitJob",
+      // Resource: {
+      //   "Fn::Join": [
+      //     "",
+      //     [
+      //       "arn:",
+      //       {
+      //         Ref: "AWS::Partition",
+      //       },
+      //       ":states:::batch:submitJob",
+      //     ],
+      //   ],
+      // },
+      End: true,
+      Parameters: {
+        JobDefinition: stack.resolve(batchJobDefinition.jobDefinitionArn),
+        // JobDefinition: { Ref: "JobDefinition24FFE3ED" },
+        JobName: "JobName",
+        JobQueue: stack.resolve(batchJobQueue.jobQueueArn),
+        // JobQueue: {
+        //   "Fn::GetAtt": [
+        //     "JobQueueEE3AD499",
+        //     "JobQueueArn",
+        //   ],
+        // },
+        ArrayProperties: { Size: 15 },
+        ContainerOverrides: {
+          Command: ["sudo", "rm"],
+          Environment: [{ Name: "key", Value: "value" }],
+          InstanceType: "MULTI",
+          ResourceRequirements: [
+            { Type: "GPU", Value: "1" },
+            { Type: "MEMORY", Value: "1024" },
+            { Type: "VCPU", Value: "10" },
+          ],
+        },
+        DependsOn: [{ JobId: "1234", Type: "some_type" }],
+        Parameters: { "foo.$": "$.bar" },
+        RetryStrategy: { Attempts: 3 },
+        Timeout: { AttemptDurationSeconds: 60 },
+      },
+    });
+  });
+
+  // 'Task with all the parameters - using JSONata' DROPPED - JSONata not ported (base
+  // compute.TaskStateBase has no query-language support).
+
+  test("supports tokens", () => {
+    // WHEN
+    const task = new BatchSubmitJob(stack, "Task", {
+      jobName: compute.JsonPath.stringAt("$.jobName"),
+      jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+      jobQueueArn: batchJobQueue.jobQueueArn,
+      arraySize: compute.JsonPath.numberAt("$.arraySize"),
+      taskTimeout: compute.Timeout.at("$.timeout"),
+      attempts: compute.JsonPath.numberAt("$.attempts"),
+    });
+
+    // THEN
+    expect(stack.resolve(task.toStateJson())).toEqual({
+      Type: "Task",
+      Resource:
+        "arn:${data.aws_partition.Partitition.partition}:states:::batch:submitJob.sync",
+      // Resource: {
+      //   "Fn::Join": [
+      //     "",
+      //     [
+      //       "arn:",
+      //       {
+      //         Ref: "AWS::Partition",
+      //       },
+      //       ":states:::batch:submitJob.sync",
+      //     ],
+      //   ],
+      // },
+      End: true,
+      Parameters: {
+        JobDefinition: stack.resolve(batchJobDefinition.jobDefinitionArn),
+        "JobName.$": "$.jobName",
+        JobQueue: stack.resolve(batchJobQueue.jobQueueArn),
+        ArrayProperties: {
+          "Size.$": "$.arraySize",
+        },
+        RetryStrategy: {
+          "Attempts.$": "$.attempts",
+        },
+        Timeout: {
+          "AttemptDurationSeconds.$": "$.timeout",
+        },
+      },
+    });
+  });
+
+  test("container overrides are tokens", () => {
+    // WHEN
+    const task = new BatchSubmitJob(stack, "Task", {
+      jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+      jobName: "JobName",
+      jobQueueArn: batchJobQueue.jobQueueArn,
+      containerOverrides: {
+        memory: Size.mebibytes(compute.JsonPath.numberAt("$.asdf")),
+      },
+    });
+
+    // THEN
+    expect(stack.resolve(task.toStateJson())).toEqual({
+      Type: "Task",
+      Resource:
+        "arn:${data.aws_partition.Partitition.partition}:states:::batch:submitJob.sync",
+      // Resource: { "Fn::Join": ["", ["arn:", { Ref: "AWS::Partition" }, ":states:::batch:submitJob.sync"]] },
+      End: true,
+      Parameters: {
+        JobDefinition: stack.resolve(batchJobDefinition.jobDefinitionArn),
+        JobName: "JobName",
+        JobQueue: stack.resolve(batchJobQueue.jobQueueArn),
+        ContainerOverrides: {
+          ResourceRequirements: [{ Type: "MEMORY", "Value.$": "$.asdf" }],
+        },
+      },
+    });
+  });
+
+  test("supports passing task input into payload", () => {
+    // WHEN
+    const task = new BatchSubmitJob(stack, "Task", {
+      jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+      jobQueueArn: batchJobQueue.jobQueueArn,
+      jobName: compute.JsonPath.stringAt("$.jobName"),
+      payload: compute.TaskInput.fromJsonPathAt("$.foo"),
+    });
+
+    // THEN
+    expect(stack.resolve(task.toStateJson())).toEqual({
+      Type: "Task",
+      Resource:
+        "arn:${data.aws_partition.Partitition.partition}:states:::batch:submitJob.sync",
+      // Resource: {
+      //   "Fn::Join": [
+      //     "",
+      //     [
+      //       "arn:",
+      //       {
+      //         Ref: "AWS::Partition",
+      //       },
+      //       ":states:::batch:submitJob.sync",
+      //     ],
+      //   ],
+      // },
+      End: true,
+      Parameters: {
+        JobDefinition: stack.resolve(batchJobDefinition.jobDefinitionArn),
+        "JobName.$": "$.jobName",
+        JobQueue: stack.resolve(batchJobQueue.jobQueueArn),
+        "Parameters.$": "$.foo",
+      },
+    });
+  });
+
+  test("Task throws if WAIT_FOR_TASK_TOKEN is supplied as service integration pattern", () => {
+    expect(() => {
+      new BatchSubmitJob(stack, "Task", {
+        jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+        jobName: "JobName",
+        jobQueueArn: batchJobQueue.jobQueueArn,
+        integrationPattern: compute.IntegrationPattern.WAIT_FOR_TASK_TOKEN,
+      });
+    }).toThrow(
+      /Unsupported service integration pattern. Supported Patterns: REQUEST_RESPONSE,RUN_JOB. Received: WAIT_FOR_TASK_TOKEN/,
+    );
+  });
+
+  test("Task throws if environment in containerOverrides contain env with name starting with AWS_BATCH", () => {
+    expect(() => {
+      new BatchSubmitJob(stack, "Task", {
+        jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+        jobName: "JobName",
+        jobQueueArn: batchJobQueue.jobQueueArn,
+        containerOverrides: {
+          environment: { AWS_BATCH_MY_NAME: "MY_VALUE" },
+        },
+      });
+    }).toThrow(
+      /Invalid environment variable name: AWS_BATCH_MY_NAME. Environment variable names starting with 'AWS_BATCH' are reserved./,
+    );
+  });
+
+  test("Task throws if arraySize is out of limits 2-10000", () => {
+    expect(() => {
+      new BatchSubmitJob(stack, "Task", {
+        jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+        jobName: "JobName",
+        jobQueueArn: batchJobQueue.jobQueueArn,
+        arraySize: 1,
+      });
+    }).toThrow(/arraySize must be between 2 and 10,000/);
+
+    expect(() => {
+      new BatchSubmitJob(stack, "Task2", {
+        jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+        jobName: "JobName",
+        jobQueueArn: batchJobQueue.jobQueueArn,
+        arraySize: 10001,
+      });
+    }).toThrow(/arraySize must be between 2 and 10,000/);
+  });
+
+  test("Task throws if dependencies exceeds 20", () => {
+    expect(() => {
+      new BatchSubmitJob(stack, "Task", {
+        jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+        jobName: "JobName",
+        jobQueueArn: batchJobQueue.jobQueueArn,
+        dependsOn: [...Array(21).keys()].map((i) => ({
+          jobId: `${i}`,
+          type: `some_type-${i}`,
+        })),
+      });
+    }).toThrow(/dependencies must be 20 or less/);
+  });
+
+  test("Task throws if attempts is out of limits 1-10", () => {
+    expect(() => {
+      new BatchSubmitJob(stack, "Task", {
+        jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+        jobName: "JobName",
+        jobQueueArn: batchJobQueue.jobQueueArn,
+        attempts: 0,
+      });
+    }).toThrow(/attempts must be between 1 and 10/);
+
+    expect(() => {
+      new BatchSubmitJob(stack, "Task2", {
+        jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+        jobName: "JobName",
+        jobQueueArn: batchJobQueue.jobQueueArn,
+        attempts: 11,
+      });
+    }).toThrow(/attempts must be between 1 and 10/);
+  });
+
+  test("Task throws if attempt duration is less than 60 sec", () => {
+    expect(() => {
+      new BatchSubmitJob(stack, "Task", {
+        jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+        jobName: "JobName",
+        jobQueueArn: batchJobQueue.jobQueueArn,
+        taskTimeout: compute.Timeout.duration(Duration.seconds(59)),
+      });
+    }).toThrow(/attempt duration must be greater than 60 seconds./);
+  });
+
+  test("supports passing tags", () => {
+    // WHEN
+    const task = new BatchSubmitJob(stack, "Task", {
+      jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+      jobQueueArn: batchJobQueue.jobQueueArn,
+      jobName: compute.JsonPath.stringAt("$.jobName"),
+      tags: {
+        test: "this is a tag",
+      },
+    });
+
+    // THEN
+    expect(stack.resolve(task.toStateJson())).toEqual({
+      Type: "Task",
+      Resource:
+        "arn:${data.aws_partition.Partitition.partition}:states:::batch:submitJob.sync",
+      // Resource: {
+      //   "Fn::Join": [
+      //     "",
+      //     [
+      //       "arn:",
+      //       {
+      //         Ref: "AWS::Partition",
+      //       },
+      //       ":states:::batch:submitJob.sync",
+      //     ],
+      //   ],
+      // },
+      End: true,
+      Parameters: {
+        JobDefinition: stack.resolve(batchJobDefinition.jobDefinitionArn),
+        "JobName.$": "$.jobName",
+        JobQueue: stack.resolve(batchJobQueue.jobQueueArn),
+        Tags: {
+          test: "this is a tag",
+        },
+      },
+    });
+  });
+
+  test("throws if tags has invalid value", () => {
+    expect(() => {
+      const tags: { [key: string]: string } = {};
+      for (let i = 0; i < 100; i++) {
+        tags[i] = "tag";
+      }
+      new BatchSubmitJob(stack, "Task1", {
+        jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+        jobName: "JobName",
+        jobQueueArn: batchJobQueue.jobQueueArn,
+        tags,
+      });
+    }).toThrow(/Maximum tag number of entries is 50./);
+
+    expect(() => {
+      const keyTooLong = "k".repeat(150);
+      const tags: { [key: string]: string } = {};
+      tags[keyTooLong] = "tag";
+      new BatchSubmitJob(stack, "Task2", {
+        jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+        jobName: "JobName",
+        jobQueueArn: batchJobQueue.jobQueueArn,
+        tags,
+      });
+    }).toThrow(/Tag key size must be between 1 and 128/);
+
+    expect(() => {
+      const tags = { key: "k".repeat(300) };
+      new BatchSubmitJob(stack, "Task3", {
+        jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+        jobName: "JobName",
+        jobQueueArn: batchJobQueue.jobQueueArn,
+        tags,
+      });
+    }).toThrow(/Tag value maximum size is 256/);
+  });
+
+  // TERRACONSTRUCTS addition (no upstream counterpart): SubmitJob calls that carry
+  // tags also need batch:TagResource - AWS rejects the tagged SubmitJob with
+  // AccessDeniedException on the job-definition otherwise (caught live by the
+  // sfn.batch-submit-job integ test; upstream grants only batch:SubmitJob and has
+  // the same runtime failure).
+  test("grants batch:TagResource alongside batch:SubmitJob when tags are set", () => {
+    // WHEN
+    const task = new BatchSubmitJob(stack, "Task", {
+      jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+      jobQueueArn: batchJobQueue.jobQueueArn,
+      jobName: "JobName",
+      tags: { key: "value" },
+    });
+    new compute.StateMachine(stack, "ParentStateMachine", {
+      definitionBody: compute.DefinitionBody.fromChainable(task),
+    });
+
+    // THEN
+    const template = new Template(stack);
+    template.expect.toHaveDataSourceWithProperties(
+      dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+      {
+        statement: expect.arrayContaining([
+          expect.objectContaining({
+            actions: ["batch:SubmitJob", "batch:TagResource"],
+            effect: "Allow",
+            resources: [
+              expect.stringMatching(/job-definition\/\*/),
+              stack.resolve(batchJobQueue.jobQueueArn),
+            ],
+          }),
+        ]),
+      },
+    );
+  });
+
+  test("supports passing jobQueueArn as JsonPath", () => {
+    // upstream title: 'supports passing jobQueueArn as JsonPath or JSONata' - the
+    // JSONata half is dropped along with the rest of the JSONata surface.
+
+    // WHEN
+    const task = new BatchSubmitJob(stack, "Task", {
+      jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+      jobQueueArn: compute.JsonPath.stringAt("$.jobQueueArn"),
+      jobName: compute.JsonPath.stringAt("$.jobName"),
+    });
+
+    const parentStateMachine = new compute.StateMachine(
+      stack,
+      "ParentStateMachine",
+      {
+        definitionBody: compute.DefinitionBody.fromChainable(task),
+      },
+    );
+
+    // THEN
+    expect(stack.resolve(task.toStateJson())).toEqual({
+      Type: "Task",
+      Resource:
+        "arn:${data.aws_partition.Partitition.partition}:states:::batch:submitJob.sync",
+      // Resource: {
+      //   "Fn::Join": [
+      //     "",
+      //     [
+      //       "arn:",
+      //       {
+      //         Ref: "AWS::Partition",
+      //       },
+      //       ":states:::batch:submitJob.sync",
+      //     ],
+      //   ],
+      // },
+      End: true,
+      Parameters: {
+        JobDefinition: stack.resolve(batchJobDefinition.jobDefinitionArn),
+        "JobName.$": "$.jobName",
+        "JobQueue.$": "$.jobQueueArn",
+      },
+    });
+
+    // Task.taskPolicies are only materialized into the parent StateMachine role's
+    // policy once the graph is bound - assert the graph-registered policy via
+    // Template.synth (aws_iam_role_policy + its backing policy-document data source),
+    // mirroring the sibling idiom in stepfunctions/start-execution.test.ts and
+    // authorizers/lambda.test.ts.
+    const template = new Template(stack);
+    template.expect.toHaveDataSourceWithProperties(
+      dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+      {
+        statement: [
+          {
+            actions: ["batch:SubmitJob"],
+            effect: "Allow",
+            resources: ["*"],
+          },
+          {
+            actions: [
+              "events:PutTargets",
+              "events:PutRule",
+              "events:DescribeRule",
+            ],
+            effect: "Allow",
+            resources: [
+              "arn:${data.aws_partition.Partitition.partition}:events:${data.aws_region.Region.name}:${data.aws_caller_identity.CallerIdentity.account_id}:rule/StepFunctionsGetEventsForBatchJobsRule",
+            ],
+          },
+        ],
+      },
+    );
+    template.expect.toHaveResourceWithProperties(iamRolePolicy.IamRolePolicy, {
+      role: stack.resolve(parentStateMachine.role.roleName),
+      policy: expect.stringMatching(
+        /^\$\{data\.aws_iam_policy_document\..*\.json\}$/,
+      ),
+    });
+    // Template.fromStack(stack).hasResourceProperties('AWS::IAM::Policy', {
+    //   PolicyDocument: {
+    //     Statement: [
+    //       {
+    //         Action: 'batch:SubmitJob',
+    //         Effect: 'Allow',
+    //         Resource: '*',
+    //       },
+    //       {
+    //         Action: [
+    //           'events:PutTargets',
+    //           'events:PutRule',
+    //           'events:DescribeRule',
+    //         ],
+    //         Effect: 'Allow',
+    //         Resource: {
+    //           'Fn::Join': [
+    //             '',
+    //             [
+    //               'arn:',
+    //               {
+    //                 Ref: 'AWS::Partition',
+    //               },
+    //               ':events:',
+    //               {
+    //                 Ref: 'AWS::Region',
+    //               },
+    //               ':',
+    //               {
+    //                 Ref: 'AWS::AccountId',
+    //               },
+    //               ':rule/StepFunctionsGetEventsForBatchJobsRule',
+    //             ],
+    //           ],
+    //         },
+    //       },
+    //     ],
+    //     Version: '2012-10-17',
+    //   },
+    // });
+  });
+});
+
+// snapshot tests must not use the default local backend - its state file path
+// is machine-dependent and would leak into the snapshot (established idiom, see
+// test/aws/compute/batch/managed-compute-environment.test.ts).
+describe("BatchSubmitJob synth", () => {
+  test("BatchSubmitJob synthesizes and matches snapshot", () => {
+    // GIVEN
+    const app = Testing.app();
+    const synthStack = new AwsStack(app, "TestStack");
+    new HttpBackend(synthStack, { address: "http://localhost:3000" });
+
+    const jobDefinition = new batch.EcsJobDefinition(
+      synthStack,
+      "JobDefinition",
+      {
+        container: new batch.EcsEc2ContainerDefinition(
+          synthStack,
+          "Container",
+          {
+            image: ecs.ContainerImage.fromRegistry(
+              "public.ecr.aws/docker/library/python:3.13-alpine",
+            ),
+            cpu: 256,
+            memory: Size.mebibytes(2048),
+          },
+        ),
+      },
+    );
+    const jobQueue = new batch.JobQueue(synthStack, "JobQueue", {
+      computeEnvironments: [
+        {
+          order: 1,
+          computeEnvironment: new batch.ManagedEc2EcsComputeEnvironment(
+            synthStack,
+            "ComputeEnv",
+            {
+              vpc: new compute.Vpc(synthStack, "vpc"),
+            },
+          ),
+        },
+      ],
+    });
+
+    // WHEN
+    const task = new BatchSubmitJob(synthStack, "Task", {
+      jobDefinitionArn: jobDefinition.jobDefinitionArn,
+      jobName: "JobName",
+      jobQueueArn: jobQueue.jobQueueArn,
+    });
+    new compute.StateMachine(synthStack, "StateMachine", {
+      definitionBody: compute.DefinitionBody.fromChainable(task),
+    });
+
+    // THEN
+    synthStack.prepareStack();
+    expect(Testing.synth(synthStack)).toMatchSnapshot();
+  });
+});

--- a/test/aws/compute/tasks/batch/submit-job.test.ts
+++ b/test/aws/compute/tasks/batch/submit-job.test.ts
@@ -542,6 +542,14 @@ describe("BatchSubmitJob", () => {
             effect: "Allow",
             resources: ["*"],
           },
+          // .sync (RUN_JOB) polling fallback + best-effort cancellation - job ids
+          // are runtime-generated, so AWS's IAM template documents Resource "*"
+          // (https://docs.aws.amazon.com/step-functions/latest/dg/connect-batch.html).
+          {
+            actions: ["batch:DescribeJobs", "batch:TerminateJob"],
+            effect: "Allow",
+            resources: ["*"],
+          },
           {
             actions: [
               "events:PutTargets",
@@ -603,6 +611,119 @@ describe("BatchSubmitJob", () => {
     //   },
     // });
   });
+
+  // -------------------------------------------------------------------------
+  // TERRACONSTRUCTS additions (no upstream counterparts) - PR #137 review:
+  // AWS's IAM template for the Batch integration requires batch:DescribeJobs
+  // (.sync polling fallback) and batch:TerminateJob (best-effort cancellation
+  // on StopExecution) for RUN_JOB, and neither the wildcard nor the
+  // EventBridge managed-rule statement for REQUEST_RESPONSE.
+  // https://docs.aws.amazon.com/step-functions/latest/dg/connect-batch.html
+  // -------------------------------------------------------------------------
+
+  test("RUN_JOB (default) grants DescribeJobs/TerminateJob wildcard alongside scoped SubmitJob", () => {
+    // WHEN
+    const task = new BatchSubmitJob(stack, "Task", {
+      jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+      jobQueueArn: batchJobQueue.jobQueueArn,
+      jobName: "JobName",
+    });
+    new compute.StateMachine(stack, "ParentStateMachine", {
+      definitionBody: compute.DefinitionBody.fromChainable(task),
+    });
+
+    // THEN
+    const template = new Template(stack);
+    template.expect.toHaveDataSourceWithProperties(
+      dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+      {
+        statement: [
+          {
+            actions: ["batch:SubmitJob"],
+            effect: "Allow",
+            resources: [
+              expect.stringMatching(/job-definition\/\*/),
+              stack.resolve(batchJobQueue.jobQueueArn),
+            ],
+          },
+          {
+            actions: ["batch:DescribeJobs", "batch:TerminateJob"],
+            effect: "Allow",
+            resources: ["*"],
+          },
+          {
+            actions: [
+              "events:PutTargets",
+              "events:PutRule",
+              "events:DescribeRule",
+            ],
+            effect: "Allow",
+            resources: [
+              expect.stringMatching(
+                /rule\/StepFunctionsGetEventsForBatchJobsRule$/,
+              ),
+            ],
+          },
+        ],
+      },
+    );
+  });
+
+  test("REQUEST_RESPONSE grants only batch:SubmitJob - no .sync polling/cancel/events statements", () => {
+    // WHEN
+    const task = new BatchSubmitJob(stack, "Task", {
+      jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+      jobQueueArn: batchJobQueue.jobQueueArn,
+      jobName: "JobName",
+      integrationPattern: compute.IntegrationPattern.REQUEST_RESPONSE,
+    });
+    new compute.StateMachine(stack, "ParentStateMachine", {
+      definitionBody: compute.DefinitionBody.fromChainable(task),
+    });
+
+    // THEN
+    const template = new Template(stack);
+    template.expect.toHaveDataSourceWithProperties(
+      dataAwsIamPolicyDocument.DataAwsIamPolicyDocument,
+      {
+        statement: [
+          {
+            actions: ["batch:SubmitJob"],
+            effect: "Allow",
+            resources: [
+              expect.stringMatching(/job-definition\/\*/),
+              stack.resolve(batchJobQueue.jobQueueArn),
+            ],
+          },
+        ],
+      },
+    );
+    const synthed = Testing.synth(stack);
+    expect(synthed).not.toContain("batch:TerminateJob");
+    expect(synthed).not.toContain("StepFunctionsGetEventsForBatchJobsRule");
+  });
+
+  test("rejects a literal zero-second timeout instead of silently dropping it", () => {
+    // upstream truthiness bug: `if (definedTimeout && ...)` skips 0, and the
+    // render path `if (this.props.timeout)` silently omits it.
+    expect(() => {
+      new BatchSubmitJob(stack, "TaskTimeout0", {
+        jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+        jobQueueArn: batchJobQueue.jobQueueArn,
+        jobName: "JobName",
+        taskTimeout: compute.Timeout.duration(Duration.seconds(0)),
+      });
+    }).toThrow(/attempt duration must be greater than 60 seconds. Received 0/);
+
+    expect(() => {
+      new BatchSubmitJob(stack, "Timeout0", {
+        jobDefinitionArn: batchJobDefinition.jobDefinitionArn,
+        jobQueueArn: batchJobQueue.jobQueueArn,
+        jobName: "JobName",
+        timeout: Duration.seconds(0),
+      });
+    }).toThrow(/attempt duration must be greater than 60 seconds. Received 0/);
+  });
 });
 
 // snapshot tests must not use the default local backend - its state file path
@@ -658,7 +779,15 @@ describe("BatchSubmitJob synth", () => {
     });
 
     // THEN
+    // Snapshot only the task-relevant artifacts (state machine definition + IAM
+    // policy documents) rather than the full supporting infrastructure - the full
+    // stack snapshot churned on every unrelated synthesis change (PR #137 review).
     synthStack.prepareStack();
-    expect(Testing.synth(synthStack)).toMatchSnapshot();
+    const synthed = JSON.parse(Testing.synth(synthStack));
+    expect({
+      stateMachine: synthed.resource.aws_sfn_state_machine,
+      rolePolicies: synthed.resource.aws_iam_role_policy,
+      policyDocuments: synthed.data.aws_iam_policy_document,
+    }).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## Summary

Stacked on #136. Ports `BatchSubmitJob` from `aws-cdk-lib/aws-stepfunctions-tasks` v2.233.0 into `compute/tasks/batch` and adds the end-to-end **StepFunctions → Batch job on ECS** live integ test (`sfn.batch-submit-job`) — the target scenario for this port series. Built by a claude-native dynamic workflow (opus plan/verify, sonnet port), report: `conversion-run/report-sfn-batch-submit-job.md`.

Two commits:
1. The task construct (+ tasks barrel wiring, unit tests, snapshot).
2. The integ fixture: app + Go validator + Makefile target.

## Design notes

- **Decoupling preserved**: `jobDefinitionArn`/`jobQueueArn` stay plain strings (upstream's deliberate zero-dependency on the batch L2).
- **JSONata surface not ported** — base `TaskStateBase` predates it (JsonPath-only, like all existing tasks). Deprecated `run-batch-job.ts` skipped.
- All IAM statements preserved: `batch:SubmitJob` scoping (`job-definition/*` + queue ARN, `*` for JsonPath queue), plus the `.sync` EventBridge managed-rule statements (`events:PutTargets/PutRule/DescribeRule` on `StepFunctionsGetEventsForBatchJobsRule`).

## Deviation (live-caught upstream bug)

**`batch:TagResource` is granted alongside `batch:SubmitJob` when `tags` is set.** A tagged `SubmitJob` call fails with `AccessDeniedException ... not authorized to perform: batch:TagResource on ... job-definition/...` otherwise — caught by this PR's live run; upstream aws-cdk grants only `batch:SubmitJob` and fails identically at runtime. Pinned by a unit test.

## Verification

- compile clean; verify (opus) PASS — 0 invariant violations; 16/16 unit tests, snapshot locked; eslint clean (repo config, `--fix` applied).
- **Live end-to-end PASS** (`make sfn.batch-submit-job`, 452s): 23 applied → CEs VALID/ENABLED → StartExecution `{"bar":"SomeValue"}` → execution **SUCCEEDED** (Pass → BatchSubmitJob `.sync`) → **drift oracle: `tofu plan -detailed-exitcode` == 0 ("No changes.")** → Batch job **SUCCEEDED** on the EC2 compute environment → 23 destroyed, zero residue.
- The drift oracle run deploys an `aws_batch_job_definition` and is what confirmed-then-revalidated the `retry_strategy {}` perpetual-drift fix on #136 (`e21a5a3`) — see the ANSWERED section there. This PR should merge after #136.

## Fixture notes

- Mirrors upstream `integ.submit-job.ts`; `ContainerImage.fromAsset(batchjob-image)` swapped for `fromRegistry("public.ecr.aws/docker/library/python:3.13-alpine")` + `python -c "print('Hello from Batch!')"` (behaviorally identical job; base has no Docker image assets).
- gridUUID `g77777777-7777`; suffix-matched physical names; cheapest working network (2-AZ public-only VPC, `natGateways: 0`, CEs pinned to PUBLIC subnets — proven ecs.asg-capacity-provider pattern).
