### PR TITLE
feat(ecs): canned metrics for the ECS/ContainerInsights namespace

### DIFF
--- a/integ/aws/monitoring/Makefile
+++ b/integ/aws/monitoring/Makefile
@@ -4,6 +4,10 @@ all: ## Test all Monitoring integrations
 	go test -v -timeout 30m ./...
 .PHONY: all
 
+ecs-insights-metrics: ## Test ECS/ContainerInsights service metrics and alarms
+	go test -v -count 1 -timeout 30m ./... -run ^TestEcsInsightsMetrics$
+.PHONY: ecs-insights-metrics
+
 log-destination-kinesis: ## Test CloudWatch Log Delivery to Kinesis
 	go test -v -count 1 -timeout 15m ./... -run ^TestLogDestinationKinesis$
 .PHONY: log-destination-kinesis

--- a/integ/aws/monitoring/README.md
+++ b/integ/aws/monitoring/README.md
@@ -11,6 +11,7 @@ Run terratest:
 
 Test Targets:
   all                        Test all Monitoring integrations
+  ecs-insights-metrics       Test ECS/ContainerInsights service metrics and alarms
   log-destination-kinesis    Test CloudWatch Log Delivery to Kinesis
   log-destination-lambda     Test CloudWatch Log Delivery to Lambda
   log-group-dataprotection   Test CloudWatch Log Group Data Protection

--- a/integ/aws/monitoring/apps/ecs-insights-metrics.ts
+++ b/integ/aws/monitoring/apps/ecs-insights-metrics.ts
@@ -3,8 +3,10 @@
 //
 // Extended beyond the upstream test (which only asserts the cluster setting): each
 // `ECS/ContainerInsights` canned metric on BaseService creates a CloudWatch alarm, so
-// the Go validation can read the monitors back and verify namespace, metric name,
-// dimensions, statistic, and period against what Container Insights actually emits.
+// the Go validation can read the deployed monitors back and verify their configured
+// namespace, metric name, dimensions, statistic, and period. It validates the deployed
+// cluster setting and alarm configuration, not runtime metric publication — CloudWatch
+// accepts alarms on metric/dimension combinations that have not emitted data yet.
 
 import { App, LocalBackend, TerraformOutput } from "cdktn";
 import { aws } from "../../../../src";
@@ -105,7 +107,7 @@ const cpuReservedAlarm = service
 const ephemeralStorageAlarm = service
   .metricContainerInsights("EphemeralStorageUtilized")
   .createAlarm(stack, "EphemeralStorageAlarm", {
-    threshold: 20 * 1024, // MiB (20 GiB is the Fargate default ephemeral storage size)
+    threshold: 20, // GB — EphemeralStorageUtilized is reported in GB; Fargate's default capacity is 20 GB
     evaluationPeriods: 1,
   });
 

--- a/integ/aws/monitoring/apps/ecs-insights-metrics.ts
+++ b/integ/aws/monitoring/apps/ecs-insights-metrics.ts
@@ -1,0 +1,133 @@
+// Adapted from
+// https://github.com/aws/aws-cdk/blob/v2.263.0/packages/%40aws-cdk-testing/framework-integ/test/aws-ecs/test/integ.cluster-enhanced-container-insights.ts
+//
+// Extended beyond the upstream test (which only asserts the cluster setting): each
+// `ECS/ContainerInsights` canned metric on BaseService creates a CloudWatch alarm, so
+// the Go validation can read the monitors back and verify namespace, metric name,
+// dimensions, statistic, and period against what Container Insights actually emits.
+
+import { App, LocalBackend, TerraformOutput } from "cdktn";
+import { aws } from "../../../../src";
+
+const environmentName = process.env.ENVIRONMENT_NAME ?? "test";
+const region = process.env.AWS_REGION ?? "us-east-1";
+const outdir = process.env.OUT_DIR ?? "cdktf.out";
+const stackName = process.env.STACK_NAME ?? "ecs-insights-metrics";
+
+const app = new App({
+  outdir,
+});
+const stack = new aws.AwsStack(app, stackName, {
+  gridUUID: "g12345678-1234",
+  environmentName,
+  providerConfig: {
+    region,
+  },
+});
+new LocalBackend(stack, {
+  path: `${stackName}.tfstate`,
+});
+
+// Cheapest possible network for this fixture: 2 AZs, no NAT Gateways. Tasks get
+// `assignPublicIp: true` below so they can pull the "nginx" image and ship
+// Container Insights telemetry without a NAT Gateway.
+const vpc = new aws.compute.Vpc(stack, "Vpc", {
+  maxAzs: 2,
+  natGateways: 0,
+  subnetConfiguration: [
+    {
+      name: "public",
+      subnetType: aws.compute.SubnetType.PUBLIC,
+      cidrMask: 24,
+    },
+  ],
+});
+
+const cluster = new aws.compute.ecs.Cluster(stack, "Cluster", {
+  vpc,
+  containerInsightsV2: aws.compute.ecs.ContainerInsights.ENHANCED,
+  registerOutputs: true,
+  outputName: "cluster",
+});
+
+const taskDefinition = new aws.compute.ecs.FargateTaskDefinition(
+  stack,
+  "TaskDef",
+  {
+    memoryLimitMiB: 512,
+    cpu: 256,
+  },
+);
+
+taskDefinition.addContainer("nginx", {
+  image: aws.compute.ecs.ContainerImage.fromRegistry("nginx"),
+});
+
+const service = new aws.compute.ecs.FargateService(stack, "Service", {
+  cluster,
+  taskDefinition,
+  assignPublicIp: true,
+  registerOutputs: true,
+  outputName: "service",
+});
+
+// Monitors on the ECS/ContainerInsights canned metrics. Thresholds are absolute
+// (MiB / CPU units), unlike the AWS/ECS percentage metrics.
+const memoryUtilizedAlarm = service
+  .metricMemoryUtilized()
+  .createAlarm(stack, "MemoryUtilizedAlarm", {
+    threshold: 512,
+    evaluationPeriods: 1,
+  });
+
+const memoryReservedAlarm = service
+  .metricMemoryReserved()
+  .createAlarm(stack, "MemoryReservedAlarm", {
+    threshold: 512,
+    evaluationPeriods: 1,
+  });
+
+const cpuUtilizedAlarm = service
+  .metricCpuUtilized()
+  .createAlarm(stack, "CpuUtilizedAlarm", {
+    threshold: 256,
+    evaluationPeriods: 1,
+  });
+
+const cpuReservedAlarm = service
+  .metricCpuReserved()
+  .createAlarm(stack, "CpuReservedAlarm", {
+    threshold: 256,
+    evaluationPeriods: 1,
+  });
+
+// Escape hatch for Container Insights metrics without a canned helper.
+const ephemeralStorageAlarm = service
+  .metricContainerInsights("EphemeralStorageUtilized")
+  .createAlarm(stack, "EphemeralStorageAlarm", {
+    threshold: 20 * 1024, // MiB (20 GiB is the Fargate default ephemeral storage size)
+    evaluationPeriods: 1,
+  });
+
+// HACK: This is a workaround for createAlarmOptions missing AwsConstructProps (registerOutputs)
+new TerraformOutput(stack, "memory_utilized_alarm", {
+  value: memoryUtilizedAlarm.alarmOutputs,
+  staticId: true,
+});
+new TerraformOutput(stack, "memory_reserved_alarm", {
+  value: memoryReservedAlarm.alarmOutputs,
+  staticId: true,
+});
+new TerraformOutput(stack, "cpu_utilized_alarm", {
+  value: cpuUtilizedAlarm.alarmOutputs,
+  staticId: true,
+});
+new TerraformOutput(stack, "cpu_reserved_alarm", {
+  value: cpuReservedAlarm.alarmOutputs,
+  staticId: true,
+});
+new TerraformOutput(stack, "ephemeral_storage_alarm", {
+  value: ephemeralStorageAlarm.alarmOutputs,
+  staticId: true,
+});
+app.synth();

--- a/integ/aws/monitoring/ecs_insights_metrics_test.go
+++ b/integ/aws/monitoring/ecs_insights_metrics_test.go
@@ -1,0 +1,101 @@
+package test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ecs"
+	ecstypes "github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	terratestaws "github.com/gruntwork-io/terratest/modules/aws"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
+	"github.com/stretchr/testify/require"
+	"github.com/terraconstructs/base/integ"
+	util "github.com/terraconstructs/base/integ/aws"
+)
+
+// Run the apps/ecs-insights-metrics.ts integration test.
+//
+// Port of the upstream integ.cluster-enhanced-container-insights.ts describeClusters
+// assertion, extended to validate the alarms created from the ECS/ContainerInsights
+// canned metrics on BaseService.
+func TestEcsInsightsMetrics(t *testing.T) {
+	app := "ecs-insights-metrics"
+	runMonitoringIntegrationTest(t, app, "us-east-1",
+		func(t *testing.T, tfWorkingDir string, awsRegion string) {
+			snapshotPath := filepath.Join("snapshots", app)
+			// Load the Terraform Options saved by the earlier deploy_terraform stage
+			terraformOptions := test_structure.LoadTerraformOptions(t, tfWorkingDir)
+			clusterName := util.LoadOutputAttribute(t, terraformOptions, "cluster", "name")
+			serviceName := util.LoadOutputAttribute(t, terraformOptions, "service", "name")
+
+			// Upstream assertion: the cluster reports containerInsights=enhanced.
+			ecsClient := terratestaws.NewEcsClient(t, awsRegion)
+			describeOut, err := ecsClient.DescribeClusters(context.Background(), &ecs.DescribeClustersInput{
+				Clusters: []string{clusterName},
+				// Container insights is in the settings array, so it must be included.
+				Include: []ecstypes.ClusterField{ecstypes.ClusterFieldSettings},
+			})
+			require.NoError(t, err)
+			require.Len(t, describeOut.Clusters, 1)
+			insightsValue := ""
+			for _, setting := range describeOut.Clusters[0].Settings {
+				if setting.Name == ecstypes.ClusterSettingNameContainerInsights {
+					insightsValue = aws.ToString(setting.Value)
+				}
+			}
+			require.Equal(t, "enhanced", insightsValue,
+				"expected containerInsights=enhanced on cluster %s", clusterName)
+
+			// The alarms created from the canned metrics. The first four use the canned
+			// Maximum statistic; the escape-hatch alarm keeps the cloudwatch.Metric
+			// default of Average.
+			alarms := []struct {
+				outputName string
+				metricName string
+				statistic  string
+			}{
+				{"memory_utilized_alarm", "MemoryUtilized", "Maximum"},
+				{"memory_reserved_alarm", "MemoryReserved", "Maximum"},
+				{"cpu_utilized_alarm", "CpuUtilized", "Maximum"},
+				{"cpu_reserved_alarm", "CpuReserved", "Maximum"},
+				{"ephemeral_storage_alarm", "EphemeralStorageUtilized", "Average"},
+			}
+			for _, expected := range alarms {
+				alarmName := util.LoadOutputAttribute(t, terraformOptions, expected.outputName, "alarmName")
+				alarm := util.GetMetricAlarm(t, awsRegion, alarmName)
+				require.NotNil(t, alarm)
+				if os.Getenv("WRITE_SNAPSHOTS") == "true" {
+					writeSnapshot(t, snapshotPath, alarm, expected.outputName)
+				} else {
+					integ.Assert(t, alarm, []integ.Assertion{
+						{
+							Path:           "Namespace",
+							ExpectedRegexp: aws.String(`^ECS/ContainerInsights$`),
+						},
+						{
+							Path:           "MetricName",
+							ExpectedRegexp: aws.String(fmt.Sprintf("^%s$", expected.metricName)),
+						},
+						{
+							Path:           "Period",
+							ExpectedRegexp: aws.String(`^300$`),
+						},
+					})
+					require.Equal(t, expected.statistic, string(alarm.Statistic),
+						"unexpected statistic on alarm %s", alarmName)
+					dims := map[string]string{}
+					for _, d := range alarm.Dimensions {
+						dims[aws.ToString(d.Name)] = aws.ToString(d.Value)
+					}
+					require.Equal(t, clusterName, dims["ClusterName"],
+						"expected ClusterName dimension on alarm %s", alarmName)
+					require.Equal(t, serviceName, dims["ServiceName"],
+						"expected ServiceName dimension on alarm %s", alarmName)
+				}
+			}
+		})
+}

--- a/src/aws/compute/ecs/base/base-service.ts
+++ b/src/aws/compute/ecs/base/base-service.ts
@@ -1969,12 +1969,14 @@ export abstract class BaseService
 
   /**
    * This method returns the CloudWatch metric for the memory used by this service's
-   * tasks, in MiB.
+   * tasks, in MiB, aggregated across the service.
    *
-   * Use this rather than `metricMemoryUtilization()` when you need to compare against a
-   * container's hard memory limit — for example to redeploy a leaking service before it
-   * is OOM-killed. The `AWS/ECS` percentage is relative to the task's reservation and
-   * cannot answer that question.
+   * Use this rather than `metricMemoryUtilization()` when you need absolute MiB instead
+   * of a percentage of the task's reservation. Note this is a service-level aggregate:
+   * one leaking task or container among several can stay hidden below the aggregate, so
+   * this suits service/task aggregate monitoring, not per-container memory-limit
+   * tracking (which requires Container Insights enhanced observability metrics with
+   * task/container-level dimensions).
    *
    * Requires Container Insights to be enabled on the cluster.
    *

--- a/src/aws/compute/ecs/base/base-service.ts
+++ b/src/aws/compute/ecs/base/base-service.ts
@@ -61,7 +61,9 @@ import {
   Cluster,
 } from "../cluster";
 import { ContainerDefinition, Protocol } from "../container-definition";
+import { ContainerInsightsMetrics } from "../container-insights-canned-metrics";
 import { IDeploymentLifecycleHookTarget } from "../deployment-lifecycle-hook-target";
+import { MetricWithDims } from "../ecs-canned-metrics.generated";
 import { LogDriver, LogDriverConfig } from "../log-drivers/log-driver";
 
 /**
@@ -1938,6 +1940,120 @@ export abstract class BaseService
     props?: cloudwatch.MetricOptions,
   ): cloudwatch.Metric {
     return this.metric("CPUUtilization", props);
+  }
+
+  /**
+   * This method returns the specified CloudWatch metric name for this service from the
+   * `ECS/ContainerInsights` namespace.
+   *
+   * Unlike `metric()`, which reads `AWS/ECS` utilization as a percentage of the task's
+   * reservation, Container Insights reports absolute values (CPU units, MiB). Requires
+   * Container Insights to be enabled on the cluster.
+   *
+   * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-metrics-ECS.html
+   */
+  public metricContainerInsights(
+    metricName: string,
+    props?: cloudwatch.MetricOptions,
+  ): cloudwatch.Metric {
+    return new cloudwatch.Metric({
+      namespace: "ECS/ContainerInsights",
+      metricName,
+      dimensionsMap: {
+        ClusterName: this.cluster.clusterName,
+        ServiceName: this.serviceName,
+      },
+      ...props,
+    }).attachTo(this);
+  }
+
+  /**
+   * This method returns the CloudWatch metric for the memory used by this service's
+   * tasks, in MiB.
+   *
+   * Use this rather than `metricMemoryUtilization()` when you need to compare against a
+   * container's hard memory limit — for example to redeploy a leaking service before it
+   * is OOM-killed. The `AWS/ECS` percentage is relative to the task's reservation and
+   * cannot answer that question.
+   *
+   * Requires Container Insights to be enabled on the cluster.
+   *
+   * @default maximum over 5 minutes
+   */
+  public metricMemoryUtilized(
+    props?: cloudwatch.MetricOptions,
+  ): cloudwatch.Metric {
+    return this.cannedContainerInsightsMetric(
+      ContainerInsightsMetrics.memoryUtilizedMaximum,
+      props,
+    );
+  }
+
+  /**
+   * This method returns the CloudWatch metric for the memory reserved by this service's
+   * tasks, in MiB.
+   *
+   * Requires Container Insights to be enabled on the cluster.
+   *
+   * @default maximum over 5 minutes
+   */
+  public metricMemoryReserved(
+    props?: cloudwatch.MetricOptions,
+  ): cloudwatch.Metric {
+    return this.cannedContainerInsightsMetric(
+      ContainerInsightsMetrics.memoryReservedMaximum,
+      props,
+    );
+  }
+
+  /**
+   * This method returns the CloudWatch metric for the CPU units used by this service's
+   * tasks.
+   *
+   * Requires Container Insights to be enabled on the cluster.
+   *
+   * @default maximum over 5 minutes
+   */
+  public metricCpuUtilized(
+    props?: cloudwatch.MetricOptions,
+  ): cloudwatch.Metric {
+    return this.cannedContainerInsightsMetric(
+      ContainerInsightsMetrics.cpuUtilizedMaximum,
+      props,
+    );
+  }
+
+  /**
+   * This method returns the CloudWatch metric for the CPU units reserved by this
+   * service's tasks.
+   *
+   * Requires Container Insights to be enabled on the cluster.
+   *
+   * @default maximum over 5 minutes
+   */
+  public metricCpuReserved(
+    props?: cloudwatch.MetricOptions,
+  ): cloudwatch.Metric {
+    return this.cannedContainerInsightsMetric(
+      ContainerInsightsMetrics.cpuReservedMaximum,
+      props,
+    );
+  }
+
+  private cannedContainerInsightsMetric(
+    fn: (dims: {
+      ClusterName: string;
+      ServiceName: string;
+    }) => MetricWithDims<{ ClusterName: string; ServiceName: string }>,
+    props?: cloudwatch.MetricOptions,
+  ): cloudwatch.Metric {
+    return new cloudwatch.Metric({
+      ...fn({
+        ClusterName: this.cluster.clusterName,
+        ServiceName: this.serviceName,
+      }),
+      ...props,
+    }).attachTo(this);
   }
 
   /**

--- a/src/aws/compute/ecs/container-insights-canned-metrics.ts
+++ b/src/aws/compute/ecs/container-insights-canned-metrics.ts
@@ -1,0 +1,123 @@
+// Canned metrics for the `ECS/ContainerInsights` namespace.
+//
+// Hand-written, following the same pattern as
+// src/aws/notify/kinesis-fixed-canned-metrics.ts: the generated canned metrics do not
+// cover what the service actually emits.
+//
+// The generator (https://github.com/cdklabs/awscdk-service-spec/blob/main/sources/CloudWatchConsoleServiceDirectory)
+// maps one namespace per CloudFormation service, so `ECSMetrics` in
+// ecs-canned-metrics.generated.ts only ever emits the `AWS/ECS` namespace. Container
+// Insights has no CloudFormation resource behind it and is therefore never emitted —
+// aws-cdk has the same gap.
+//
+// Container Insights metrics reference:
+// https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights-metrics-ECS.html
+import { MetricWithDims } from "./ecs-canned-metrics.generated";
+
+/**
+ * Canned metrics for the `ECS/ContainerInsights` namespace.
+ *
+ * These complement `ECSMetrics`, which only covers `AWS/ECS`. The two namespaces are not
+ * interchangeable: `AWS/ECS` reports utilization as a *percentage of the task's
+ * reservation*, whereas Container Insights reports absolute CPU units and MiB. Only the
+ * latter can be compared against a container's hard memory limit, which is what you need
+ * to detect a container approaching an OOM kill.
+ *
+ * Requires Container Insights to be enabled on the cluster.
+ */
+export class ContainerInsightsMetrics {
+  /**
+   * Memory used by the service's tasks, in MiB.
+   */
+  public static memoryUtilizedMaximum(dimensions: {
+    ClusterName: string;
+    ServiceName: string;
+  }): MetricWithDims<{ ClusterName: string; ServiceName: string }>;
+  public static memoryUtilizedMaximum(dimensions: {
+    ClusterName: string;
+  }): MetricWithDims<{ ClusterName: string }>;
+  public static memoryUtilizedMaximum(dimensions: any): MetricWithDims<any> {
+    return {
+      namespace: "ECS/ContainerInsights",
+      metricName: "MemoryUtilized",
+      dimensionsMap: dimensions,
+      statistic: "Maximum",
+    };
+  }
+
+  /**
+   * Memory reserved by the service's tasks, in MiB.
+   */
+  public static memoryReservedMaximum(dimensions: {
+    ClusterName: string;
+    ServiceName: string;
+  }): MetricWithDims<{ ClusterName: string; ServiceName: string }>;
+  public static memoryReservedMaximum(dimensions: {
+    ClusterName: string;
+  }): MetricWithDims<{ ClusterName: string }>;
+  public static memoryReservedMaximum(dimensions: any): MetricWithDims<any> {
+    return {
+      namespace: "ECS/ContainerInsights",
+      metricName: "MemoryReserved",
+      dimensionsMap: dimensions,
+      statistic: "Maximum",
+    };
+  }
+
+  /**
+   * CPU units used by the service's tasks.
+   */
+  public static cpuUtilizedMaximum(dimensions: {
+    ClusterName: string;
+    ServiceName: string;
+  }): MetricWithDims<{ ClusterName: string; ServiceName: string }>;
+  public static cpuUtilizedMaximum(dimensions: {
+    ClusterName: string;
+  }): MetricWithDims<{ ClusterName: string }>;
+  public static cpuUtilizedMaximum(dimensions: any): MetricWithDims<any> {
+    return {
+      namespace: "ECS/ContainerInsights",
+      metricName: "CpuUtilized",
+      dimensionsMap: dimensions,
+      statistic: "Maximum",
+    };
+  }
+
+  /**
+   * CPU units reserved by the service's tasks.
+   */
+  public static cpuReservedMaximum(dimensions: {
+    ClusterName: string;
+    ServiceName: string;
+  }): MetricWithDims<{ ClusterName: string; ServiceName: string }>;
+  public static cpuReservedMaximum(dimensions: {
+    ClusterName: string;
+  }): MetricWithDims<{ ClusterName: string }>;
+  public static cpuReservedMaximum(dimensions: any): MetricWithDims<any> {
+    return {
+      namespace: "ECS/ContainerInsights",
+      metricName: "CpuReserved",
+      dimensionsMap: dimensions,
+      statistic: "Maximum",
+    };
+  }
+
+  /**
+   * Number of tasks running for the service.
+   */
+  public static runningTaskCountAverage(dimensions: {
+    ClusterName: string;
+    ServiceName: string;
+  }): MetricWithDims<{ ClusterName: string; ServiceName: string }>;
+  public static runningTaskCountAverage(dimensions: {
+    ClusterName: string;
+  }): MetricWithDims<{ ClusterName: string }>;
+  public static runningTaskCountAverage(dimensions: any): MetricWithDims<any> {
+    return {
+      namespace: "ECS/ContainerInsights",
+      metricName: "RunningTaskCount",
+      dimensionsMap: dimensions,
+      statistic: "Average",
+    };
+  }
+}

--- a/src/aws/compute/ecs/container-insights-canned-metrics.ts
+++ b/src/aws/compute/ecs/container-insights-canned-metrics.ts
@@ -19,9 +19,12 @@ import { MetricWithDims } from "./ecs-canned-metrics.generated";
  *
  * These complement `ECSMetrics`, which only covers `AWS/ECS`. The two namespaces are not
  * interchangeable: `AWS/ECS` reports utilization as a *percentage of the task's
- * reservation*, whereas Container Insights reports absolute CPU units and MiB. Only the
- * latter can be compared against a container's hard memory limit, which is what you need
- * to detect a container approaching an OOM kill.
+ * reservation*, whereas Container Insights reports absolute CPU units and MiB.
+ *
+ * These are aggregates over all tasks in the selected dimension set (e.g. all tasks of a
+ * service) — they cannot single out one task or container, so a single outlier can be
+ * hidden by the aggregate. Per-task/per-container series require Container Insights
+ * *enhanced observability* metrics and dimensions, which are not covered here.
  *
  * Requires Container Insights to be enabled on the cluster.
  */
@@ -99,25 +102,6 @@ export class ContainerInsightsMetrics {
       metricName: "CpuReserved",
       dimensionsMap: dimensions,
       statistic: "Maximum",
-    };
-  }
-
-  /**
-   * Number of tasks running for the service.
-   */
-  public static runningTaskCountAverage(dimensions: {
-    ClusterName: string;
-    ServiceName: string;
-  }): MetricWithDims<{ ClusterName: string; ServiceName: string }>;
-  public static runningTaskCountAverage(dimensions: {
-    ClusterName: string;
-  }): MetricWithDims<{ ClusterName: string }>;
-  public static runningTaskCountAverage(dimensions: any): MetricWithDims<any> {
-    return {
-      namespace: "ECS/ContainerInsights",
-      metricName: "RunningTaskCount",
-      dimensionsMap: dimensions,
-      statistic: "Average",
     };
   }
 }

--- a/src/aws/compute/ecs/index.ts
+++ b/src/aws/compute/ecs/index.ts
@@ -5,6 +5,10 @@ export * from "./base/service-managed-volume";
 
 export * from "./availability-zone-rebalancing";
 export * from "./container-definition";
+// NOTE: ./container-insights-canned-metrics is deliberately NOT exported, matching the
+// generated canned-metric modules. jsii cannot model their inline dimension types
+// (JSII1003: only string-indexed map types are supported). The public surface is the
+// metricContainerInsights()/metricMemoryUtilized()/... methods on BaseService.
 export * from "./container-image";
 export * from "./amis";
 export * from "./cluster";

--- a/test/aws/compute/ecs/fargate/fargate-service.test.ts
+++ b/test/aws/compute/ecs/fargate/fargate-service.test.ts
@@ -4114,6 +4114,94 @@ describe("fargate service", () => {
     });
   });
 
+  test("Container Insights metrics", () => {
+    // GIVEN
+    const stack = new AwsStack();
+    const vpc = new compute.Vpc(stack, "MyVpc");
+    const cluster = new ecs.Cluster(stack, "EcsCluster", { vpc });
+    const taskDefinition = new ecs.FargateTaskDefinition(
+      stack,
+      "FargateTaskDef",
+    );
+    taskDefinition.addContainer("Container", {
+      image: ecs.ContainerImage.fromRegistry("hello"),
+    });
+
+    // WHEN
+    const service = new ecs.FargateService(stack, "Service", {
+      cluster,
+      taskDefinition,
+    });
+
+    const dimensions = {
+      ClusterName: stack.resolve(cluster.clusterName),
+      ServiceName: stack.resolve(service.serviceName),
+    };
+
+    // THEN
+    // MemoryUtilized is absolute MiB, unlike the AWS/ECS MemoryUtilization percentage.
+    expect(stack.resolve(service.metricMemoryUtilized())).toEqual({
+      dimensions,
+      namespace: "ECS/ContainerInsights",
+      metricName: "MemoryUtilized",
+      period: Duration.minutes(5),
+      statistic: "Maximum",
+    });
+
+    expect(stack.resolve(service.metricMemoryReserved())).toEqual({
+      dimensions,
+      namespace: "ECS/ContainerInsights",
+      metricName: "MemoryReserved",
+      period: Duration.minutes(5),
+      statistic: "Maximum",
+    });
+
+    expect(stack.resolve(service.metricCpuUtilized())).toEqual({
+      dimensions,
+      namespace: "ECS/ContainerInsights",
+      metricName: "CpuUtilized",
+      period: Duration.minutes(5),
+      statistic: "Maximum",
+    });
+
+    expect(stack.resolve(service.metricCpuReserved())).toEqual({
+      dimensions,
+      namespace: "ECS/ContainerInsights",
+      metricName: "CpuReserved",
+      period: Duration.minutes(5),
+      statistic: "Maximum",
+    });
+
+    // props override the canned statistic and period
+    expect(
+      stack.resolve(
+        service.metricMemoryUtilized({
+          statistic: "Average",
+          period: Duration.minutes(1),
+        }),
+      ),
+    ).toEqual({
+      dimensions,
+      namespace: "ECS/ContainerInsights",
+      metricName: "MemoryUtilized",
+      period: Duration.minutes(1),
+      statistic: "Average",
+    });
+
+    // escape hatch for Container Insights metrics without a canned helper
+    expect(
+      stack.resolve(
+        service.metricContainerInsights("EphemeralStorageUtilized"),
+      ),
+    ).toEqual({
+      dimensions,
+      namespace: "ECS/ContainerInsights",
+      metricName: "EphemeralStorageUtilized",
+      period: Duration.minutes(5),
+      statistic: "Average",
+    });
+  });
+
   describe("When import a Fargate Service", () => {
     test("fromFargateServiceArn old format", () => {
       // GIVEN


### PR DESCRIPTION
## What

Adds canned metrics for the `ECS/ContainerInsights` namespace, and surfaces them on `BaseService` as `metricMemoryUtilized()`, `metricMemoryReserved()`, `metricCpuUtilized()`, `metricCpuReserved()`, plus a general `metricContainerInsights(metricName)` escape hatch.

## Why

The generated `ECSMetrics` only covers `AWS/ECS`, where the utilization metrics are **percentages of the task's reservation**. Container Insights reports **absolute** CPU units and MiB, which is what you want when alarm thresholds are naturally expressed in absolute units (e.g. alert when the service's tasks use more than N MiB). Today that means hand-writing the namespace/metricName/statistic literals at every call site.

**Scope note (from review):** these series carry only `ClusterName` + `ServiceName` dimensions, so they are **service-level aggregates** across all of the service's tasks and containers. They suit service/task aggregate monitoring; they cannot single out one leaking task or container below the aggregate — that requires Container Insights *enhanced observability* metrics with task/container-level dimensions, which is out of scope here. The API docs state this explicitly.

The generator never emits this namespace: [awscdk-service-spec's CloudWatchConsoleServiceDirectory](https://github.com/cdklabs/awscdk-service-spec/blob/main/sources/CloudWatchConsoleServiceDirectory) maps one namespace per CloudFormation service, and Container Insights has no CloudFormation resource behind it. aws-cdk has the same gap — there are zero references to `ECS/ContainerInsights` or `MemoryUtilized` anywhere in `aws-cdk-lib` on `main`, so this isn't a parity catch-up but a small step ahead.

## How

`src/aws/compute/ecs/container-insights-canned-metrics.ts` is hand-written, following the existing `src/aws/notify/kinesis-fixed-canned-metrics.ts` precedent (same situation — the generated canned metrics don't match what the service emits). It reuses `MetricWithDims` from `ecs-canned-metrics.generated` rather than redeclaring it.

On `BaseService` the methods go through a private `cannedContainerInsightsMetric()` helper that mirrors the `cannedMetric()` idiom already in `cluster.ts`.

```ts
// before
new cloudwatch.Metric({
  namespace: "ECS/ContainerInsights",
  metricName: "MemoryUtilized",
  statistic: "Maximum",
  dimensionsMap: { ClusterName: cluster.clusterName, ServiceName: service.serviceName },
  period: Duration.minutes(1),
}).createAlarm(this, "MemoryHigh", { threshold: 5120, /* MiB */ ... });

// after
service.metricMemoryUtilized({ period: Duration.minutes(1) })
  .createAlarm(this, "MemoryHigh", { threshold: 5120, /* MiB */ ... });
```

## Note on the index export

`ContainerInsightsMetrics` is **not** exported from `src/aws/compute/ecs/index.ts`, matching the generated canned-metric modules. I tried exporting it — jsii rejects it with `JSII1003: Only string-indexed map types are supported` on the inline dimension types, which I assume is why none of the generated canned-metric modules are exported either. The `BaseService` methods are the public surface; I left a comment in the index recording the reason so the next person doesn't retry it.

Happy to add a jsii-safe public wrapper (non-generic return interface, one method per dimension set) in a follow-up if you'd want the class reachable for users alarming on services this library didn't create — that's the one use case the `BaseService` methods don't cover.

## Testing

- `pnpm compile` — clean (0 errors)
- `pnpm eslint` — clean
- `pnpm jest ./test/aws/compute/ecs/` — 26 suites, 756 tests, 38 snapshots, all passing
- `Container Insights metrics` test in `fargate-service.test.ts` covering the four canned metrics, `props` overriding the canned statistic/period, and the `metricContainerInsights()` escape hatch
- **Integration test** (`integ/aws/monitoring`): `apps/ecs-insights-metrics.ts` + `TestEcsInsightsMetrics`, adapted from aws-cdk's [`integ.cluster-enhanced-container-insights.ts`](https://github.com/aws/aws-cdk/blob/v2.263.0/packages/%40aws-cdk-testing/framework-integ/test/aws-ecs/test/integ.cluster-enhanced-container-insights.ts) — a cluster with `containerInsightsV2: ENHANCED` and a Fargate service, with an alarm created from each canned metric plus the escape hatch. Validation ports the upstream `describeClusters` assertion (`containerInsights=enhanced`) and additionally asserts each alarm's namespace, metric name, statistic, period, and `ClusterName`/`ServiceName` dimensions via `DescribeAlarms`. Synth verified locally with `make ecs-insights-metrics-synth-only`; run `cd integ/aws/monitoring && make ecs-insights-metrics` with AWS credentials for the full deploy/validate cycle.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
