### PR TITLE
feat: upgrade to cdktn v0.24

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -2,7 +2,7 @@
   "dependencies": [
     {
       "name": "@aws-cdk/cloud-assembly-schema",
-      "version": "^49.4.0",
+      "version": "54.17.0",
       "type": "build"
     },
     {
@@ -192,7 +192,7 @@
     },
     {
       "name": "@aws-cdk/cloud-assembly-schema",
-      "version": "^49.4.0",
+      "version": "^54.17.0",
       "type": "peer"
     },
     {

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -12,32 +12,32 @@
     },
     {
       "name": "@cdktn/provider-archive",
-      "version": "^13.1.0",
+      "version": "14.0.0",
       "type": "build"
     },
     {
       "name": "@cdktn/provider-aws",
-      "version": "^24.8.0",
+      "version": "25.0.0",
       "type": "build"
     },
     {
       "name": "@cdktn/provider-cloudinit",
-      "version": "^13.1.0",
+      "version": "14.0.0",
       "type": "build"
     },
     {
       "name": "@cdktn/provider-docker",
-      "version": "^15.3.0",
+      "version": "16.0.0",
       "type": "build"
     },
     {
       "name": "@cdktn/provider-time",
-      "version": "^13.1.0",
+      "version": "14.0.0",
       "type": "build"
     },
     {
       "name": "@cdktn/provider-tls",
-      "version": "^13.1.0",
+      "version": "14.0.0",
       "type": "build"
     },
     {
@@ -74,7 +74,7 @@
     },
     {
       "name": "cdktn",
-      "version": "^0.23.0",
+      "version": "0.24.0",
       "type": "build"
     },
     {
@@ -84,7 +84,7 @@
     },
     {
       "name": "constructs",
-      "version": "^10.6.0",
+      "version": "10.7.0",
       "type": "build"
     },
     {
@@ -187,7 +187,7 @@
     },
     {
       "name": "minimatch",
-      "version": "^10.2.5",
+      "version": "^10.2.6",
       "type": "bundled"
     },
     {
@@ -202,42 +202,42 @@
     },
     {
       "name": "@cdktn/provider-archive",
-      "version": "^13.1.0",
+      "version": "^14.0.0",
       "type": "peer"
     },
     {
       "name": "@cdktn/provider-aws",
-      "version": "^24.8.0",
+      "version": "^25.0.0",
       "type": "peer"
     },
     {
       "name": "@cdktn/provider-cloudinit",
-      "version": "^13.1.0",
+      "version": "^14.0.0",
       "type": "peer"
     },
     {
       "name": "@cdktn/provider-docker",
-      "version": "^15.3.0",
+      "version": "^16.0.0",
       "type": "peer"
     },
     {
       "name": "@cdktn/provider-time",
-      "version": "^13.1.0",
+      "version": "^14.0.0",
       "type": "peer"
     },
     {
       "name": "@cdktn/provider-tls",
-      "version": "^13.1.0",
+      "version": "^14.0.0",
       "type": "peer"
     },
     {
       "name": "cdktn",
-      "version": "^0.23.0",
+      "version": "^0.24.0",
       "type": "peer"
     },
     {
       "name": "constructs",
-      "version": "^10.6.0",
+      "version": "^10.7.2",
       "type": "peer"
     }
   ],

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -178,7 +178,7 @@
     },
     {
       "name": "ignore",
-      "version": "^5.3.2",
+      "version": "^7.0.6",
       "type": "bundled"
     },
     {

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -173,7 +173,7 @@
     },
     {
       "name": "change-case",
-      "version": "^4.1.1",
+      "version": "^5.4.4",
       "type": "bundled"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -73,7 +73,7 @@ const project = new cdk.JsiiProject({
     "@cdktn/provider-cloudinit@^14.0.0",
     "@cdktn/provider-docker@^16.0.0",
     "constructs@^10.7.2",
-    "@aws-cdk/cloud-assembly-schema@^49.4.0",
+    "@aws-cdk/cloud-assembly-schema@^54.17.0",
     "@aws-cdk/region-info@^2.233.0",
   ],
   devDeps: [
@@ -85,7 +85,7 @@ const project = new cdk.JsiiProject({
     "@cdktn/provider-cloudinit@14.0.0",
     "@cdktn/provider-docker@16.0.0",
     "constructs@10.7.0",
-    "@aws-cdk/cloud-assembly-schema@^49.4.0",
+    "@aws-cdk/cloud-assembly-schema@54.17.0",
     "@aws-cdk/region-info@^2.233.0",
     "@jsii/spec@^1.102.0",
     "@mrgrain/jsii-struct-builder",

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -18,8 +18,8 @@ import {
   workflowBootstrapSteps,
 } from "./projenrc/github-workflows";
 
-// set strict node version compatible with webcontainers.io
-const nodeVersion = ">=20.9.0";
+// cdktn 0.24+ requires Node 22 minimum
+const nodeVersion = ">=22.12.0";
 const pnpmVersion = "11.5.0";
 const workflowNodeVersion = "24.12.0";
 
@@ -65,26 +65,26 @@ const project = new cdk.JsiiProject({
 
   // cdktn construct lib config
   peerDeps: [
-    "cdktn@^0.23.0",
-    "@cdktn/provider-aws@^24.8.0",
-    "@cdktn/provider-time@^13.1.0",
-    "@cdktn/provider-archive@^13.1.0",
-    "@cdktn/provider-tls@^13.1.0",
-    "@cdktn/provider-cloudinit@^13.1.0",
-    "@cdktn/provider-docker@^15.3.0",
-    "constructs@^10.6.0",
+    "cdktn@^0.24.0",
+    "@cdktn/provider-aws@^25.0.0",
+    "@cdktn/provider-time@^14.0.0",
+    "@cdktn/provider-archive@^14.0.0",
+    "@cdktn/provider-tls@^14.0.0",
+    "@cdktn/provider-cloudinit@^14.0.0",
+    "@cdktn/provider-docker@^16.0.0",
+    "constructs@^10.7.2",
     "@aws-cdk/cloud-assembly-schema@^49.4.0",
     "@aws-cdk/region-info@^2.233.0",
   ],
   devDeps: [
-    "cdktn@^0.23.0",
-    "@cdktn/provider-aws@^24.8.0",
-    "@cdktn/provider-time@^13.1.0",
-    "@cdktn/provider-archive@^13.1.0",
-    "@cdktn/provider-tls@^13.1.0",
-    "@cdktn/provider-cloudinit@^13.1.0",
-    "@cdktn/provider-docker@^15.3.0",
-    "constructs@^10.6.0",
+    "cdktn@0.24.0",
+    "@cdktn/provider-aws@25.0.0",
+    "@cdktn/provider-time@14.0.0",
+    "@cdktn/provider-archive@14.0.0",
+    "@cdktn/provider-tls@14.0.0",
+    "@cdktn/provider-cloudinit@14.0.0",
+    "@cdktn/provider-docker@16.0.0",
+    "constructs@10.7.0",
     "@aws-cdk/cloud-assembly-schema@^49.4.0",
     "@aws-cdk/region-info@^2.233.0",
     "@jsii/spec@^1.102.0",
@@ -102,7 +102,7 @@ const project = new cdk.JsiiProject({
     "change-case@^4.1.1",
     "@balena/dockerignore@^1.0.2",
     "ignore@^5.3.2",
-    "minimatch@^10.2.5",
+    "minimatch@^10.2.6",
   ],
   // deps: ["@balena/dockerignore@^1.0.2", "ignore@^5.3.2"],
 

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -99,7 +99,7 @@ const project = new cdk.JsiiProject({
   ],
   bundledDeps: [
     "mime-types",
-    "change-case@^4.1.1",
+    "change-case@^5.4.4",
     "@balena/dockerignore@^1.0.2",
     "ignore@^5.3.2",
     "minimatch@^10.2.6",
@@ -116,6 +116,19 @@ const project = new cdk.JsiiProject({
       // Jest is resource greedy so this shouldn't be more than 50%
       maxWorkers: "50%",
       testEnvironment: "node",
+      // change-case v5 is ESM-only; transform it to CJS for jest.
+      transformIgnorePatterns: ["/node_modules/(?!change-case)"],
+      transform: {
+        // Override projen's default ts-only transform to also handle .js
+        // files (needed for ESM-only bundled deps like change-case v5).
+        "^.+\\.[t]sx?$": new javascript.Transform("ts-jest", {
+          tsconfig: "test/tsconfig.json",
+        }),
+        "^.+\\.jsx?$": new javascript.Transform("ts-jest", {
+          tsconfig: "test/tsconfig.json",
+          useESM: false,
+        }),
+      },
     },
   },
 

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -101,10 +101,10 @@ const project = new cdk.JsiiProject({
     "mime-types",
     "change-case@^5.4.4",
     "@balena/dockerignore@^1.0.2",
-    "ignore@^5.3.2",
+    "ignore@^7.0.6",
     "minimatch@^10.2.6",
   ],
-  // deps: ["@balena/dockerignore@^1.0.2", "ignore@^5.3.2"],
+  // deps: ["@balena/dockerignore@^1.0.2", "ignore@^7.0.6"],
 
   workflowNodeVersion,
   workflowBootstrapSteps,

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "dependencies": {
     "@balena/dockerignore": "^1.0.2",
     "change-case": "^5.4.4",
-    "ignore": "^5.3.2",
+    "ignore": "^7.0.6",
     "mime-types": "^2.1.35",
     "minimatch": "^10.2.6"
   },

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
   "devDependencies": {
     "@aws-cdk/cloud-assembly-schema": "49.4.0",
     "@aws-cdk/region-info": "2.233.0",
-    "@cdktn/provider-archive": "13.1.0",
-    "@cdktn/provider-aws": "24.8.0",
-    "@cdktn/provider-cloudinit": "13.1.0",
-    "@cdktn/provider-docker": "15.3.0",
-    "@cdktn/provider-time": "13.1.0",
-    "@cdktn/provider-tls": "13.1.0",
+    "@cdktn/provider-archive": "14.0.0",
+    "@cdktn/provider-aws": "25.0.0",
+    "@cdktn/provider-cloudinit": "14.0.0",
+    "@cdktn/provider-docker": "16.0.0",
+    "@cdktn/provider-time": "14.0.0",
+    "@cdktn/provider-tls": "14.0.0",
     "@jsii/spec": "^1.102.0",
     "@mrgrain/jsii-struct-builder": "^0.7.64",
     "@types/jest": "^29.5.14",
@@ -48,9 +48,9 @@
     "@types/node": "ts5.9",
     "@typescript-eslint/eslint-plugin": "^8",
     "@typescript-eslint/parser": "^8",
-    "cdktn": "0.23.0",
+    "cdktn": "0.24.0",
     "commit-and-tag-version": "^12",
-    "constructs": "10.6.0",
+    "constructs": "10.7.2",
     "delay": "^5.0.0",
     "eslint": "^9",
     "eslint-config-prettier": "^9.1.2",
@@ -73,21 +73,21 @@
   "peerDependencies": {
     "@aws-cdk/cloud-assembly-schema": "^49.4.0",
     "@aws-cdk/region-info": "^2.233.0",
-    "@cdktn/provider-archive": "^13.1.0",
-    "@cdktn/provider-aws": "^24.8.0",
-    "@cdktn/provider-cloudinit": "^13.1.0",
-    "@cdktn/provider-docker": "^15.3.0",
-    "@cdktn/provider-time": "^13.1.0",
-    "@cdktn/provider-tls": "^13.1.0",
-    "cdktn": "^0.23.0",
-    "constructs": "^10.6.0"
+    "@cdktn/provider-archive": "^14.0.0",
+    "@cdktn/provider-aws": "^25.0.0",
+    "@cdktn/provider-cloudinit": "^14.0.0",
+    "@cdktn/provider-docker": "^16.0.0",
+    "@cdktn/provider-time": "^14.0.0",
+    "@cdktn/provider-tls": "^14.0.0",
+    "cdktn": "^0.24.0",
+    "constructs": "^10.7.2"
   },
   "dependencies": {
     "@balena/dockerignore": "^1.0.2",
     "change-case": "^4.1.1",
     "ignore": "^5.3.2",
     "mime-types": "^2.1.35",
-    "minimatch": "^10.2.5"
+    "minimatch": "^10.2.6"
   },
   "bundledDependencies": [
     "@balena/dockerignore",
@@ -101,7 +101,7 @@
     "terraconstructs"
   ],
   "engines": {
-    "node": ">=20.9.0"
+    "node": ">=22.12.0"
   },
   "devEngines": {
     "packageManager": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "organization": false
   },
   "devDependencies": {
-    "@aws-cdk/cloud-assembly-schema": "49.4.0",
+    "@aws-cdk/cloud-assembly-schema": "54.17.0",
     "@aws-cdk/region-info": "2.233.0",
     "@cdktn/provider-archive": "14.0.0",
     "@cdktn/provider-aws": "25.0.0",
@@ -71,7 +71,7 @@
     "typescript": "~5.9"
   },
   "peerDependencies": {
-    "@aws-cdk/cloud-assembly-schema": "^49.4.0",
+    "@aws-cdk/cloud-assembly-schema": "^54.17.0",
     "@aws-cdk/region-info": "^2.233.0",
     "@cdktn/provider-archive": "^14.0.0",
     "@cdktn/provider-aws": "^25.0.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
   },
   "dependencies": {
     "@balena/dockerignore": "^1.0.2",
-    "change-case": "^4.1.1",
+    "change-case": "^5.4.4",
     "ignore": "^5.3.2",
     "mime-types": "^2.1.35",
     "minimatch": "^10.2.6"
@@ -125,6 +125,24 @@
     ],
     "maxWorkers": "50%",
     "testEnvironment": "node",
+    "transformIgnorePatterns": [
+      "/node_modules/(?!change-case)"
+    ],
+    "transform": {
+      "^.+\\.[t]sx?$": [
+        "ts-jest",
+        {
+          "tsconfig": "test/tsconfig.json"
+        }
+      ],
+      "^.+\\.jsx?$": [
+        "ts-jest",
+        {
+          "tsconfig": "test/tsconfig.json",
+          "useESM": false
+        }
+      ]
+    },
     "testMatch": [
       "<rootDir>/@(src|test)/**/*(*.)@(spec|test).ts?(x)",
       "<rootDir>/@(src|test)/**/__tests__/**/*.ts?(x)",
@@ -158,15 +176,7 @@
           "outputDirectory": "test-reports"
         }
       ]
-    ],
-    "transform": {
-      "^.+\\.[t]sx?$": [
-        "ts-jest",
-        {
-          "tsconfig": "test/tsconfig.json"
-        }
-      ]
-    }
+    ]
   },
   "types": "lib/index.d.ts",
   "jsii": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,8 +25,8 @@ importers:
         version: 10.2.6
     devDependencies:
       '@aws-cdk/cloud-assembly-schema':
-        specifier: 49.4.0
-        version: 49.4.0
+        specifier: 54.17.0
+        version: 54.17.0
       '@aws-cdk/region-info':
         specifier: 2.233.0
         version: 2.233.0
@@ -135,8 +135,8 @@ importers:
 
 packages:
 
-  '@aws-cdk/cloud-assembly-schema@49.4.0':
-    resolution: {integrity: sha512-gZh5tHe5mtTuwWj92Hso2j1FKo7yYzRg72bKn2QfL3Nm6JRkATZKQ1uRlIR1VZcU/cN19YxeLF1Ud7ag72rbRg==}
+  '@aws-cdk/cloud-assembly-schema@54.17.0':
+    resolution: {integrity: sha512-wV1GmMM5AvDkiJIenb9aJcBiGTa5KwX/C/mIjFZCsWsB5b1rEMLnwMageqrOpL2mWKicpxqS8ofF/Yte4Lm3Dg==}
     engines: {node: '>= 18.0.0'}
     bundledDependencies:
       - jsonschema
@@ -3503,7 +3503,7 @@ packages:
 
 snapshots:
 
-  '@aws-cdk/cloud-assembly-schema@49.4.0': {}
+  '@aws-cdk/cloud-assembly-schema@54.17.0': {}
 
   '@aws-cdk/region-info@2.233.0': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^5.4.4
         version: 5.4.4
       ignore:
-        specifier: ^5.3.2
-        version: 5.3.2
+        specifier: ^7.0.6
+        version: 7.0.6
       mime-types:
         specifier: ^2.1.35
         version: 2.1.35
@@ -32,28 +32,28 @@ importers:
         version: 2.233.0
       '@cdktn/provider-archive':
         specifier: 14.0.0
-        version: 14.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)
+        version: 14.0.0(cdktn@0.24.0(constructs@10.7.2))(constructs@10.7.2)
       '@cdktn/provider-aws':
         specifier: 25.0.0
-        version: 25.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)
+        version: 25.0.0(cdktn@0.24.0(constructs@10.7.2))(constructs@10.7.2)
       '@cdktn/provider-cloudinit':
         specifier: 14.0.0
-        version: 14.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)
+        version: 14.0.0(cdktn@0.24.0(constructs@10.7.2))(constructs@10.7.2)
       '@cdktn/provider-docker':
         specifier: 16.0.0
-        version: 16.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)
+        version: 16.0.0(cdktn@0.24.0(constructs@10.7.2))(constructs@10.7.2)
       '@cdktn/provider-time':
         specifier: 14.0.0
-        version: 14.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)
+        version: 14.0.0(cdktn@0.24.0(constructs@10.7.2))(constructs@10.7.2)
       '@cdktn/provider-tls':
         specifier: 14.0.0
-        version: 14.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)
+        version: 14.0.0(cdktn@0.24.0(constructs@10.7.2))(constructs@10.7.2)
       '@jsii/spec':
         specifier: ^1.102.0
         version: 1.137.0
       '@mrgrain/jsii-struct-builder':
         specifier: ^0.7.64
-        version: 0.7.64(projen@0.100.7(constructs@10.7.0))
+        version: 0.7.64(projen@0.100.7(constructs@10.7.2))
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -71,13 +71,13 @@ importers:
         version: 8.62.0(eslint@9.39.4)(typescript@5.9.3)
       cdktn:
         specifier: 0.24.0
-        version: 0.24.0(constructs@10.7.0)
+        version: 0.24.0(constructs@10.7.2)
       commit-and-tag-version:
         specifier: ^12
         version: 12.7.3
       constructs:
-        specifier: 10.7.0
-        version: 10.7.0
+        specifier: 10.7.2
+        version: 10.7.2
       delay:
         specifier: ^5.0.0
         version: 5.0.0
@@ -122,7 +122,7 @@ importers:
         version: 3.3.3
       projen:
         specifier: ^0.100.7
-        version: 0.100.7(constructs@10.7.0)
+        version: 0.100.7(constructs@10.7.2)
       ts-jest:
         specifier: ^29.4.11
         version: 29.4.11(@babel/core@8.0.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.1))(jest-util@29.7.0)(jest@29.7.0(@types/node@26.2.0)(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3)))(typescript@5.9.3)
@@ -1209,8 +1209,8 @@ packages:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
     engines: {'0': node >= 6.0}
 
-  constructs@10.7.0:
-    resolution: {integrity: sha512-Vzwc30bMywc7DCzX8XOyuZbsBmfXTCrn6HHmhhELZK1J5dnUWwJ5uL7hBXGGq7xFPVOOO6cs9FwaxOshAxgcWQ==}
+  constructs@10.7.2:
+    resolution: {integrity: sha512-vA7JOqvO/xwq2HBCuq3qc6V2R9mHZCxJ8HPoucUcUWJY88YULe7bzMcsdBy27/gJJIphZi73U1oIXDY2Eqg6nA==}
 
   conventional-changelog-angular@6.0.0:
     resolution: {integrity: sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==}
@@ -1941,6 +1941,10 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  ignore@7.0.6:
+    resolution: {integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==}
+    engines: {node: '>= 4'}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -2533,10 +2537,6 @@ packages:
   min-indent@1.0.1:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
-
-  minimatch@10.2.5:
-    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
-    engines: {node: 18 || 20 || >=22}
 
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
@@ -3847,35 +3847,35 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@cdktn/provider-archive@14.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)':
+  '@cdktn/provider-archive@14.0.0(cdktn@0.24.0(constructs@10.7.2))(constructs@10.7.2)':
     dependencies:
-      cdktn: 0.24.0(constructs@10.7.0)
-      constructs: 10.7.0
+      cdktn: 0.24.0(constructs@10.7.2)
+      constructs: 10.7.2
 
-  '@cdktn/provider-aws@25.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)':
+  '@cdktn/provider-aws@25.0.0(cdktn@0.24.0(constructs@10.7.2))(constructs@10.7.2)':
     dependencies:
-      cdktn: 0.24.0(constructs@10.7.0)
-      constructs: 10.7.0
+      cdktn: 0.24.0(constructs@10.7.2)
+      constructs: 10.7.2
 
-  '@cdktn/provider-cloudinit@14.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)':
+  '@cdktn/provider-cloudinit@14.0.0(cdktn@0.24.0(constructs@10.7.2))(constructs@10.7.2)':
     dependencies:
-      cdktn: 0.24.0(constructs@10.7.0)
-      constructs: 10.7.0
+      cdktn: 0.24.0(constructs@10.7.2)
+      constructs: 10.7.2
 
-  '@cdktn/provider-docker@16.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)':
+  '@cdktn/provider-docker@16.0.0(cdktn@0.24.0(constructs@10.7.2))(constructs@10.7.2)':
     dependencies:
-      cdktn: 0.24.0(constructs@10.7.0)
-      constructs: 10.7.0
+      cdktn: 0.24.0(constructs@10.7.2)
+      constructs: 10.7.2
 
-  '@cdktn/provider-time@14.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)':
+  '@cdktn/provider-time@14.0.0(cdktn@0.24.0(constructs@10.7.2))(constructs@10.7.2)':
     dependencies:
-      cdktn: 0.24.0(constructs@10.7.0)
-      constructs: 10.7.0
+      cdktn: 0.24.0(constructs@10.7.2)
+      constructs: 10.7.2
 
-  '@cdktn/provider-tls@14.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)':
+  '@cdktn/provider-tls@14.0.0(cdktn@0.24.0(constructs@10.7.2))(constructs@10.7.2)':
     dependencies:
-      cdktn: 0.24.0(constructs@10.7.0)
-      constructs: 10.7.0
+      cdktn: 0.24.0(constructs@10.7.2)
+      constructs: 10.7.2
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -4179,10 +4179,10 @@ snapshots:
 
   '@jsii/spec@1.137.0': {}
 
-  '@mrgrain/jsii-struct-builder@0.7.64(projen@0.100.7(constructs@10.7.0))':
+  '@mrgrain/jsii-struct-builder@0.7.64(projen@0.100.7(constructs@10.7.2))':
     dependencies:
       '@jsii/spec': 1.137.0
-      projen: 0.100.7(constructs@10.7.0)
+      projen: 0.100.7(constructs@10.7.2)
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -4375,7 +4375,7 @@ snapshots:
       '@typescript-eslint/types': 8.62.0
       '@typescript-eslint/visitor-keys': 8.62.0
       debug: 4.4.3
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@5.9.3)
@@ -4761,9 +4761,9 @@ snapshots:
 
   case@1.6.3: {}
 
-  cdktn@0.24.0(constructs@10.7.0):
+  cdktn@0.24.0(constructs@10.7.2):
     dependencies:
-      constructs: 10.7.0
+      constructs: 10.7.2
 
   chalk@2.4.2:
     dependencies:
@@ -4858,7 +4858,7 @@ snapshots:
       readable-stream: 3.6.2
       typedarray: 0.0.6
 
-  constructs@10.7.0: {}
+  constructs@10.7.2: {}
 
   conventional-changelog-angular@6.0.0:
     dependencies:
@@ -5725,6 +5725,8 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  ignore@7.0.6: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -6577,10 +6579,6 @@ snapshots:
 
   min-indent@1.0.1: {}
 
-  minimatch@10.2.5:
-    dependencies:
-      brace-expansion: 5.0.9
-
   minimatch@10.2.6:
     dependencies:
       brace-expansion: 5.0.9
@@ -6805,9 +6803,9 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
-  projen@0.100.7(constructs@10.7.0):
+  projen@0.100.7(constructs@10.7.2):
     dependencies:
-      constructs: 10.7.0
+      constructs: 10.7.2
 
   prompts@2.4.2:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^2.1.35
         version: 2.1.35
       minimatch:
-        specifier: ^10.2.5
-        version: 10.2.5
+        specifier: ^10.2.6
+        version: 10.2.6
     devDependencies:
       '@aws-cdk/cloud-assembly-schema':
         specifier: 49.4.0
@@ -31,29 +31,29 @@ importers:
         specifier: 2.233.0
         version: 2.233.0
       '@cdktn/provider-archive':
-        specifier: 13.1.0
-        version: 13.1.0(cdktn@0.23.0(constructs@10.6.0))(constructs@10.6.0)
+        specifier: 14.0.0
+        version: 14.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)
       '@cdktn/provider-aws':
-        specifier: 24.8.0
-        version: 24.8.0(cdktn@0.23.0(constructs@10.6.0))(constructs@10.6.0)
+        specifier: 25.0.0
+        version: 25.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)
       '@cdktn/provider-cloudinit':
-        specifier: 13.1.0
-        version: 13.1.0(cdktn@0.23.0(constructs@10.6.0))(constructs@10.6.0)
+        specifier: 14.0.0
+        version: 14.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)
       '@cdktn/provider-docker':
-        specifier: 15.3.0
-        version: 15.3.0(cdktn@0.23.0(constructs@10.6.0))(constructs@10.6.0)
+        specifier: 16.0.0
+        version: 16.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)
       '@cdktn/provider-time':
-        specifier: 13.1.0
-        version: 13.1.0(cdktn@0.23.0(constructs@10.6.0))(constructs@10.6.0)
+        specifier: 14.0.0
+        version: 14.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)
       '@cdktn/provider-tls':
-        specifier: 13.1.0
-        version: 13.1.0(cdktn@0.23.0(constructs@10.6.0))(constructs@10.6.0)
+        specifier: 14.0.0
+        version: 14.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)
       '@jsii/spec':
         specifier: ^1.102.0
         version: 1.137.0
       '@mrgrain/jsii-struct-builder':
         specifier: ^0.7.64
-        version: 0.7.64(projen@0.100.7(constructs@10.6.0))
+        version: 0.7.64(projen@0.100.7(constructs@10.7.0))
       '@types/jest':
         specifier: ^29.5.14
         version: 29.5.14
@@ -62,7 +62,7 @@ importers:
         version: 2.1.4
       '@types/node':
         specifier: ts5.9
-        version: 26.1.1
+        version: 26.2.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8
         version: 8.62.0(@typescript-eslint/parser@8.62.0(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)
@@ -70,14 +70,14 @@ importers:
         specifier: ^8
         version: 8.62.0(eslint@9.39.4)(typescript@5.9.3)
       cdktn:
-        specifier: 0.23.0
-        version: 0.23.0(constructs@10.6.0)
+        specifier: 0.24.0
+        version: 0.24.0(constructs@10.7.0)
       commit-and-tag-version:
         specifier: ^12
         version: 12.7.3
       constructs:
-        specifier: 10.6.0
-        version: 10.6.0
+        specifier: 10.7.0
+        version: 10.7.0
       delay:
         specifier: ^5.0.0
         version: 5.0.0
@@ -101,7 +101,7 @@ importers:
         version: 3.23.2
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.9.3))
+        version: 29.7.0(@types/node@26.2.0)(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3))
       jest-junit:
         specifier: ^17
         version: 17.0.0
@@ -122,22 +122,18 @@ importers:
         version: 3.3.3
       projen:
         specifier: ^0.100.7
-        version: 0.100.7(constructs@10.6.0)
+        version: 0.100.7(constructs@10.7.0)
       ts-jest:
         specifier: ^29.4.11
-        version: 29.4.11(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest-util@29.7.0)(jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3)
+        version: 29.4.11(@babel/core@8.0.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.1))(jest-util@29.7.0)(jest@29.7.0(@types/node@26.2.0)(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3)))(typescript@5.9.3)
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@types/node@26.1.1)(typescript@5.9.3)
+        version: 10.9.2(@types/node@26.2.0)(typescript@5.9.3)
       typescript:
         specifier: ~5.9
         version: 5.9.3
 
 packages:
-
-  '@ampproject/remapping@2.3.0':
-    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
-    engines: {node: '>=6.0.0'}
 
   '@aws-cdk/cloud-assembly-schema@49.4.0':
     resolution: {integrity: sha512-gZh5tHe5mtTuwWj92Hso2j1FKo7yYzRg72bKn2QfL3Nm6JRkATZKQ1uRlIR1VZcU/cN19YxeLF1Ud7ag72rbRg==}
@@ -154,28 +150,64 @@ packages:
     resolution: {integrity: sha512-BcYH1CVJBO9tvyIZ2jVeXgSIMvGZ2FDRvDdOIVQyuklNKSsx+eppDEBq/g47Ayw+RqNFE+URvOShmf+f/qwAlA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/compat-data@7.25.2':
-    resolution: {integrity: sha512-bYcppcpKBvX4znYaPEeFau03bp89ShqNMLs+rmdptMw+heSZh9+z84d2YG+K7cYLbWwzdjtDoW/uqZmPjulClQ==}
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/core@7.25.2':
-    resolution: {integrity: sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==}
+  '@babel/code-frame@8.0.0':
+    resolution: {integrity: sha512-dYYg153EyN2Ekbqw2zAsbd6/JR+9N2SEoC7YV2GyyqMM7x9bLDTjBD6XBhSMLH0wtIVyJj03jWNriQhaN+eoCw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@8.0.0':
+    resolution: {integrity: sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@8.0.1':
+    resolution: {integrity: sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/generator@7.25.0':
     resolution: {integrity: sha512-3LEEcj3PVW8pW2R1SR1M89g/qrYk/m/mB/tLqn7dn4sbBUQyTqnlod+II2U4dqiGtUmkcnAmkMDralTFZttRiw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-compilation-targets@7.25.2':
-    resolution: {integrity: sha512-U2U5LsSaZ7TAt3cfaymQ8WHh0pxvdHoEk6HVpaexxixjyEquMh0L0YNJNM6CTGKMXV1iksi0iZkGw4AcFkPaaw==}
+  '@babel/generator@7.29.8':
+    resolution: {integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-imports@7.24.7':
-    resolution: {integrity: sha512-8AyH3C+74cgCVVXow/myrynrAGv+nTVg5vKu2nZph9x7RcRwzmh0VFallJuFTZ9mx6u4eSdXZfcOzSqTUm0HCA==}
+  '@babel/generator@8.0.0':
+    resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-module-transforms@7.25.2':
-    resolution: {integrity: sha512-BjyRAbix6j/wv83ftcVJmBt72QtHI56C7JXZoG2xATiLpmoC7dpd8WnkikExHDVPpi/3qCmO6WY1EaXOluiecQ==}
+  '@babel/helper-compilation-targets@8.0.0':
+    resolution: {integrity: sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@8.0.0':
+    resolution: {integrity: sha512-lLozHOM6sWWlxNo8CYqHy4MBZeTvHXNgVPBfPOGsjPKUzHC2Az9QwB6gxdQmpwHl6GlQtbGgS+lj5887guDiLw==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -184,25 +216,45 @@ packages:
     resolution: {integrity: sha512-FFWx5142D8h2Mgr/iPVGH5G7w6jDn4jUSpZTyDnQO0Yn7Ks2Kuz6Pci8H6MPCoUJegd/UZQ3tAvfLCxQSnWWwg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-simple-access@7.24.7':
-    resolution: {integrity: sha512-zBAIvbCMh5Ts+b86r/CjU+4XGYIs+R1j951gxI3KmmxBMhCg4oQMsv6ZXQ64XOm/cvzfU1FmoCyt6+owc5QMYg==}
-    engines: {node: '>=6.9.0'}
-
   '@babel/helper-string-parser@7.24.8':
     resolution: {integrity: sha512-pO9KhhRcuUyGnJWwyEgnRJTSIZHiT+vMD0kPeD+so0l7mxkMT19g3pjY9GTnHySck/hDzq+dtW/4VgnMkippsQ==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@8.0.0':
+    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-identifier@7.24.7':
     resolution: {integrity: sha512-rR+PBcQ1SMQDDyF6X0wxtG8QyLCgUB0eRAGguqRLfkCA87l7yAP7ehq8SNj96OOGTO8OBV70KhuFYcIkHXOg0w==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-option@7.24.8':
-    resolution: {integrity: sha512-xb8t9tD1MHLungh/AIoWYN+gVHaB9kwlu8gffXGSt3FFEIT7RjS+xWbc2vUD1UTZdIpKj/ab3rdqJ7ufngyi2Q==}
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helpers@7.25.0':
-    resolution: {integrity: sha512-MjgLZ42aCm0oGjJj8CtSM3DB8NOOf8h2l7DCTePJs29u+v7yO/RBX9nShlKMgFnRks/Q4tBAe7Hxnov9VkGwLw==}
+  '@babel/helper-validator-identifier@8.0.4':
+    resolution: {integrity: sha512-4wFaiLd0bVo4cIoTXI3zKI038NIWE/cr3jvBjejOVYVxV/m8Ltav1USiGzG1fmS5J2RhgEOgXNNK46cRPnRsrg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@8.0.0':
+    resolution: {integrity: sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@8.0.0':
+    resolution: {integrity: sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/highlight@7.24.7':
     resolution: {integrity: sha512-EStJpq4OuY8xYfhGVXngigBJRWxftKX9ksiGDnmlY3o7B/V7KIAc9X4oiK87uPJSc/vs5L869bem5fhZa8caZw==}
@@ -211,6 +263,16 @@ packages:
   '@babel/parser@7.25.3':
     resolution: {integrity: sha512-iLTJKDbJ4hMvFPgQwwsVoxtHyWpKKPBrxkANrSYewDPaPpT5py5yeVkgPIJ7XYXhndxJpaA3PyALSXQ7u8e/Dw==}
     engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.8':
+    resolution: {integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@8.0.4':
+    resolution: {integrity: sha512-srpptsAkEbbNIC/q8nT7o+m6CQe8CJUTV/t7MYc9NnWlgYVtHOb7JH6SorxMhN0kuRJjVqXbKClG6xSbPtzz+g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
   '@babel/plugin-syntax-async-generators@7.8.4':
@@ -290,13 +352,33 @@ packages:
     resolution: {integrity: sha512-aOOgh1/5XzKvg1jvVz7AVrx2piJ2XBi227DHmbY6y+bM9H2FlN+IfecYu4Xl0cNiiVejlsCri89LUsbj8vJD9Q==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/traverse@7.25.3':
-    resolution: {integrity: sha512-HefgyP1x754oGCsKmV5reSmtV7IXj/kpaE1XYY+D9G5PvKKoFfSbiS4M77MdjuwlZKDIKFCffq9rPU+H/s3ZdQ==}
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/template@8.0.0':
+    resolution: {integrity: sha512-eAD0QW/AlbamBbw0FeGiwasbCVPq5ncW0HNVyLP3B9czqLyh4gvw+5JTSNt6le9+ziAU7mqDZsKTHf3jTb4chQ==}
+    engines: {node: ^22.18.0 || >=24.11.0}
+
+  '@babel/traverse@7.29.8':
+    resolution: {integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@8.0.4':
+    resolution: {integrity: sha512-bZnmqzGG8UZneG1lLxBoWIH0G6Gr1D846Yu4/3XnY6FhCndMR49u26nTY08u/dAxWmLWF9vGQOuC+84FfIUoeg==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/types@7.25.2':
     resolution: {integrity: sha512-YTnYtra7W9e6/oAZEHj0bJehPRUlLH9/fbpT5LfB0NhQXyALCRkRs3zH9v07IYhkgpqX6Z78FnuccZr/l4Fs4Q==}
     engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.8':
+    resolution: {integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@8.0.4':
+    resolution: {integrity: sha512-eY+Yn3dCqTGmyiq2QRU66lA5FL8lqqqvecHt0fF3uHONIa7ToYsaCiWV8lOKqAs0Rb2SjixiKFROngnulPtt2g==}
+    engines: {node: ^22.18.0 || >=24.11.0}
 
   '@balena/dockerignore@1.0.2':
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
@@ -304,47 +386,47 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  '@cdktn/provider-archive@13.1.0':
-    resolution: {integrity: sha512-O7KBThxvpgaBVI2czF+CptCbkxhYT/XpNS/FjSQTEMRj1RaOyARHJM/0IQ75KpPsiZh5LmAz4AGm+7K0J6x4xw==}
-    engines: {node: '>= 20.16.0'}
+  '@cdktn/provider-archive@14.0.0':
+    resolution: {integrity: sha512-aa/iRWT5DJXKofPjrFsU1Q4xYhVLRctrkEl7FPYjXFWEchi+hNkuHBLmbElq6Eb7/5O/+4p801Hh4kCk6opXXw==}
+    engines: {node: '>= 22.11.0'}
     peerDependencies:
-      cdktn: ^0.23.0
-      constructs: ^10.6.0
+      cdktn: ^0.24.0
+      constructs: '>=10.6.0 <10.8.0'
 
-  '@cdktn/provider-aws@24.8.0':
-    resolution: {integrity: sha512-UI7qJhjkE5VQB6WacXentpOg5mKWv2RbbCNZCMR28Tww35gT8nr7zG9WhFCBebQ0+l1nnLgOd/KRYMJ6puIBSw==}
-    engines: {node: '>= 20.16.0'}
+  '@cdktn/provider-aws@25.0.0':
+    resolution: {integrity: sha512-9ogmOmVW2sN1BvTWgBN0JuMyMBlrc0ATKQ1LwWNI+q1H/hYbhyTXfKXYNbyXaBpRSlWVmKEGIq4kkAUlJG3i3w==}
+    engines: {node: '>= 22.11.0'}
     peerDependencies:
-      cdktn: ^0.23.0
-      constructs: ^10.6.0
+      cdktn: ^0.24.0
+      constructs: '>=10.6.0 <10.8.0'
 
-  '@cdktn/provider-cloudinit@13.1.0':
-    resolution: {integrity: sha512-4iHiBpVTU3SGgSNwGGL58DgGFMdWEPPjvXFG58np1H8yna1v4iCEYrZu8vVcGzQYZa8GfGCfyD+vNPZTcP/zJg==}
-    engines: {node: '>= 20.16.0'}
+  '@cdktn/provider-cloudinit@14.0.0':
+    resolution: {integrity: sha512-ma0uiAEYyN6lKeMTuHAZa3CjC0XwYaf6qWI0gDdGKqWohzs/rOo2u+09yVwcWDuWazifmS7ZMbWWBQPfSlbNzA==}
+    engines: {node: '>= 22.11.0'}
     peerDependencies:
-      cdktn: ^0.23.0
-      constructs: ^10.6.0
+      cdktn: ^0.24.0
+      constructs: '>=10.6.0 <10.8.0'
 
-  '@cdktn/provider-docker@15.3.0':
-    resolution: {integrity: sha512-jqGVPoq732zBExGhEVWO41mDU3OL5TXs1eq5OgRrPs3XoyceU7tHZ/EfkfgwI9rM+fCozs2Cq7U8uMBPHxym1A==}
-    engines: {node: '>= 20.16.0'}
+  '@cdktn/provider-docker@16.0.0':
+    resolution: {integrity: sha512-g3kbAPXmaS/gGpnH3PuMFjQkliyl5T7iAcN9p6Svx1gSmJyvgZ7HILtn6AZdgBWwDZsp9uGk3GBjmMp/CjHTuw==}
+    engines: {node: '>= 22.11.0'}
     peerDependencies:
-      cdktn: ^0.23.0
-      constructs: ^10.6.0
+      cdktn: ^0.24.0
+      constructs: '>=10.6.0 <10.8.0'
 
-  '@cdktn/provider-time@13.1.0':
-    resolution: {integrity: sha512-wQ6RbjAewq+qBdPp8o88uT3YQvBoQPeQP1RxXU2njrU8mYbutzZ719kMbrzjuOQ82X6jsXY6VtFxqgqhQvYD2A==}
-    engines: {node: '>= 20.16.0'}
+  '@cdktn/provider-time@14.0.0':
+    resolution: {integrity: sha512-vOgDaEiwOGOXJS2LPU8MwDG6ZP3os4awIYYXeeFYCx6gPRkLlycqq65I+e/ATrJy126UBOsDb+UvmUC+ZnmISw==}
+    engines: {node: '>= 22.11.0'}
     peerDependencies:
-      cdktn: ^0.23.0
-      constructs: ^10.6.0
+      cdktn: ^0.24.0
+      constructs: '>=10.6.0 <10.8.0'
 
-  '@cdktn/provider-tls@13.1.0':
-    resolution: {integrity: sha512-OBDHuomHad4yl+OLhrbvtZJnOLmiIZTPG1E5chLAYQWPgR9anPasYmnCoEskfpdfD5G2Wc6djK68ltBmoee8wg==}
-    engines: {node: '>= 20.16.0'}
+  '@cdktn/provider-tls@14.0.0':
+    resolution: {integrity: sha512-uDuRiVyvedauSF7VCEzZ8BpIizRFzYvUE3TQTkyg/0B9Od9BoUh7+QDS8q14oXHxSTGfW+ShF3Iw5kcGFYxUEw==}
+    engines: {node: '>= 22.11.0'}
     peerDependencies:
-      cdktn: ^0.23.0
-      constructs: ^10.6.0
+      cdktn: ^0.24.0
+      constructs: '>=10.6.0 <10.8.0'
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -491,9 +573,15 @@ packages:
     resolution: {integrity: sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
   '@jridgewell/gen-mapping@0.3.5':
     resolution: {integrity: sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==}
     engines: {node: '>=6.0.0'}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
 
   '@jridgewell/resolve-uri@3.1.2':
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
@@ -508,6 +596,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
@@ -537,8 +628,8 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@nodable/entities@2.2.0':
-    resolution: {integrity: sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==}
+  '@nodable/entities@3.0.0':
+    resolution: {integrity: sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -602,6 +693,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/gensync@1.0.5':
+    resolution: {integrity: sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==}
+
   '@types/graceful-fs@4.1.9':
     resolution: {integrity: sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==}
 
@@ -617,6 +711,9 @@ packages:
   '@types/jest@29.5.14':
     resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
 
+  '@types/jsesc@2.5.1':
+    resolution: {integrity: sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -629,11 +726,11 @@ packages:
   '@types/minimist@1.2.5':
     resolution: {integrity: sha512-hov8bUuiLiyFPGyFPE1lwWhmzYbirOXQNNo40+y3zow8aFVTeyn3VWL0VFFfdNddA8S4Vf0Tc062rzyNr7Paag==}
 
-  '@types/node@26.0.1':
-    resolution: {integrity: sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==}
-
   '@types/node@26.1.1':
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
+
+  '@types/node@26.2.0':
+    resolution: {integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
@@ -957,19 +1054,24 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
+  baseline-browser-mapping@2.11.13:
+    resolution: {integrity: sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
     engines: {node: '>=8'}
 
-  browserslist@4.23.3:
-    resolution: {integrity: sha512-btwCFJVjI4YWDNfau8RhZ+B1Q/VLoUITrm3RlP6y1tYGWIOa+InuYiRGXUBXo8nA1qKmHMyLB/iVQg5TT4eFoA==}
+  browserslist@4.28.8:
+    resolution: {integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
@@ -1018,8 +1120,8 @@ packages:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
 
-  caniuse-lite@1.0.30001651:
-    resolution: {integrity: sha512-9Cf+Xv1jJNe1xPZLGuUXLNkE1BoDkqRqYyFJ9TDYSqhduqA4hu4oR9HluGoWYQC/aj8WHjsGVV+bwkh0+tegRg==}
+  caniuse-lite@1.0.30001809:
+    resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
 
   capital-case@1.0.4:
     resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
@@ -1028,14 +1130,14 @@ packages:
     resolution: {integrity: sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==}
     engines: {node: '>= 0.8.0'}
 
-  cdktn@0.23.0:
-    resolution: {integrity: sha512-TF9sTWHOMb8O9tB/qSkIhspoPZ7QMEcoov5o3SIhGjEh6GdBB25R0ByHRKKEIwRqSXhMMlGqrocZLU+0Yt2QOg==}
+  cdktn@0.24.0:
+    resolution: {integrity: sha512-Ok7kYlM2BWyXebnQi4Se9JPsjsRZKoVtkyshkVEkhHY/fGWonMvdWvivXmdB6caBGcQ8cwioQOZXKkps+dCnZg==}
     peerDependencies:
-      constructs: ^10.6.0
+      constructs: '>=10.6.0 <10.8.0'
     bundledDependencies:
-      - json-stable-stringify
+      - fflate
+      - safe-stable-stringify
       - semver
-      - yazl
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -1116,8 +1218,8 @@ packages:
   constant-case@3.0.4:
     resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
 
-  constructs@10.6.0:
-    resolution: {integrity: sha512-TxHOnBO5zMo/G76ykzGF/wMpEHu257TbWiIxP9K0Yv/+t70UzgBQiTqjkAsWOPC6jW91DzJI0+ehQV6xDRNBuQ==}
+  constructs@10.7.0:
+    resolution: {integrity: sha512-Vzwc30bMywc7DCzX8XOyuZbsBmfXTCrn6HHmhhELZK1J5dnUWwJ5uL7hBXGGq7xFPVOOO6cs9FwaxOshAxgcWQ==}
 
   conventional-changelog-angular@6.0.0:
     resolution: {integrity: sha512-6qLgrBF4gueoC7AFVHu51nHL9pF9FRjXrH+ceVf7WmAfH3gs+gEYOkvxhjMPjZu57I4AGUGoNTY8V7Hrgf1uqg==}
@@ -1326,8 +1428,8 @@ packages:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
 
-  diff@4.0.2:
-    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+  diff@4.0.4:
+    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
 
   doctrine@2.1.0:
@@ -1349,8 +1451,8 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
-  electron-to-chromium@1.5.6:
-    resolution: {integrity: sha512-jwXWsM5RPf6j9dPYzaorcBSUg6AiqocPEyMpkchkvntaH9HGfOOMZwxMJjDY/XEs3T5dM7uyH1VhRMkqUU9qVw==}
+  electron-to-chromium@1.5.403:
+    resolution: {integrity: sha512-MQsYmdaLzvaCX5j+ZZBr5Fm6uCCnPQcRtlvmvRlWqrXy+BH2O4ffXIAScF+JQznQWB9brWp4lSD9Z4yNmaf2BA==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -1358,6 +1460,10 @@ packages:
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  empathic@2.0.1:
+    resolution: {integrity: sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==}
+    engines: {node: '>=14'}
 
   entities@3.0.1:
     resolution: {integrity: sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==}
@@ -1590,8 +1696,8 @@ packages:
   fast-xml-builder@1.2.0:
     resolution: {integrity: sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==}
 
-  fast-xml-parser@5.9.3:
-    resolution: {integrity: sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==}
+  fast-xml-parser@5.10.1:
+    resolution: {integrity: sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==}
     hasBin: true
 
   fastq@1.17.1:
@@ -1641,8 +1747,8 @@ packages:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
     engines: {node: '>=16'}
 
-  flatted@3.3.1:
-    resolution: {integrity: sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==}
+  flatted@3.4.4:
+    resolution: {integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==}
 
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
@@ -1760,10 +1866,6 @@ packages:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
-  globals@11.12.0:
-    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
-    engines: {node: '>=4'}
-
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
@@ -1862,6 +1964,9 @@ packages:
     resolution: {integrity: sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==}
     engines: {node: '>=8'}
     hasBin: true
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -2050,8 +2155,8 @@ packages:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
-  is-unsafe@1.0.1:
-    resolution: {integrity: sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==}
+  is-unsafe@2.0.0:
+    resolution: {integrity: sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==}
 
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
@@ -2234,20 +2339,28 @@ packages:
       node-notifier:
         optional: true
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@3.15.1:
+    resolution: {integrity: sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
     hasBin: true
 
   jsii-diff@1.137.0:
@@ -2372,6 +2485,10 @@ packages:
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -2415,10 +2532,6 @@ packages:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
 
-  micromatch@4.0.7:
-    resolution: {integrity: sha512-LPP/3KorzCwBxfeUuZmaR6bG2kdeHSbe0P2tY3FLRU4vYrjYz5hI4QZwV0njUx3jeuKe67YukQ1LSPZBKDqO/Q==}
-    engines: {node: '>=8.6'}
-
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
@@ -2441,6 +2554,10 @@ packages:
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimatch@10.2.6:
+    resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
     engines: {node: 18 || 20 || >=22}
 
   minimatch@3.1.5:
@@ -2482,8 +2599,9 @@ packages:
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
 
-  node-releases@2.0.18:
-    resolution: {integrity: sha512-d9VeXT4SJ7ZeOqGX6R5EM022wpL+eWPooLI+5UpWn2jCT1aosUQEhQP214x33Wkwx3JQMvIm+tIoVOdodFS40g==}
+  node-releases@2.0.53:
+    resolution: {integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==}
+    engines: {node: '>=18'}
 
   normalize-package-data@2.5.0:
     resolution: {integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==}
@@ -2531,6 +2649,10 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -2620,6 +2742,10 @@ packages:
     resolution: {integrity: sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==}
     engines: {node: '>=14.0.0'}
 
+  path-expression-matcher@1.6.2:
+    resolution: {integrity: sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==}
+    engines: {node: '>=14.0.0'}
+
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
@@ -2638,20 +2764,15 @@ packages:
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
 
-  picomatch@2.3.1:
-    resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
-    engines: {node: '>=8.6'}
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
   picomatch@2.3.2:
     resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
     engines: {node: '>=8.6'}
 
-  picomatch@4.0.3:
-    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
-    engines: {node: '>=12'}
-
-  picomatch@4.0.4:
-    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
   pify@2.3.0:
@@ -3234,8 +3355,8 @@ packages:
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
-  update-browserslist-db@1.1.0:
-    resolution: {integrity: sha512-EdRAaAyk2cUE1wOf2DkEhzxqOQvFOoRJFNS6NeyJ01Gp2beMRpBAINjM2iDXE3KCuKhwnvHIQCJm6ThL2Z+HzQ==}
+  update-browserslist-db@1.3.0:
+    resolution: {integrity: sha512-x/M6q3w4Ybp91CNaS4S69UnliqR3BzRpOT6LWbksjth0S/+jhfaPJsWjt/TewpT8j9eLIojUf5jr29WextHroA==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
@@ -3322,6 +3443,10 @@ packages:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
     engines: {node: '>=16.0.0'}
 
+  xml-naming@0.3.0:
+    resolution: {integrity: sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==}
+    engines: {node: '>=16.0.0'}
+
   xml@1.0.1:
     resolution: {integrity: sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==}
 
@@ -3343,8 +3468,8 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
-  yaml@2.8.2:
-    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -3378,11 +3503,6 @@ packages:
 
 snapshots:
 
-  '@ampproject/remapping@2.3.0':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.5
-      '@jridgewell/trace-mapping': 0.3.25
-
   '@aws-cdk/cloud-assembly-schema@49.4.0': {}
 
   '@aws-cdk/region-info@2.233.0': {}
@@ -3392,20 +3512,35 @@ snapshots:
       '@babel/highlight': 7.24.7
       picocolors: 1.0.1
 
-  '@babel/compat-data@7.25.2': {}
-
-  '@babel/core@7.25.2':
+  '@babel/code-frame@7.29.7':
     dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.25.0
-      '@babel/helper-compilation-targets': 7.25.2
-      '@babel/helper-module-transforms': 7.25.2(@babel/core@7.25.2)
-      '@babel/helpers': 7.25.0
-      '@babel/parser': 7.25.3
-      '@babel/template': 7.25.0
-      '@babel/traverse': 7.25.3
-      '@babel/types': 7.25.2
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/code-frame@8.0.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 8.0.4
+      js-tokens: 10.0.0
+    optional: true
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/compat-data@8.0.0':
+    optional: true
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
       debug: 4.4.3
       gensync: 1.0.0-beta.2
@@ -3414,6 +3549,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/core@8.0.1':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/generator': 8.0.0
+      '@babel/helper-compilation-targets': 8.0.0
+      '@babel/helpers': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/template': 8.0.0
+      '@babel/traverse': 8.0.4
+      '@babel/types': 8.0.4
+      '@types/gensync': 1.0.5
+      convert-source-map: 2.0.0
+      empathic: 2.0.1
+      gensync: 1.0.0-beta.2
+      import-meta-resolve: 4.2.0
+      json5: 2.2.3
+      obug: 2.1.4
+      semver: 7.8.5
+    optional: true
+
   '@babel/generator@7.25.0':
     dependencies:
       '@babel/types': 7.25.2
@@ -3421,50 +3576,93 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.25
       jsesc: 2.5.2
 
-  '@babel/helper-compilation-targets@7.25.2':
+  '@babel/generator@7.29.8':
     dependencies:
-      '@babel/compat-data': 7.25.2
-      '@babel/helper-validator-option': 7.24.8
-      browserslist: 4.23.3
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/generator@8.0.0':
+    dependencies:
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@types/jsesc': 2.5.1
+      jsesc: 3.1.0
+    optional: true
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.8
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  '@babel/helper-module-imports@7.24.7':
+  '@babel/helper-compilation-targets@8.0.0':
     dependencies:
-      '@babel/traverse': 7.25.3
-      '@babel/types': 7.25.2
+      '@babel/compat-data': 8.0.0
+      '@babel/helper-validator-option': 8.0.0
+      browserslist: 4.28.8
+      lru-cache: 11.5.2
+      semver: 7.8.5
+    optional: true
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-globals@8.0.0':
+    optional: true
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.8
+      '@babel/types': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/helper-module-transforms@7.25.2(@babel/core@7.25.2)':
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.25.2
-      '@babel/helper-module-imports': 7.24.7
-      '@babel/helper-simple-access': 7.24.7
-      '@babel/helper-validator-identifier': 7.24.7
-      '@babel/traverse': 7.25.3
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.8
     transitivePeerDependencies:
       - supports-color
 
   '@babel/helper-plugin-utils@7.24.8': {}
 
-  '@babel/helper-simple-access@7.24.7':
-    dependencies:
-      '@babel/traverse': 7.25.3
-      '@babel/types': 7.25.2
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-string-parser@7.24.8': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-string-parser@8.0.0':
+    optional: true
 
   '@babel/helper-validator-identifier@7.24.7': {}
 
-  '@babel/helper-validator-option@7.24.8': {}
+  '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/helpers@7.25.0':
+  '@babel/helper-validator-identifier@8.0.4':
+    optional: true
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helper-validator-option@8.0.0':
+    optional: true
+
+  '@babel/helpers@7.29.7':
     dependencies:
-      '@babel/template': 7.25.0
-      '@babel/types': 7.25.2
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
+
+  '@babel/helpers@8.0.0':
+    dependencies:
+      '@babel/template': 8.0.0
+      '@babel/types': 8.0.4
+    optional: true
 
   '@babel/highlight@7.24.7':
     dependencies:
@@ -3477,74 +3675,155 @@ snapshots:
     dependencies:
       '@babel/types': 7.25.2
 
-  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.25.2)':
+  '@babel/parser@7.29.8':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/types': 7.29.8
+
+  '@babel/parser@8.0.4':
+    dependencies:
+      '@babel/types': 8.0.4
+    optional: true
+
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-async-generators@7.8.4(@babel/core@8.0.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.24.8
+    optional: true
+
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-bigint@7.8.3(@babel/core@8.0.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.24.8
+    optional: true
+
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-class-properties@7.12.13(@babel/core@8.0.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.24.8
+    optional: true
+
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@8.0.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.24.8
+    optional: true
+
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-json-strings@7.8.3(@babel/core@8.0.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.24.8
+    optional: true
+
+  '@babel/plugin-syntax-jsx@7.24.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@8.0.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.24.8
+    optional: true
+
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@8.0.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.24.8
+    optional: true
+
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@8.0.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.24.8
+    optional: true
+
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@8.0.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.24.8
+    optional: true
+
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@8.0.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.24.8
+    optional: true
+
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@8.0.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.24.8
+    optional: true
+
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.24.8
 
-  '@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.25.2)':
+  '@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@8.0.1)':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 8.0.1
+      '@babel/helper-plugin-utils': 7.24.8
+    optional: true
+
+  '@babel/plugin-syntax-typescript@7.24.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.24.8
 
   '@babel/template@7.25.0':
@@ -3553,17 +3832,41 @@ snapshots:
       '@babel/parser': 7.25.3
       '@babel/types': 7.25.2
 
-  '@babel/traverse@7.25.3':
+  '@babel/template@7.29.7':
     dependencies:
-      '@babel/code-frame': 7.24.7
-      '@babel/generator': 7.25.0
-      '@babel/parser': 7.25.3
-      '@babel/template': 7.25.0
-      '@babel/types': 7.25.2
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/types': 7.29.8
+
+  '@babel/template@8.0.0':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/types': 8.0.4
+    optional: true
+
+  '@babel/traverse@7.29.8':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.8
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.8
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.8
       debug: 4.4.3
-      globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+
+  '@babel/traverse@8.0.4':
+    dependencies:
+      '@babel/code-frame': 8.0.0
+      '@babel/generator': 8.0.0
+      '@babel/helper-globals': 8.0.0
+      '@babel/parser': 8.0.4
+      '@babel/template': 8.0.0
+      '@babel/types': 8.0.4
+      obug: 2.1.4
+    optional: true
 
   '@babel/types@7.25.2':
     dependencies:
@@ -3571,39 +3874,50 @@ snapshots:
       '@babel/helper-validator-identifier': 7.24.7
       to-fast-properties: 2.0.0
 
+  '@babel/types@7.29.8':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@babel/types@8.0.4':
+    dependencies:
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.4
+    optional: true
+
   '@balena/dockerignore@1.0.2': {}
 
   '@bcoe/v8-coverage@0.2.3': {}
 
-  '@cdktn/provider-archive@13.1.0(cdktn@0.23.0(constructs@10.6.0))(constructs@10.6.0)':
+  '@cdktn/provider-archive@14.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)':
     dependencies:
-      cdktn: 0.23.0(constructs@10.6.0)
-      constructs: 10.6.0
+      cdktn: 0.24.0(constructs@10.7.0)
+      constructs: 10.7.0
 
-  '@cdktn/provider-aws@24.8.0(cdktn@0.23.0(constructs@10.6.0))(constructs@10.6.0)':
+  '@cdktn/provider-aws@25.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)':
     dependencies:
-      cdktn: 0.23.0(constructs@10.6.0)
-      constructs: 10.6.0
+      cdktn: 0.24.0(constructs@10.7.0)
+      constructs: 10.7.0
 
-  '@cdktn/provider-cloudinit@13.1.0(cdktn@0.23.0(constructs@10.6.0))(constructs@10.6.0)':
+  '@cdktn/provider-cloudinit@14.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)':
     dependencies:
-      cdktn: 0.23.0(constructs@10.6.0)
-      constructs: 10.6.0
+      cdktn: 0.24.0(constructs@10.7.0)
+      constructs: 10.7.0
 
-  '@cdktn/provider-docker@15.3.0(cdktn@0.23.0(constructs@10.6.0))(constructs@10.6.0)':
+  '@cdktn/provider-docker@16.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)':
     dependencies:
-      cdktn: 0.23.0(constructs@10.6.0)
-      constructs: 10.6.0
+      cdktn: 0.24.0(constructs@10.7.0)
+      constructs: 10.7.0
 
-  '@cdktn/provider-time@13.1.0(cdktn@0.23.0(constructs@10.6.0))(constructs@10.6.0)':
+  '@cdktn/provider-time@14.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)':
     dependencies:
-      cdktn: 0.23.0(constructs@10.6.0)
-      constructs: 10.6.0
+      cdktn: 0.24.0(constructs@10.7.0)
+      constructs: 10.7.0
 
-  '@cdktn/provider-tls@13.1.0(cdktn@0.23.0(constructs@10.6.0))(constructs@10.6.0)':
+  '@cdktn/provider-tls@14.0.0(cdktn@0.24.0(constructs@10.7.0))(constructs@10.7.0)':
     dependencies:
-      cdktn: 0.23.0(constructs@10.6.0)
-      constructs: 10.6.0
+      cdktn: 0.24.0(constructs@10.7.0)
+      constructs: 10.7.0
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -3656,7 +3970,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.5
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -3689,7 +4003,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.15.0
+      js-yaml: 3.15.1
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -3697,27 +4011,27 @@ snapshots:
   '@jest/console@29.7.0':
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       chalk: 4.1.2
       jest-message-util: 29.7.0
       jest-util: 29.7.0
       slash: 3.0.0
 
-  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.9.3))':
+  '@jest/core@29.7.0(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3))':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 3.9.0
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@26.0.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3))
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -3729,7 +4043,7 @@ snapshots:
       jest-util: 29.7.0
       jest-validate: 29.7.0
       jest-watcher: 29.7.0
-      micromatch: 4.0.7
+      micromatch: 4.0.8
       pretty-format: 29.7.0
       slash: 3.0.0
       strip-ansi: 6.0.1
@@ -3742,7 +4056,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -3760,7 +4074,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -3782,7 +4096,7 @@ snapshots:
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       chalk: 4.1.2
       collect-v8-coverage: 1.0.2
       exit: 0.1.2
@@ -3829,7 +4143,7 @@ snapshots:
 
   '@jest/transform@29.7.0':
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.29.7
       '@jest/types': 29.6.3
       '@jridgewell/trace-mapping': 0.3.25
       babel-plugin-istanbul: 6.1.1
@@ -3852,15 +4166,25 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       '@types/yargs': 17.0.33
       chalk: 4.1.2
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.0
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/gen-mapping@0.3.5':
     dependencies:
       '@jridgewell/set-array': 1.2.1
       '@jridgewell/sourcemap-codec': 1.5.0
       '@jridgewell/trace-mapping': 0.3.25
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/resolve-uri@3.1.2': {}
 
@@ -3869,6 +4193,11 @@ snapshots:
   '@jridgewell/sourcemap-codec@1.5.0': {}
 
   '@jridgewell/trace-mapping@0.3.25':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -3892,10 +4221,10 @@ snapshots:
 
   '@jsii/spec@1.137.0': {}
 
-  '@mrgrain/jsii-struct-builder@0.7.64(projen@0.100.7(constructs@10.6.0))':
+  '@mrgrain/jsii-struct-builder@0.7.64(projen@0.100.7(constructs@10.7.0))':
     dependencies:
       '@jsii/spec': 1.137.0
-      projen: 0.100.7(constructs@10.6.0)
+      projen: 0.100.7(constructs@10.7.0)
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -3904,7 +4233,7 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@nodable/entities@2.2.0': {}
+  '@nodable/entities@3.0.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -3970,9 +4299,12 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/gensync@1.0.5':
+    optional: true
+
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
 
   '@types/istanbul-lib-coverage@2.0.6': {}
 
@@ -3989,6 +4321,9 @@ snapshots:
       expect: 29.7.0
       pretty-format: 29.7.0
 
+  '@types/jsesc@2.5.1':
+    optional: true
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -3997,11 +4332,11 @@ snapshots:
 
   '@types/minimist@1.2.5': {}
 
-  '@types/node@26.0.1':
+  '@types/node@26.1.1':
     dependencies:
       undici-types: 8.3.0
 
-  '@types/node@26.1.1':
+  '@types/node@26.2.0':
     dependencies:
       undici-types: 8.3.0
 
@@ -4300,18 +4635,32 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
-  babel-jest@29.7.0(@babel/core@7.25.2):
+  babel-jest@29.7.0(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.29.7
       '@jest/transform': 29.7.0
       '@types/babel__core': 7.20.5
       babel-plugin-istanbul: 6.1.1
-      babel-preset-jest: 29.6.3(@babel/core@7.25.2)
+      babel-preset-jest: 29.6.3(@babel/core@7.29.7)
       chalk: 4.1.2
       graceful-fs: 4.2.11
       slash: 3.0.0
     transitivePeerDependencies:
       - supports-color
+
+  babel-jest@29.7.0(@babel/core@8.0.1):
+    dependencies:
+      '@babel/core': 8.0.1
+      '@jest/transform': 29.7.0
+      '@types/babel__core': 7.20.5
+      babel-plugin-istanbul: 6.1.1
+      babel-preset-jest: 29.6.3(@babel/core@8.0.1)
+      chalk: 4.1.2
+      graceful-fs: 4.2.11
+      slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+    optional: true
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
@@ -4330,38 +4679,64 @@ snapshots:
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.6
 
-  babel-preset-current-node-syntax@1.0.1(@babel/core@7.25.2):
+  babel-preset-current-node-syntax@1.0.1(@babel/core@7.29.7):
     dependencies:
-      '@babel/core': 7.25.2
-      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.25.2)
-      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.25.2)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.25.2)
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.25.2)
-      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.25.2)
-      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.25.2)
-      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.25.2)
-      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.25.2)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.25.2)
-      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.25.2)
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.25.2)
-      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.25.2)
+      '@babel/core': 7.29.7
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.29.7)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.29.7)
 
-  babel-preset-jest@29.6.3(@babel/core@7.25.2):
+  babel-preset-current-node-syntax@1.0.1(@babel/core@8.0.1):
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 8.0.1
+      '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@8.0.1)
+      '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@8.0.1)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@8.0.1)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@8.0.1)
+      '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@8.0.1)
+      '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@8.0.1)
+      '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@8.0.1)
+      '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@8.0.1)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@8.0.1)
+      '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@8.0.1)
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@8.0.1)
+      '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@8.0.1)
+    optional: true
+
+  babel-preset-jest@29.6.3(@babel/core@7.29.7):
+    dependencies:
+      '@babel/core': 7.29.7
       babel-plugin-jest-hoist: 29.6.3
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.25.2)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.29.7)
+
+  babel-preset-jest@29.6.3(@babel/core@8.0.1):
+    dependencies:
+      '@babel/core': 8.0.1
+      babel-plugin-jest-hoist: 29.6.3
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@8.0.1)
+    optional: true
 
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
 
-  brace-expansion@1.1.16:
+  baseline-browser-mapping@2.11.13: {}
+
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4369,12 +4744,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.23.3:
+  browserslist@4.28.8:
     dependencies:
-      caniuse-lite: 1.0.30001651
-      electron-to-chromium: 1.5.6
-      node-releases: 2.0.18
-      update-browserslist-db: 1.1.0(browserslist@4.23.3)
+      baseline-browser-mapping: 2.11.13
+      caniuse-lite: 1.0.30001809
+      electron-to-chromium: 1.5.403
+      node-releases: 2.0.53
+      update-browserslist-db: 1.3.0(browserslist@4.28.8)
 
   bs-logger@0.2.6:
     dependencies:
@@ -4428,7 +4804,7 @@ snapshots:
 
   camelcase@6.3.0: {}
 
-  caniuse-lite@1.0.30001651: {}
+  caniuse-lite@1.0.30001809: {}
 
   capital-case@1.0.4:
     dependencies:
@@ -4438,9 +4814,9 @@ snapshots:
 
   case@1.6.3: {}
 
-  cdktn@0.23.0(constructs@10.6.0):
+  cdktn@0.24.0(constructs@10.7.0):
     dependencies:
-      constructs: 10.6.0
+      constructs: 10.7.0
 
   chalk@2.4.2:
     dependencies:
@@ -4520,12 +4896,12 @@ snapshots:
       detect-indent: 6.1.0
       detect-newline: 3.1.0
       dotgitignore: 2.1.0
-      fast-xml-parser: 5.9.3
+      fast-xml-parser: 5.10.1
       figures: 3.2.0
       find-up: 5.0.0
       git-semver-tags: 5.0.1
       semver: 7.8.5
-      yaml: 2.8.2
+      yaml: 2.9.0
       yargs: 17.7.3
 
   commonmark@0.31.2:
@@ -4554,7 +4930,7 @@ snapshots:
       tslib: 2.6.3
       upper-case: 2.0.2
 
-  constructs@10.6.0: {}
+  constructs@10.7.0: {}
 
   conventional-changelog-angular@6.0.0:
     dependencies:
@@ -4648,13 +5024,13 @@ snapshots:
 
   core-util-is@1.0.3: {}
 
-  create-jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.9.3)):
+  create-jest@29.7.0(@types/node@26.2.0)(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3)):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@26.2.0)(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3))
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -4760,7 +5136,7 @@ snapshots:
 
   diff-sequences@29.6.3: {}
 
-  diff@4.0.2: {}
+  diff@4.0.4: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -4786,11 +5162,14 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
-  electron-to-chromium@1.5.6: {}
+  electron-to-chromium@1.5.403: {}
 
   emittery@0.13.1: {}
 
   emoji-regex@8.0.0: {}
+
+  empathic@2.0.1:
+    optional: true
 
   entities@3.0.1: {}
 
@@ -5156,14 +5535,14 @@ snapshots:
       path-expression-matcher: 1.6.1
       xml-naming: 0.1.0
 
-  fast-xml-parser@5.9.3:
+  fast-xml-parser@5.10.1:
     dependencies:
-      '@nodable/entities': 2.2.0
+      '@nodable/entities': 3.0.0
       fast-xml-builder: 1.2.0
-      is-unsafe: 1.0.1
-      path-expression-matcher: 1.6.1
+      is-unsafe: 2.0.0
+      path-expression-matcher: 1.6.2
       strnum: 2.4.1
-      xml-naming: 0.1.0
+      xml-naming: 0.3.0
 
   fastq@1.17.1:
     dependencies:
@@ -5173,13 +5552,9 @@ snapshots:
     dependencies:
       bser: 2.1.1
 
-  fdir@6.5.0(picomatch@4.0.3):
+  fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
-      picomatch: 4.0.3
-
-  fdir@6.5.0(picomatch@4.0.4):
-    optionalDependencies:
-      picomatch: 4.0.4
+      picomatch: 4.0.5
 
   figures@3.2.0:
     dependencies:
@@ -5213,10 +5588,10 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.3.1
+      flatted: 3.4.4
       keyv: 4.5.4
 
-  flatted@3.3.1: {}
+  flatted@3.4.4: {}
 
   for-each@0.3.3:
     dependencies:
@@ -5359,8 +5734,6 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
-  globals@11.12.0: {}
-
   globals@14.0.0: {}
 
   globalthis@1.0.4:
@@ -5443,6 +5816,9 @@ snapshots:
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
+
+  import-meta-resolve@4.2.0:
+    optional: true
 
   imurmurhash@0.1.4: {}
 
@@ -5633,7 +6009,7 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.19
 
-  is-unsafe@1.0.1: {}
+  is-unsafe@2.0.0: {}
 
   is-weakmap@2.0.2: {}
 
@@ -5660,7 +6036,7 @@ snapshots:
 
   istanbul-lib-instrument@5.2.1:
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.29.7
       '@babel/parser': 7.25.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -5670,7 +6046,7 @@ snapshots:
 
   istanbul-lib-instrument@6.0.3:
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.29.7
       '@babel/parser': 7.25.3
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
@@ -5709,7 +6085,7 @@ snapshots:
       '@jest/expect': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.5.3
@@ -5729,16 +6105,16 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.9.3)):
+  jest-cli@29.7.0(@types/node@26.2.0)(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.9.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3))
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.9.3))
+      create-jest: 29.7.0(@types/node@26.2.0)(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3))
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.9.3))
+      jest-config: 29.7.0(@types/node@26.2.0)(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3))
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -5748,43 +6124,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@29.7.0(@types/node@26.0.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.9.3)):
+  jest-config@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3)):
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.29.7
       '@jest/test-sequencer': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.25.2)
-      chalk: 4.1.2
-      ci-info: 3.9.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 26.0.1
-      ts-node: 10.9.2(@types/node@26.1.1)(typescript@5.9.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.9.3)):
-    dependencies:
-      '@babel/core': 7.25.2
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.25.2)
+      babel-jest: 29.7.0(@babel/core@7.29.7)
       chalk: 4.1.2
       ci-info: 3.9.0
       deepmerge: 4.3.1
@@ -5805,7 +6150,38 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 26.1.1
-      ts-node: 10.9.2(@types/node@26.1.1)(typescript@5.9.3)
+      ts-node: 10.9.2(@types/node@26.2.0)(typescript@5.9.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@26.2.0)(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3)):
+    dependencies:
+      '@babel/core': 7.29.7
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.7)
+      chalk: 4.1.2
+      ci-info: 3.9.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 26.2.0
+      ts-node: 10.9.2(@types/node@26.2.0)(typescript@5.9.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -5834,7 +6210,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -5844,7 +6220,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -5890,7 +6266,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -5925,7 +6301,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       chalk: 4.1.2
       emittery: 0.13.1
       graceful-fs: 4.2.11
@@ -5953,7 +6329,7 @@ snapshots:
       '@jest/test-result': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       chalk: 4.1.2
       cjs-module-lexer: 1.3.1
       collect-v8-coverage: 1.0.2
@@ -5973,15 +6349,15 @@ snapshots:
 
   jest-snapshot@29.7.0:
     dependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 7.29.7
       '@babel/generator': 7.25.0
-      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.25.2)
-      '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.25.2)
+      '@babel/plugin-syntax-jsx': 7.24.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-typescript': 7.24.7(@babel/core@7.29.7)
       '@babel/types': 7.25.2
       '@jest/expect-utils': 29.7.0
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.25.2)
+      babel-preset-current-node-syntax: 1.0.1(@babel/core@7.29.7)
       chalk: 4.1.2
       expect: 29.7.0
       graceful-fs: 4.2.11
@@ -5999,11 +6375,11 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   jest-validate@29.7.0:
     dependencies:
@@ -6018,7 +6394,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -6027,35 +6403,40 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 26.0.1
+      '@types/node': 26.1.1
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.9.3)):
+  jest@29.7.0(@types/node@26.2.0)(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3)):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.9.3))
+      '@jest/core': 29.7.0(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3))
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.9.3))
+      jest-cli: 29.7.0(@types/node@26.2.0)(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
       - supports-color
       - ts-node
 
+  js-tokens@10.0.0:
+    optional: true
+
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@3.15.1:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
   jsesc@2.5.2: {}
+
+  jsesc@3.1.0: {}
 
   jsii-diff@1.137.0:
     dependencies:
@@ -6210,7 +6591,7 @@ snapshots:
     dependencies:
       date-format: 4.0.14
       debug: 4.4.3
-      flatted: 3.3.1
+      flatted: 3.4.4
       rfdc: 1.4.1
       streamroller: 3.1.5
     transitivePeerDependencies:
@@ -6219,6 +6600,9 @@ snapshots:
   lower-case@2.0.2:
     dependencies:
       tslib: 2.6.3
+
+  lru-cache@11.5.2:
+    optional: true
 
   lru-cache@5.1.1:
     dependencies:
@@ -6264,15 +6648,10 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  micromatch@4.0.7:
-    dependencies:
-      braces: 3.0.3
-      picomatch: 2.3.1
-
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.1
+      picomatch: 2.3.2
 
   mime-db@1.52.0: {}
 
@@ -6286,11 +6665,15 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
+
+  minimatch@10.2.6:
+    dependencies:
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimist-options@4.1.0:
     dependencies:
@@ -6319,7 +6702,7 @@ snapshots:
 
   node-int64@0.4.0: {}
 
-  node-releases@2.0.18: {}
+  node-releases@2.0.53: {}
 
   normalize-package-data@2.5.0:
     dependencies:
@@ -6382,6 +6765,9 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.0.0
+
+  obug@2.1.4:
+    optional: true
 
   once@1.4.0:
     dependencies:
@@ -6477,6 +6863,8 @@ snapshots:
 
   path-expression-matcher@1.6.1: {}
 
+  path-expression-matcher@1.6.2: {}
+
   path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
@@ -6489,13 +6877,11 @@ snapshots:
 
   picocolors@1.0.1: {}
 
-  picomatch@2.3.1: {}
+  picocolors@1.1.1: {}
 
   picomatch@2.3.2: {}
 
-  picomatch@4.0.3: {}
-
-  picomatch@4.0.4: {}
+  picomatch@4.0.5: {}
 
   pify@2.3.0: {}
 
@@ -6525,9 +6911,9 @@ snapshots:
 
   process-nextick-args@2.0.1: {}
 
-  projen@0.100.7(constructs@10.6.0):
+  projen@0.100.7(constructs@10.7.0):
     dependencies:
-      constructs: 10.6.0
+      constructs: 10.7.0
 
   prompts@2.4.2:
     dependencies:
@@ -6941,13 +7327,13 @@ snapshots:
 
   tinyglobby@0.2.15:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.3)
-      picomatch: 4.0.3
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tinyglobby@0.2.17:
     dependencies:
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
 
   tmpl@1.0.5: {}
 
@@ -6963,12 +7349,12 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  ts-jest@29.4.11(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(jest-util@29.7.0)(jest@29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.9.3)))(typescript@5.9.3):
+  ts-jest@29.4.11(@babel/core@8.0.1)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@8.0.1))(jest-util@29.7.0)(jest@29.7.0(@types/node@26.2.0)(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3)))(typescript@5.9.3):
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
       handlebars: 4.7.9
-      jest: 29.7.0(@types/node@26.1.1)(ts-node@10.9.2(@types/node@26.1.1)(typescript@5.9.3))
+      jest: 29.7.0(@types/node@26.2.0)(ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3))
       json5: 2.2.3
       lodash.memoize: 4.1.2
       make-error: 1.3.6
@@ -6977,25 +7363,25 @@ snapshots:
       typescript: 5.9.3
       yargs-parser: 21.1.1
     optionalDependencies:
-      '@babel/core': 7.25.2
+      '@babel/core': 8.0.1
       '@jest/transform': 29.7.0
       '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.25.2)
+      babel-jest: 29.7.0(@babel/core@8.0.1)
       jest-util: 29.7.0
 
-  ts-node@10.9.2(@types/node@26.1.1)(typescript@5.9.3):
+  ts-node@10.9.2(@types/node@26.2.0)(typescript@5.9.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
       '@tsconfig/node12': 1.0.11
       '@tsconfig/node14': 1.0.3
       '@tsconfig/node16': 1.0.4
-      '@types/node': 26.1.1
+      '@types/node': 26.2.0
       acorn: 8.12.1
       acorn-walk: 8.3.3
       arg: 4.1.3
       create-require: 1.1.1
-      diff: 4.0.2
+      diff: 4.0.4
       make-error: 1.3.6
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
@@ -7142,11 +7528,11 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
-  update-browserslist-db@1.1.0(browserslist@4.23.3):
+  update-browserslist-db@1.3.0(browserslist@4.28.8):
     dependencies:
-      browserslist: 4.23.3
+      browserslist: 4.28.8
       escalade: 3.2.0
-      picocolors: 1.0.1
+      picocolors: 1.1.1
 
   upper-case-first@2.0.2:
     dependencies:
@@ -7263,6 +7649,8 @@ snapshots:
 
   xml-naming@0.1.0: {}
 
+  xml-naming@0.3.0: {}
+
   xml@1.0.1: {}
 
   xmlbuilder@15.1.1: {}
@@ -7275,7 +7663,7 @@ snapshots:
 
   yallist@4.0.0: {}
 
-  yaml@2.8.2: {}
+  yaml@2.9.0: {}
 
   yargs-parser@20.2.9: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.0.2
         version: 1.0.2
       change-case:
-        specifier: ^4.1.1
-        version: 4.1.2
+        specifier: ^5.4.4
+        version: 5.4.4
       ignore:
         specifier: ^5.3.2
         version: 5.3.2
@@ -1105,9 +1105,6 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  camel-case@4.1.2:
-    resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
-
   camelcase-keys@6.2.2:
     resolution: {integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==}
     engines: {node: '>=8'}
@@ -1122,9 +1119,6 @@ packages:
 
   caniuse-lite@1.0.30001809:
     resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
-
-  capital-case@1.0.4:
-    resolution: {integrity: sha512-ds37W8CytHgwnhGGTi88pcPyR15qoNkOpYwmMMfnWqqWgESapLqvDx6huFjQ5vqWSn2Z06173XNA7LtMOeUh1A==}
 
   case@1.6.3:
     resolution: {integrity: sha512-mzDSXIPaFwVDvZAHqZ9VlbyF4yyXRuX6IvB06WvPYkqJVO24kX1PPhv9bfpKNFZyxYFmmgo03HUiD8iklmJYRQ==}
@@ -1147,8 +1141,8 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
-  change-case@4.1.2:
-    resolution: {integrity: sha512-bSxY2ws9OtviILG1EiY5K7NNxkqg/JnRnFxLtKQ96JaviiIxi7djMrSd0ECT9AC+lttClmYwKw53BWpOMblo7A==}
+  change-case@5.4.4:
+    resolution: {integrity: sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==}
 
   char-regex@1.0.2:
     resolution: {integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==}
@@ -1214,9 +1208,6 @@ packages:
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
     engines: {'0': node >= 6.0}
-
-  constant-case@3.0.4:
-    resolution: {integrity: sha512-I2hSBi7Vvs7BEuJDr5dDHfzb/Ruj3FyvFyh7KLilAjNQw3Be+xgqUBA2W6scVEcL0hL1dwPRtIqEPVUCKkSsyQ==}
 
   constructs@10.7.0:
     resolution: {integrity: sha512-Vzwc30bMywc7DCzX8XOyuZbsBmfXTCrn6HHmhhELZK1J5dnUWwJ5uL7hBXGGq7xFPVOOO6cs9FwaxOshAxgcWQ==}
@@ -1435,9 +1426,6 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
-
-  dot-case@3.0.4:
-    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
 
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
@@ -1930,9 +1918,6 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
-
-  header-case@2.0.4:
-    resolution: {integrity: sha512-H/vuk5TEEVZwrR0lp2zed9OCo1uAILMlx0JEMgC26rzyJJ3N1v6XkwHHXJQdR2doSjcGPM6OKPYoJgf0plJ11Q==}
 
   hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -2482,9 +2467,6 @@ packages:
     resolution: {integrity: sha512-1somDdy9sChrr9/f4UlzhdaGfDR2c/SaD2a4T7qEkG4jTS57/B3qmnjLYePwQ8cqWnUHZI0iAKxMBpCZICiZ2g==}
     engines: {node: '>=8.0'}
 
-  lower-case@2.0.2:
-    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
-
   lru-cache@11.5.2:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
@@ -2592,9 +2574,6 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
-
-  no-case@3.0.4:
-    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -2709,9 +2688,6 @@ packages:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
 
-  param-case@3.0.4:
-    resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
-
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2723,12 +2699,6 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
-
-  pascal-case@3.1.2:
-    resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
-
-  path-case@3.0.4:
-    resolution: {integrity: sha512-qO4qCFjXqVTrcbPt/hQfhTQ+VhFsqNKOPtytgNKkKxSoEp3XPUQ8ObFuePylOIok5gjn69ry8XiULxCwot3Wfg==}
 
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
@@ -2981,9 +2951,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  sentence-case@3.0.4:
-    resolution: {integrity: sha512-8LS0JInaQMCRoQ7YUytAo/xUu5W2XnQxV2HI/6uM6U7CITS1RqPElr30V6uIqyMKM9lJGRVFy5/4CuzcixNYSg==}
-
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -3033,9 +3000,6 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
-
-  snake-case@3.0.4:
-    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
   sort-json@2.0.1:
     resolution: {integrity: sha512-s8cs2bcsQCzo/P2T/uoU6Js4dS/jnX8+4xunziNoq9qmSpZNCrRIAIvp4avsz0ST18HycV4z/7myJ7jsHWB2XQ==}
@@ -3360,12 +3324,6 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
-
-  upper-case-first@2.0.2:
-    resolution: {integrity: sha512-514ppYHBaKwfJRK/pNC6c/OxfGa0obSnAl106u97Ed0I625Nin96KAjttZF6ZL3e1XLtphxnqrOi9iWgm+u+bg==}
-
-  upper-case@2.0.2:
-    resolution: {integrity: sha512-KgdgDGJt2TpuwBUIjgG6lzw2GWFRCW9Qkfkiv0DxqHHLYJHmtmdUIKcZd8rHgFSjopVTlw6ggzCm1b8MFQwikg==}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -4789,11 +4747,6 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  camel-case@4.1.2:
-    dependencies:
-      pascal-case: 3.1.2
-      tslib: 2.6.3
-
   camelcase-keys@6.2.2:
     dependencies:
       camelcase: 5.3.1
@@ -4805,12 +4758,6 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001809: {}
-
-  capital-case@1.0.4:
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.6.3
-      upper-case-first: 2.0.2
 
   case@1.6.3: {}
 
@@ -4829,20 +4776,7 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  change-case@4.1.2:
-    dependencies:
-      camel-case: 4.1.2
-      capital-case: 1.0.4
-      constant-case: 3.0.4
-      dot-case: 3.0.4
-      header-case: 2.0.4
-      no-case: 3.0.4
-      param-case: 3.0.4
-      pascal-case: 3.1.2
-      path-case: 3.0.4
-      sentence-case: 3.0.4
-      snake-case: 3.0.4
-      tslib: 2.6.3
+  change-case@5.4.4: {}
 
   char-regex@1.0.2: {}
 
@@ -4923,12 +4857,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
       typedarray: 0.0.6
-
-  constant-case@3.0.4:
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.6.3
-      upper-case: 2.0.2
 
   constructs@10.7.0: {}
 
@@ -5141,11 +5069,6 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
-
-  dot-case@3.0.4:
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.6.3
 
   dot-prop@5.3.0:
     dependencies:
@@ -5787,11 +5710,6 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
-
-  header-case@2.0.4:
-    dependencies:
-      capital-case: 1.0.4
-      tslib: 2.6.3
 
   hosted-git-info@2.8.9: {}
 
@@ -6597,10 +6515,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  lower-case@2.0.2:
-    dependencies:
-      tslib: 2.6.3
-
   lru-cache@11.5.2:
     optional: true
 
@@ -6694,11 +6608,6 @@ snapshots:
   natural-compare@1.4.0: {}
 
   neo-async@2.6.2: {}
-
-  no-case@3.0.4:
-    dependencies:
-      lower-case: 2.0.2
-      tslib: 2.6.3
 
   node-int64@0.4.0: {}
 
@@ -6826,11 +6735,6 @@ snapshots:
 
   p-try@2.2.0: {}
 
-  param-case@3.0.4:
-    dependencies:
-      dot-case: 3.0.4
-      tslib: 2.6.3
-
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -6846,16 +6750,6 @@ snapshots:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
-
-  pascal-case@3.1.2:
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.6.3
-
-  path-case@3.0.4:
-    dependencies:
-      dot-case: 3.0.4
-      tslib: 2.6.3
 
   path-exists@3.0.0: {}
 
@@ -7078,12 +6972,6 @@ snapshots:
 
   semver@7.8.5: {}
 
-  sentence-case@3.0.4:
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.6.3
-      upper-case-first: 2.0.2
-
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -7152,11 +7040,6 @@ snapshots:
   sisteransi@1.0.5: {}
 
   slash@3.0.0: {}
-
-  snake-case@3.0.4:
-    dependencies:
-      dot-case: 3.0.4
-      tslib: 2.6.3
 
   sort-json@2.0.1:
     dependencies:
@@ -7533,14 +7416,6 @@ snapshots:
       browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
-
-  upper-case-first@2.0.2:
-    dependencies:
-      tslib: 2.6.3
-
-  upper-case@2.0.2:
-    dependencies:
-      tslib: 2.6.3
 
   uri-js@4.4.1:
     dependencies:

--- a/src/aws/compute/function-vpc-config.generated.ts
+++ b/src/aws/compute/function-vpc-config.generated.ts
@@ -11,17 +11,17 @@ import type { securityGroup } from '@cdktn/provider-aws';
  */
 export interface VpcConfig {
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lambda_function#ipv6_allowed_for_dual_stack LambdaFunction#ipv6_allowed_for_dual_stack}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lambda_function#ipv6_allowed_for_dual_stack LambdaFunction#ipv6_allowed_for_dual_stack}.
    * @stability stable
    */
   readonly ipv6AllowedForDualStack?: boolean | IResolvable;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lambda_function#subnet_ids LambdaFunction#subnet_ids}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lambda_function#subnet_ids LambdaFunction#subnet_ids}.
    * @stability stable
    */
   readonly subnetIds: Array<string>;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lambda_function#security_group_ids LambdaFunction#security_group_ids}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lambda_function#security_group_ids LambdaFunction#security_group_ids}.
    * @default created
    * @stability stable
    */

--- a/src/aws/compute/lb-shared/lb-listener-config.generated.ts
+++ b/src/aws/compute/lb-shared/lb-listener-config.generated.ts
@@ -8,166 +8,166 @@ import type { FileProvisioner, IResolvable, ITerraformDependable, ITerraformIter
 export interface LbListenerConfig {
   /**
    * timeouts block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#timeouts LbListener#timeouts}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#timeouts LbListener#timeouts}
    * @stability stable
    */
   readonly timeouts?: lbListener.LbListenerTimeouts;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#tcp_idle_timeout_seconds LbListener#tcp_idle_timeout_seconds}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#tcp_idle_timeout_seconds LbListener#tcp_idle_timeout_seconds}.
    * @stability stable
    */
   readonly tcpIdleTimeoutSeconds?: number;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#tags_all LbListener#tags_all}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#tags_all LbListener#tags_all}.
    * @stability stable
    */
   readonly tagsAll?: Record<string, string>;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#tags LbListener#tags}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#tags LbListener#tags}.
    * @stability stable
    */
   readonly tags?: Record<string, string>;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#ssl_policy LbListener#ssl_policy}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#ssl_policy LbListener#ssl_policy}.
    * @stability stable
    */
   readonly sslPolicy?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_response_x_frame_options_header_value LbListener#routing_http_response_x_frame_options_header_value}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_response_x_frame_options_header_value LbListener#routing_http_response_x_frame_options_header_value}.
    * @stability stable
    */
   readonly routingHttpResponseXFrameOptionsHeaderValue?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_response_x_content_type_options_header_value LbListener#routing_http_response_x_content_type_options_header_value}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_response_x_content_type_options_header_value LbListener#routing_http_response_x_content_type_options_header_value}.
    * @stability stable
    */
   readonly routingHttpResponseXContentTypeOptionsHeaderValue?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_response_strict_transport_security_header_value LbListener#routing_http_response_strict_transport_security_header_value}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_response_strict_transport_security_header_value LbListener#routing_http_response_strict_transport_security_header_value}.
    * @stability stable
    */
   readonly routingHttpResponseStrictTransportSecurityHeaderValue?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_response_server_enabled LbListener#routing_http_response_server_enabled}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_response_server_enabled LbListener#routing_http_response_server_enabled}.
    * @stability stable
    */
   readonly routingHttpResponseServerEnabled?: boolean | IResolvable;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_response_content_security_policy_header_value LbListener#routing_http_response_content_security_policy_header_value}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_response_content_security_policy_header_value LbListener#routing_http_response_content_security_policy_header_value}.
    * @stability stable
    */
   readonly routingHttpResponseContentSecurityPolicyHeaderValue?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_response_access_control_max_age_header_value LbListener#routing_http_response_access_control_max_age_header_value}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_response_access_control_max_age_header_value LbListener#routing_http_response_access_control_max_age_header_value}.
    * @stability stable
    */
   readonly routingHttpResponseAccessControlMaxAgeHeaderValue?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_response_access_control_expose_headers_header_value LbListener#routing_http_response_access_control_expose_headers_header_value}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_response_access_control_expose_headers_header_value LbListener#routing_http_response_access_control_expose_headers_header_value}.
    * @stability stable
    */
   readonly routingHttpResponseAccessControlExposeHeadersHeaderValue?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_response_access_control_allow_origin_header_value LbListener#routing_http_response_access_control_allow_origin_header_value}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_response_access_control_allow_origin_header_value LbListener#routing_http_response_access_control_allow_origin_header_value}.
    * @stability stable
    */
   readonly routingHttpResponseAccessControlAllowOriginHeaderValue?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_response_access_control_allow_methods_header_value LbListener#routing_http_response_access_control_allow_methods_header_value}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_response_access_control_allow_methods_header_value LbListener#routing_http_response_access_control_allow_methods_header_value}.
    * @stability stable
    */
   readonly routingHttpResponseAccessControlAllowMethodsHeaderValue?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_response_access_control_allow_headers_header_value LbListener#routing_http_response_access_control_allow_headers_header_value}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_response_access_control_allow_headers_header_value LbListener#routing_http_response_access_control_allow_headers_header_value}.
    * @stability stable
    */
   readonly routingHttpResponseAccessControlAllowHeadersHeaderValue?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_response_access_control_allow_credentials_header_value LbListener#routing_http_response_access_control_allow_credentials_header_value}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_response_access_control_allow_credentials_header_value LbListener#routing_http_response_access_control_allow_credentials_header_value}.
    * @stability stable
    */
   readonly routingHttpResponseAccessControlAllowCredentialsHeaderValue?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_request_x_amzn_tls_version_header_name LbListener#routing_http_request_x_amzn_tls_version_header_name}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_request_x_amzn_tls_version_header_name LbListener#routing_http_request_x_amzn_tls_version_header_name}.
    * @stability stable
    */
   readonly routingHttpRequestXAmznTlsVersionHeaderName?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_request_x_amzn_tls_cipher_suite_header_name LbListener#routing_http_request_x_amzn_tls_cipher_suite_header_name}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_request_x_amzn_tls_cipher_suite_header_name LbListener#routing_http_request_x_amzn_tls_cipher_suite_header_name}.
    * @stability stable
    */
   readonly routingHttpRequestXAmznTlsCipherSuiteHeaderName?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_request_x_amzn_mtls_clientcert_validity_header_name LbListener#routing_http_request_x_amzn_mtls_clientcert_validity_header_name}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_request_x_amzn_mtls_clientcert_validity_header_name LbListener#routing_http_request_x_amzn_mtls_clientcert_validity_header_name}.
    * @stability stable
    */
   readonly routingHttpRequestXAmznMtlsClientcertValidityHeaderName?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_request_x_amzn_mtls_clientcert_subject_header_name LbListener#routing_http_request_x_amzn_mtls_clientcert_subject_header_name}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_request_x_amzn_mtls_clientcert_subject_header_name LbListener#routing_http_request_x_amzn_mtls_clientcert_subject_header_name}.
    * @stability stable
    */
   readonly routingHttpRequestXAmznMtlsClientcertSubjectHeaderName?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_request_x_amzn_mtls_clientcert_serial_number_header_name LbListener#routing_http_request_x_amzn_mtls_clientcert_serial_number_header_name}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_request_x_amzn_mtls_clientcert_serial_number_header_name LbListener#routing_http_request_x_amzn_mtls_clientcert_serial_number_header_name}.
    * @stability stable
    */
   readonly routingHttpRequestXAmznMtlsClientcertSerialNumberHeaderName?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_request_x_amzn_mtls_clientcert_leaf_header_name LbListener#routing_http_request_x_amzn_mtls_clientcert_leaf_header_name}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_request_x_amzn_mtls_clientcert_leaf_header_name LbListener#routing_http_request_x_amzn_mtls_clientcert_leaf_header_name}.
    * @stability stable
    */
   readonly routingHttpRequestXAmznMtlsClientcertLeafHeaderName?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_request_x_amzn_mtls_clientcert_issuer_header_name LbListener#routing_http_request_x_amzn_mtls_clientcert_issuer_header_name}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_request_x_amzn_mtls_clientcert_issuer_header_name LbListener#routing_http_request_x_amzn_mtls_clientcert_issuer_header_name}.
    * @stability stable
    */
   readonly routingHttpRequestXAmznMtlsClientcertIssuerHeaderName?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#routing_http_request_x_amzn_mtls_clientcert_header_name LbListener#routing_http_request_x_amzn_mtls_clientcert_header_name}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#routing_http_request_x_amzn_mtls_clientcert_header_name LbListener#routing_http_request_x_amzn_mtls_clientcert_header_name}.
    * @stability stable
    */
   readonly routingHttpRequestXAmznMtlsClientcertHeaderName?: string;
   /**
    * Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#region LbListener#region}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#region LbListener#region}
    * @stability stable
    */
   readonly region?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#protocol LbListener#protocol}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#protocol LbListener#protocol}.
    * @stability stable
    */
   readonly protocol?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#port LbListener#port}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#port LbListener#port}.
    * @stability stable
    */
   readonly port?: number;
   /**
    * mutual_authentication block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#mutual_authentication LbListener#mutual_authentication}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#mutual_authentication LbListener#mutual_authentication}
    * @stability stable
    */
   readonly mutualAuthentication?: lbListener.LbListenerMutualAuthentication;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#id LbListener#id}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#id LbListener#id}.
    * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
    * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
    * @stability stable
    */
   readonly id?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#certificate_arn LbListener#certificate_arn}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#certificate_arn LbListener#certificate_arn}.
    * @stability stable
    */
   readonly certificateArn?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#alpn_policy LbListener#alpn_policy}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#alpn_policy LbListener#alpn_policy}.
    * @stability stable
    */
   readonly alpnPolicy?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_listener#load_balancer_arn LbListener#load_balancer_arn}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_listener#load_balancer_arn LbListener#load_balancer_arn}.
    * @stability stable
    */
   readonly loadBalancerArn: string;

--- a/src/aws/compute/lb-shared/lb-target-group-attachment-config.generated.ts
+++ b/src/aws/compute/lb-shared/lb-target-group-attachment-config.generated.ts
@@ -7,34 +7,34 @@ import type { FileProvisioner, ITerraformDependable, ITerraformIterator, LocalEx
 export interface LbTargetGroupAttachmentConfig {
   /**
    * Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_target_group_attachment#region LbTargetGroupAttachment#region}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_target_group_attachment#region LbTargetGroupAttachment#region}
    * @stability stable
    */
   readonly region?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_target_group_attachment#quic_server_id LbTargetGroupAttachment#quic_server_id}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_target_group_attachment#quic_server_id LbTargetGroupAttachment#quic_server_id}.
    * @stability stable
    */
   readonly quicServerId?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_target_group_attachment#port LbTargetGroupAttachment#port}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_target_group_attachment#port LbTargetGroupAttachment#port}.
    * @stability stable
    */
   readonly port?: number;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_target_group_attachment#id LbTargetGroupAttachment#id}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_target_group_attachment#id LbTargetGroupAttachment#id}.
    * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
    * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
    * @stability stable
    */
   readonly id?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_target_group_attachment#availability_zone LbTargetGroupAttachment#availability_zone}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_target_group_attachment#availability_zone LbTargetGroupAttachment#availability_zone}.
    * @stability stable
    */
   readonly availabilityZone?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/lb_target_group_attachment#target_id LbTargetGroupAttachment#target_id}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/lb_target_group_attachment#target_id LbTargetGroupAttachment#target_id}.
    * @stability stable
    */
   readonly targetId: string;

--- a/src/aws/iam/policy-document-config.generated.ts
+++ b/src/aws/iam/policy-document-config.generated.ts
@@ -7,43 +7,43 @@ import type { FileProvisioner, ITerraformDependable, ITerraformIterator, LocalEx
  */
 export interface PolicyDocumentConfig {
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/iam_policy_document#version DataAwsIamPolicyDocument#version}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/iam_policy_document#version DataAwsIamPolicyDocument#version}.
    * @stability stable
    */
   readonly version?: string;
   /**
    * Configuration block for a policy statement
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/iam_policy_document#statement DataAwsIamPolicyDocument#statement}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/iam_policy_document#statement DataAwsIamPolicyDocument#statement}
    * @stability stable
    */
   readonly statement?: Array<PolicyStatement>;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/iam_policy_document#source_policy_documents DataAwsIamPolicyDocument#source_policy_documents}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/iam_policy_document#source_policy_documents DataAwsIamPolicyDocument#source_policy_documents}.
    * @stability stable
    */
   readonly sourcePolicyDocuments?: Array<string>;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/iam_policy_document#source_json DataAwsIamPolicyDocument#source_json}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/iam_policy_document#source_json DataAwsIamPolicyDocument#source_json}.
    * @stability stable
    */
   readonly sourceJson?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/iam_policy_document#policy_id DataAwsIamPolicyDocument#policy_id}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/iam_policy_document#policy_id DataAwsIamPolicyDocument#policy_id}.
    * @stability stable
    */
   readonly policyId?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/iam_policy_document#override_policy_documents DataAwsIamPolicyDocument#override_policy_documents}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/iam_policy_document#override_policy_documents DataAwsIamPolicyDocument#override_policy_documents}.
    * @stability stable
    */
   readonly overridePolicyDocuments?: Array<string>;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/iam_policy_document#override_json DataAwsIamPolicyDocument#override_json}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/iam_policy_document#override_json DataAwsIamPolicyDocument#override_json}.
    * @stability stable
    */
   readonly overrideJson?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/iam_policy_document#id DataAwsIamPolicyDocument#id}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/iam_policy_document#id DataAwsIamPolicyDocument#id}.
    * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
    * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
    * @stability stable

--- a/src/aws/iam/policy-statement-props.generated.ts
+++ b/src/aws/iam/policy-statement-props.generated.ts
@@ -6,34 +6,34 @@ import type { Condition, Effect, IPrincipal } from './';
  */
 export interface PolicyStatementProps {
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/iam_policy_document#sid DataAwsIamPolicyDocument#sid}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/iam_policy_document#sid DataAwsIamPolicyDocument#sid}.
    * @stability stable
    */
   readonly sid?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/iam_policy_document#resources DataAwsIamPolicyDocument#resources}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/iam_policy_document#resources DataAwsIamPolicyDocument#resources}.
    * @stability stable
    */
   readonly resources?: Array<string>;
   /**
    * principals block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/iam_policy_document#principals DataAwsIamPolicyDocument#principals}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/iam_policy_document#principals DataAwsIamPolicyDocument#principals}
    * @stability stable
    */
   readonly principals?: Array<IPrincipal>;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/iam_policy_document#not_resources DataAwsIamPolicyDocument#not_resources}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/iam_policy_document#not_resources DataAwsIamPolicyDocument#not_resources}.
    * @stability stable
    */
   readonly notResources?: Array<string>;
   /**
    * not_principals block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/iam_policy_document#not_principals DataAwsIamPolicyDocument#not_principals}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/iam_policy_document#not_principals DataAwsIamPolicyDocument#not_principals}
    * @stability stable
    */
   readonly notPrincipals?: Array<IPrincipal>;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/iam_policy_document#not_actions DataAwsIamPolicyDocument#not_actions}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/iam_policy_document#not_actions DataAwsIamPolicyDocument#not_actions}.
    * @stability stable
    */
   readonly notActions?: Array<string>;
@@ -45,12 +45,12 @@ export interface PolicyStatementProps {
   readonly effect?: Effect;
   /**
    * condition block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/iam_policy_document#condition DataAwsIamPolicyDocument#condition}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/iam_policy_document#condition DataAwsIamPolicyDocument#condition}
    * @stability stable
    */
   readonly condition?: Array<Condition>;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/data-sources/iam_policy_document#actions DataAwsIamPolicyDocument#actions}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/data-sources/iam_policy_document#actions DataAwsIamPolicyDocument#actions}.
    * @stability stable
    */
   readonly actions?: Array<string>;

--- a/src/aws/provider-config.generated.ts
+++ b/src/aws/provider-config.generated.ts
@@ -8,31 +8,31 @@ import type { provider } from '@cdktn/provider-aws';
 export interface AwsProviderConfig {
   /**
    * Product details to append to the User-Agent string sent in all AWS API calls.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#user_agent AwsProvider#user_agent}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#user_agent AwsProvider#user_agent}
    * @stability stable
    */
   readonly userAgent?: Array<string>;
   /**
    * Resolve an endpoint with FIPS capability.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#use_fips_endpoint AwsProvider#use_fips_endpoint}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#use_fips_endpoint AwsProvider#use_fips_endpoint}
    * @stability stable
    */
   readonly useFipsEndpoint?: boolean | IResolvable;
   /**
    * Resolve an endpoint with DualStack capability.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#use_dualstack_endpoint AwsProvider#use_dualstack_endpoint}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#use_dualstack_endpoint AwsProvider#use_dualstack_endpoint}
    * @stability stable
    */
   readonly useDualstackEndpoint?: boolean | IResolvable;
   /**
    * The capacity of the AWS SDK's token bucket rate limiter.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#token_bucket_rate_limiter_capacity AwsProvider#token_bucket_rate_limiter_capacity}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#token_bucket_rate_limiter_capacity AwsProvider#token_bucket_rate_limiter_capacity}
    * @stability stable
    */
   readonly tokenBucketRateLimiterCapacity?: number;
   /**
    * session token. A session token is only required if you are using temporary security credentials.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#token AwsProvider#token}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#token AwsProvider#token}
    * @stability stable
    */
   readonly token?: string;
@@ -40,19 +40,19 @@ export interface AwsProviderConfig {
    * The severity with which to enforce organizational tagging policies on resources managed by this provider instance.
    * At this time this only includes compliance with required tag keys by resource type. Valid values are "error", "warning", and "disabled". When unset or "disabled", tag policy compliance will not be enforced by the provider. Can also be configured with the TF_AWS_TAG_POLICY_COMPLIANCE environment variable.
    *
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#tag_policy_compliance AwsProvider#tag_policy_compliance}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#tag_policy_compliance AwsProvider#tag_policy_compliance}
    * @stability stable
    */
   readonly tagPolicyCompliance?: string;
   /**
    * The region where AWS STS operations will take place. Examples are us-east-1 and us-west-2.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#sts_region AwsProvider#sts_region}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#sts_region AwsProvider#sts_region}
    * @stability stable
    */
   readonly stsRegion?: string;
   /**
    * Skip requesting the account ID. Used for AWS API implementations that do not have IAM/STS API and/or metadata API.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#skip_requesting_account_id AwsProvider#skip_requesting_account_id}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#skip_requesting_account_id AwsProvider#skip_requesting_account_id}
    * @stability stable
    */
   readonly skipRequestingAccountId?: boolean | IResolvable;
@@ -60,43 +60,43 @@ export interface AwsProviderConfig {
    * Skip static validation of region name.
    * Used by users of alternative AWS-like APIs or users w/ access to regions that are not public (yet).
    *
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#skip_region_validation AwsProvider#skip_region_validation}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#skip_region_validation AwsProvider#skip_region_validation}
    * @stability stable
    */
   readonly skipRegionValidation?: boolean | IResolvable;
   /**
    * Skip the AWS Metadata API check. Used for AWS API implementations that do not have a metadata api endpoint.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#skip_metadata_api_check AwsProvider#skip_metadata_api_check}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#skip_metadata_api_check AwsProvider#skip_metadata_api_check}
    * @stability stable
    */
   readonly skipMetadataApiCheck?: string;
   /**
    * Skip the credentials validation via STS API. Used for AWS API implementations that do not have STS available/implemented.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#skip_credentials_validation AwsProvider#skip_credentials_validation}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#skip_credentials_validation AwsProvider#skip_credentials_validation}
    * @stability stable
    */
   readonly skipCredentialsValidation?: boolean | IResolvable;
   /**
    * List of paths to shared credentials files. If not set, defaults to [~/.aws/credentials].
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#shared_credentials_files AwsProvider#shared_credentials_files}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#shared_credentials_files AwsProvider#shared_credentials_files}
    * @stability stable
    */
   readonly sharedCredentialsFiles?: Array<string>;
   /**
    * List of paths to shared config files. If not set, defaults to [~/.aws/config].
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#shared_config_files AwsProvider#shared_config_files}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#shared_config_files AwsProvider#shared_config_files}
    * @stability stable
    */
   readonly sharedConfigFiles?: Array<string>;
   /**
    * The secret key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#secret_key AwsProvider#secret_key}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#secret_key AwsProvider#secret_key}
    * @stability stable
    */
   readonly secretKey?: string;
   /**
    * Set this to true to enable the request to use path-style addressing, i.e., https://s3.amazonaws.com/BUCKET/KEY. By default, the S3 client will use virtual hosted bucket addressing when possible (https://BUCKET.s3.amazonaws.com/KEY). Specific to the Amazon S3 service.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#s3_use_path_style AwsProvider#s3_use_path_style}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#s3_use_path_style AwsProvider#s3_use_path_style}
    * @stability stable
    */
   readonly s3UsePathStyle?: boolean | IResolvable;
@@ -104,7 +104,7 @@ export interface AwsProviderConfig {
    * Specifies whether S3 API calls in the `us-east-1` region use the legacy global endpoint or a regional endpoint.
    * Valid values are `legacy` or `regional`. Can also be configured using the `AWS_S3_US_EAST_1_REGIONAL_ENDPOINT` environment variable or the `s3_us_east_1_regional_endpoint` shared config file parameter
    *
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#s3_us_east_1_regional_endpoint AwsProvider#s3_us_east_1_regional_endpoint}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#s3_us_east_1_regional_endpoint AwsProvider#s3_us_east_1_regional_endpoint}
    * @stability stable
    */
   readonly s3UsEast1RegionalEndpoint?: string;
@@ -112,19 +112,19 @@ export interface AwsProviderConfig {
    * Specifies how retries are attempted.
    * Valid values are `standard` and `adaptive`. Can also be configured using the `AWS_RETRY_MODE` environment variable.
    *
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#retry_mode AwsProvider#retry_mode}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#retry_mode AwsProvider#retry_mode}
    * @stability stable
    */
   readonly retryMode?: string;
   /**
    * The region where AWS operations will take place. Examples are us-east-1, us-west-2, etc.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#region AwsProvider#region}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#region AwsProvider#region}
    * @stability stable
    */
   readonly region?: string;
   /**
    * The profile for API operations. If not set, the default profile created with `aws configure` will be used.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#profile AwsProvider#profile}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#profile AwsProvider#profile}
    * @stability stable
    */
   readonly profile?: string;
@@ -132,7 +132,7 @@ export interface AwsProviderConfig {
    * Comma-separated list of hosts that should not use HTTP or HTTPS proxies.
    * Can also be set using the `NO_PROXY` or `no_proxy` environment variables.
    *
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#no_proxy AwsProvider#no_proxy}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#no_proxy AwsProvider#no_proxy}
    * @stability stable
    */
   readonly noProxy?: string;
@@ -141,19 +141,19 @@ export interface AwsProviderConfig {
    * If the API request still fails, an error is
    * thrown.
    *
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#max_retries AwsProvider#max_retries}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#max_retries AwsProvider#max_retries}
    * @stability stable
    */
   readonly maxRetries?: number;
   /**
    * Explicitly allow the provider to perform "insecure" SSL requests. If omitted, default value is `false`.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#insecure AwsProvider#insecure}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#insecure AwsProvider#insecure}
    * @stability stable
    */
   readonly insecure?: boolean | IResolvable;
   /**
    * ignore_tags block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#ignore_tags AwsProvider#ignore_tags}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#ignore_tags AwsProvider#ignore_tags}
    * @stability stable
    */
   readonly ignoreTags?: IResolvable | Array<provider.AwsProviderIgnoreTags>;
@@ -161,7 +161,7 @@ export interface AwsProviderConfig {
    * URL of a proxy to use for HTTPS requests when accessing the AWS API.
    * Can also be set using the `HTTPS_PROXY` or `https_proxy` environment variables.
    *
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#https_proxy AwsProvider#https_proxy}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#https_proxy AwsProvider#https_proxy}
    * @stability stable
    */
   readonly httpsProxy?: string;
@@ -169,36 +169,36 @@ export interface AwsProviderConfig {
    * URL of a proxy to use for HTTP requests when accessing the AWS API.
    * Can also be set using the `HTTP_PROXY` or `http_proxy` environment variables.
    *
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#http_proxy AwsProvider#http_proxy}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#http_proxy AwsProvider#http_proxy}
    * @stability stable
    */
   readonly httpProxy?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#forbidden_account_ids AwsProvider#forbidden_account_ids}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#forbidden_account_ids AwsProvider#forbidden_account_ids}.
    * @stability stable
    */
   readonly forbiddenAccountIds?: Array<string>;
   /**
    * endpoints block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#endpoints AwsProvider#endpoints}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#endpoints AwsProvider#endpoints}
    * @stability stable
    */
   readonly endpoints?: IResolvable | Array<provider.AwsProviderEndpoints>;
   /**
    * Protocol to use with EC2 metadata service endpoint.Valid values are `IPv4` and `IPv6`. Can also be configured using the `AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE` environment variable.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#ec2_metadata_service_endpoint_mode AwsProvider#ec2_metadata_service_endpoint_mode}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#ec2_metadata_service_endpoint_mode AwsProvider#ec2_metadata_service_endpoint_mode}
    * @stability stable
    */
   readonly ec2MetadataServiceEndpointMode?: string;
   /**
    * Address of the EC2 metadata service endpoint to use. Can also be configured using the `AWS_EC2_METADATA_SERVICE_ENDPOINT` environment variable.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#ec2_metadata_service_endpoint AwsProvider#ec2_metadata_service_endpoint}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#ec2_metadata_service_endpoint AwsProvider#ec2_metadata_service_endpoint}
    * @stability stable
    */
   readonly ec2MetadataServiceEndpoint?: string;
   /**
    * default_tags block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#default_tags AwsProvider#default_tags}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#default_tags AwsProvider#default_tags}
    * @stability stable
    */
   readonly defaultTags?: IResolvable | Array<provider.AwsProviderDefaultTags>;
@@ -206,30 +206,30 @@ export interface AwsProviderConfig {
    * File containing custom root and intermediate certificates.
    * Can also be configured using the `AWS_CA_BUNDLE` environment variable. (Setting `ca_bundle` in the shared config file is not supported.)
    *
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#custom_ca_bundle AwsProvider#custom_ca_bundle}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#custom_ca_bundle AwsProvider#custom_ca_bundle}
    * @stability stable
    */
   readonly customCaBundle?: string;
   /**
    * assume_role_with_web_identity block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#assume_role_with_web_identity AwsProvider#assume_role_with_web_identity}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#assume_role_with_web_identity AwsProvider#assume_role_with_web_identity}
    * @stability stable
    */
   readonly assumeRoleWithWebIdentity?: IResolvable | Array<provider.AwsProviderAssumeRoleWithWebIdentity>;
   /**
    * assume_role block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#assume_role AwsProvider#assume_role}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#assume_role AwsProvider#assume_role}
    * @stability stable
    */
   readonly assumeRole?: IResolvable | Array<provider.AwsProviderAssumeRole>;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#allowed_account_ids AwsProvider#allowed_account_ids}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#allowed_account_ids AwsProvider#allowed_account_ids}.
    * @stability stable
    */
   readonly allowedAccountIds?: Array<string>;
   /**
    * The access key for API operations. You can retrieve this from the 'Security & Credentials' section of the AWS console.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs#access_key AwsProvider#access_key}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs#access_key AwsProvider#access_key}
    * @stability stable
    */
   readonly accessKey?: string;

--- a/src/aws/storage/cors-config.generated.ts
+++ b/src/aws/storage/cors-config.generated.ts
@@ -12,25 +12,25 @@ import type { CorsRuleConfig } from './';
 export interface CorsConfig {
   /**
    * Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_cors_configuration#region S3BucketCorsConfiguration#region}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_cors_configuration#region S3BucketCorsConfiguration#region}
    * @stability stable
    */
   readonly region?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_cors_configuration#id S3BucketCorsConfiguration#id}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_cors_configuration#id S3BucketCorsConfiguration#id}.
    * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
    * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
    * @stability stable
    */
   readonly id?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_cors_configuration#expected_bucket_owner S3BucketCorsConfiguration#expected_bucket_owner}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_cors_configuration#expected_bucket_owner S3BucketCorsConfiguration#expected_bucket_owner}.
    * @stability stable
    */
   readonly expectedBucketOwner?: string;
   /**
    * A set of origins and methods (cross-origin access that you want to allow).
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_cors_configuration#cors_rule S3BucketCorsConfiguration#cors_rule}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_cors_configuration#cors_rule S3BucketCorsConfiguration#cors_rule}
    * @stability stable
    */
   readonly corsRule: IResolvable | Array<CorsRuleConfig>;

--- a/src/aws/storage/cors-rule-config.generated.ts
+++ b/src/aws/storage/cors-rule-config.generated.ts
@@ -6,29 +6,29 @@ import type { HttpMethods } from './';
  */
 export interface CorsRuleConfig {
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_cors_configuration#max_age_seconds S3BucketCorsConfiguration#max_age_seconds}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_cors_configuration#max_age_seconds S3BucketCorsConfiguration#max_age_seconds}.
    * @stability stable
    */
   readonly maxAgeSeconds?: number;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_cors_configuration#id S3BucketCorsConfiguration#id}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_cors_configuration#id S3BucketCorsConfiguration#id}.
    * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
    * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
    * @stability stable
    */
   readonly id?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_cors_configuration#expose_headers S3BucketCorsConfiguration#expose_headers}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_cors_configuration#expose_headers S3BucketCorsConfiguration#expose_headers}.
    * @stability stable
    */
   readonly exposeHeaders?: Array<string>;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_cors_configuration#allowed_headers S3BucketCorsConfiguration#allowed_headers}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_cors_configuration#allowed_headers S3BucketCorsConfiguration#allowed_headers}.
    * @stability stable
    */
   readonly allowedHeaders?: Array<string>;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_cors_configuration#allowed_origins S3BucketCorsConfiguration#allowed_origins}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_cors_configuration#allowed_origins S3BucketCorsConfiguration#allowed_origins}.
    * @stability stable
    */
   readonly allowedOrigins: Array<string>;

--- a/src/aws/storage/lifecycle-config.generated.ts
+++ b/src/aws/storage/lifecycle-config.generated.ts
@@ -8,42 +8,42 @@ import type { s3BucketLifecycleConfiguration } from '@cdktn/provider-aws';
 export interface LifecycleConfigurationRule {
   /**
    * transition block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_lifecycle_configuration#transition S3BucketLifecycleConfiguration#transition}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_lifecycle_configuration#transition S3BucketLifecycleConfiguration#transition}
    * @stability stable
    */
   readonly transition?: IResolvable | Array<s3BucketLifecycleConfiguration.S3BucketLifecycleConfigurationRuleTransition>;
   /**
    * noncurrent_version_transition block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_lifecycle_configuration#noncurrent_version_transition S3BucketLifecycleConfiguration#noncurrent_version_transition}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_lifecycle_configuration#noncurrent_version_transition S3BucketLifecycleConfiguration#noncurrent_version_transition}
    * @stability stable
    */
   readonly noncurrentVersionTransition?: IResolvable | Array<s3BucketLifecycleConfiguration.S3BucketLifecycleConfigurationRuleNoncurrentVersionTransition>;
   /**
    * noncurrent_version_expiration block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_lifecycle_configuration#noncurrent_version_expiration S3BucketLifecycleConfiguration#noncurrent_version_expiration}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_lifecycle_configuration#noncurrent_version_expiration S3BucketLifecycleConfiguration#noncurrent_version_expiration}
    * @stability stable
    */
   readonly noncurrentVersionExpiration?: IResolvable | Array<s3BucketLifecycleConfiguration.S3BucketLifecycleConfigurationRuleNoncurrentVersionExpiration>;
   /**
    * filter block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_lifecycle_configuration#filter S3BucketLifecycleConfiguration#filter}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_lifecycle_configuration#filter S3BucketLifecycleConfiguration#filter}
    * @stability stable
    */
   readonly filter?: IResolvable | Array<s3BucketLifecycleConfiguration.S3BucketLifecycleConfigurationRuleFilter>;
   /**
    * expiration block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_lifecycle_configuration#expiration S3BucketLifecycleConfiguration#expiration}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_lifecycle_configuration#expiration S3BucketLifecycleConfiguration#expiration}
    * @stability stable
    */
   readonly expiration?: IResolvable | Array<s3BucketLifecycleConfiguration.S3BucketLifecycleConfigurationRuleExpiration>;
   /**
    * abort_incomplete_multipart_upload block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_lifecycle_configuration#abort_incomplete_multipart_upload S3BucketLifecycleConfiguration#abort_incomplete_multipart_upload}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_lifecycle_configuration#abort_incomplete_multipart_upload S3BucketLifecycleConfiguration#abort_incomplete_multipart_upload}
    * @stability stable
    */
   readonly abortIncompleteMultipartUpload?: IResolvable | Array<s3BucketLifecycleConfiguration.S3BucketLifecycleConfigurationRuleAbortIncompleteMultipartUpload>;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_lifecycle_configuration#id S3BucketLifecycleConfiguration#id}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_lifecycle_configuration#id S3BucketLifecycleConfiguration#id}.
    * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
    * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
    * @stability stable

--- a/src/aws/storage/website-config.generated.ts
+++ b/src/aws/storage/website-config.generated.ts
@@ -9,31 +9,31 @@ import type { s3BucketWebsiteConfiguration } from '@cdktn/provider-aws';
  */
 export interface WebsiteConfig {
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_website_configuration#routing_rules S3BucketWebsiteConfiguration#routing_rules}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_website_configuration#routing_rules S3BucketWebsiteConfiguration#routing_rules}.
    * @stability stable
    */
   readonly routingRules?: string;
   /**
    * routing_rule block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_website_configuration#routing_rule S3BucketWebsiteConfiguration#routing_rule}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_website_configuration#routing_rule S3BucketWebsiteConfiguration#routing_rule}
    * @stability stable
    */
   readonly routingRule?: IResolvable | Array<s3BucketWebsiteConfiguration.S3BucketWebsiteConfigurationRoutingRule>;
   /**
    * Region where this resource will be [managed](https://docs.aws.amazon.com/general/latest/gr/rande.html#regional-endpoints). Defaults to the Region set in the [provider configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#aws-configuration-reference).
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_website_configuration#region S3BucketWebsiteConfiguration#region}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_website_configuration#region S3BucketWebsiteConfiguration#region}
    * @stability stable
    */
   readonly region?: string;
   /**
    * index_document block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_website_configuration#index_document S3BucketWebsiteConfiguration#index_document}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_website_configuration#index_document S3BucketWebsiteConfiguration#index_document}
    * @default index.html
    * @stability stable
    */
   readonly indexDocument?: string;
   /**
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_website_configuration#id S3BucketWebsiteConfiguration#id}.
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_website_configuration#id S3BucketWebsiteConfiguration#id}.
    * Please be aware that the id field is automatically added to all resources in Terraform providers using a Terraform provider SDK version below 2.
    * If you experience problems setting this value it might not be settable. Please take a look at the provider documentation to ensure it should be settable.
    * @stability stable
@@ -41,7 +41,7 @@ export interface WebsiteConfig {
   readonly id?: string;
   /**
    * error_document block.
-   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.52.0/docs/resources/s3_bucket_website_configuration#error_document S3BucketWebsiteConfiguration#error_document}
+   * Docs at Terraform Registry: {@link https://registry.terraform.io/providers/hashicorp/aws/6.58.0/docs/resources/s3_bucket_website_configuration#error_document S3BucketWebsiteConfiguration#error_document}
    * @stability stable
    */
   readonly errorDocument?: s3BucketWebsiteConfiguration.S3BucketWebsiteConfigurationErrorDocument;

--- a/src/aws/util.ts
+++ b/src/aws/util.ts
@@ -1,6 +1,10 @@
 // ref: https://github.com/aws/aws-cdk/blob/v2.150.0/packages/aws-cdk-lib/core/lib/util.ts
 
-import { snakeCase } from "change-case";
+// change-case v5 is ESM-only; Node 22+ supports require() of sync ESM modules.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const { snakeCase } = require("change-case") as {
+  snakeCase: (value: string) => string;
+};
 
 /**
  * Returns a copy of `obj` without `undefined` (or `null`) values in maps or arrays.

--- a/test/aws/compute/__snapshots__/function-storage.test.ts.snap
+++ b/test/aws/compute/__snapshots__/function-storage.test.ts.snap
@@ -81,12 +81,10 @@ exports[`Function with Storage Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "archive": [
-      {
-      }
+      {}
     ],
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -138,8 +136,7 @@ exports[`Function with Storage Should synth and match SnapShot 1`] = `
           "aws_iam_role_policy.HelloWorld_ServiceRole_DefaultPolicy_ResourceRoles0_F82A2883"
         ],
         "environment": {
-          "variables": {
-          }
+          "variables": {}
         },
         "filename": "\${data.archive_file.HelloWorld_TestStackHelloWorldacbd18db4cc2f85cedef654fccc4a4d8D135A4C7_9A2A35D2.output_path}",
         "function_name": "gTestStack553BDD39-TestStackHelloWorld",
@@ -183,7 +180,7 @@ exports[`Function with Storage Should synth and match SnapShot 1`] = `
       },
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -258,8 +255,7 @@ exports[`Function with event rules Should handle dependencies on permissions 1`]
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -330,8 +326,7 @@ exports[`Function with event rules Should handle dependencies on permissions 1`]
           "aws_iam_role_policy.HelloWorld_ServiceRole_DefaultPolicy_ResourceRoles0_F82A2883"
         ],
         "environment": {
-          "variables": {
-          }
+          "variables": {}
         },
         "filename": "\${data.terraform_remote_state.cross-stack-reference-input-TestStack.outputs.cross-stack-output-dataarchive_fileHelloWorld_TestStackHelloWorldacbd18db4cc2f85cedef654fccc4a4d8D135A4C7_9A2A35D2output_path}",
         "function_name": "gTestStack553BDD39-TestStackHelloWorld",
@@ -369,7 +364,7 @@ exports[`Function with event rules Should handle dependencies on permissions 1`]
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/__snapshots__/function.test.ts.snap
+++ b/test/aws/compute/__snapshots__/function.test.ts.snap
@@ -69,12 +69,10 @@ exports[`Function Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "archive": [
-      {
-      }
+      {}
     ],
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -126,8 +124,7 @@ exports[`Function Should synth and match SnapShot 1`] = `
           "aws_iam_role_policy.HelloWorld_ServiceRole_DefaultPolicy_ResourceRoles0_F82A2883"
         ],
         "environment": {
-          "variables": {
-          }
+          "variables": {}
         },
         "filename": "\${data.archive_file.HelloWorld_TestStackHelloWorldacbd18db4cc2f85cedef654fccc4a4d8D135A4C7_9A2A35D2.output_path}",
         "function_name": "gTestStack553BDD39-TestStackHelloWorld",
@@ -161,7 +158,7 @@ exports[`Function Should synth and match SnapShot 1`] = `
       },
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -237,12 +234,10 @@ exports[`latest Lambda node runtime with region agnostic stack 1`] = `
   },
   "provider": {
     "archive": [
-      {
-      }
+      {}
     ],
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -294,8 +289,7 @@ exports[`latest Lambda node runtime with region agnostic stack 1`] = `
           "aws_iam_role_policy.Lambda_ServiceRole_DefaultPolicy_ResourceRoles0_DE66D1AF"
         ],
         "environment": {
-          "variables": {
-          }
+          "variables": {}
         },
         "filename": "\${data.archive_file.Lambda_StackLambdaacbd18db4cc2f85cedef654fccc4a4d8996AFBA2_92C287E8.output_path}",
         "function_name": "gStack740B6247-StackLambda",
@@ -329,7 +323,7 @@ exports[`latest Lambda node runtime with region agnostic stack 1`] = `
       },
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/api-definition.test.ts
+++ b/test/aws/compute/api-definition.test.ts
@@ -105,7 +105,7 @@ describe("api definition", () => {
       template.expect.toHaveResourceWithProperties(
         apiGatewayRestApi.ApiGatewayRestApi,
         {
-          body: '${file("assets/APIDefinition/696823B294E9370C32D2718139EAD358/sample-restapi-definition.yaml")}',
+          body: '${file("assets/APIDefinition/8F4B0D399A2C7BD6DC11C26A19C5BE28/sample-restapi-definition.yaml")}',
         },
       );
       // Verify that inlineDefinition references the CDKTF Asset

--- a/test/aws/compute/auto-scaling/__snapshots__/cfn-init.test.ts.snap
+++ b/test/aws/compute/auto-scaling/__snapshots__/cfn-init.test.ts.snap
@@ -67,8 +67,7 @@ exports[`AutoScalingGroup (cfn-init.test.ts base fixture) Should synth and match
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -482,7 +481,7 @@ exports[`AutoScalingGroup (cfn-init.test.ts base fixture) Should synth and match
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/auto-scaling/__snapshots__/lifecyclehooks.test.ts.snap
+++ b/test/aws/compute/auto-scaling/__snapshots__/lifecyclehooks.test.ts.snap
@@ -101,8 +101,7 @@ exports[`LifecycleHook Should synth and match SnapShot with a notificationTarget
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -547,7 +546,7 @@ exports[`LifecycleHook Should synth and match SnapShot with a notificationTarget
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -655,8 +654,7 @@ exports[`LifecycleHook Should synth and match SnapShot with a role and a notific
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -1103,7 +1101,7 @@ exports[`LifecycleHook Should synth and match SnapShot with a role and a notific
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/auto-scaling/__snapshots__/scheduled-action.test.ts.snap
+++ b/test/aws/compute/auto-scaling/__snapshots__/scheduled-action.test.ts.snap
@@ -67,8 +67,7 @@ exports[`ScheduledAction Should synth and match SnapShot with minCapacity only 1
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -491,7 +490,7 @@ exports[`ScheduledAction Should synth and match SnapShot with minCapacity only 1
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -565,8 +564,7 @@ exports[`ScheduledAction Should synth and match SnapShot with startTime, endTime
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -992,7 +990,7 @@ exports[`ScheduledAction Should synth and match SnapShot with startTime, endTime
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/auto-scaling/__snapshots__/warm-pool.test.ts.snap
+++ b/test/aws/compute/auto-scaling/__snapshots__/warm-pool.test.ts.snap
@@ -67,8 +67,7 @@ exports[`WarmPool Should synth and match SnapShot with all optional properties 1
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -489,7 +488,7 @@ exports[`WarmPool Should synth and match SnapShot with all optional properties 1
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -563,8 +562,7 @@ exports[`WarmPool Should synth and match SnapShot with no optional properties 1`
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -589,8 +587,7 @@ exports[`WarmPool Should synth and match SnapShot with no optional properties 1`
           "\${aws_subnet.VPC_PrivateSubnet2_8C0AEF3A.id}",
           "\${aws_subnet.VPC_PrivateSubnet3_EAEE5839.id}"
         ],
-        "warm_pool": {
-        }
+        "warm_pool": {}
       }
     },
     "aws_eip": {
@@ -979,7 +976,7 @@ exports[`WarmPool Should synth and match SnapShot with no optional properties 1`
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/auto-scaling/aspects/__snapshots__/require-imdsv2-aspect.test.ts.snap
+++ b/test/aws/compute/auto-scaling/aspects/__snapshots__/require-imdsv2-aspect.test.ts.snap
@@ -67,8 +67,7 @@ exports[`AutoScalingGroupRequireImdsv2Aspect synth applies to AutoScalingGroup a
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -484,7 +483,7 @@ exports[`AutoScalingGroupRequireImdsv2Aspect synth applies to AutoScalingGroup a
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/batch/__snapshots__/ecs-container-definition.test.ts.snap
+++ b/test/aws/compute/batch/__snapshots__/ecs-container-definition.test.ts.snap
@@ -60,8 +60,7 @@ exports[`EcsContainerDefinition Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -108,7 +107,7 @@ exports[`EcsContainerDefinition Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/batch/__snapshots__/ecs-job-definition.test.ts.snap
+++ b/test/aws/compute/batch/__snapshots__/ecs-job-definition.test.ts.snap
@@ -60,8 +60,7 @@ exports[`EcsJobDefinition Should synth and match SnapShot for EC2 container 1`] 
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -109,7 +108,7 @@ exports[`EcsJobDefinition Should synth and match SnapShot for EC2 container 1`] 
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -176,8 +175,7 @@ exports[`EcsJobDefinition Should synth and match SnapShot for Fargate container 
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -224,7 +222,7 @@ exports[`EcsJobDefinition Should synth and match SnapShot for Fargate container 
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/batch/__snapshots__/job-definition-base.test.ts.snap
+++ b/test/aws/compute/batch/__snapshots__/job-definition-base.test.ts.snap
@@ -60,8 +60,7 @@ exports[`JobDefinitionBase synth EcsJobDefinition synthesizes and matches snapsh
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -115,7 +114,7 @@ exports[`JobDefinitionBase synth EcsJobDefinition synthesizes and matches snapsh
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -182,8 +181,7 @@ exports[`JobDefinitionBase synth MultiNodeJobDefinition synthesizes and matches 
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -230,7 +228,7 @@ exports[`JobDefinitionBase synth MultiNodeJobDefinition synthesizes and matches 
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/batch/__snapshots__/job-queue.test.ts.snap
+++ b/test/aws/compute/batch/__snapshots__/job-queue.test.ts.snap
@@ -51,8 +51,7 @@ exports[`JobQueue (job-queue.test.ts snapshot) Should synth and match SnapShot 1
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -461,7 +460,7 @@ exports[`JobQueue (job-queue.test.ts snapshot) Should synth and match SnapShot 1
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -519,8 +518,7 @@ exports[`JobQueue (job-queue.test.ts snapshot) Should synth with schedulingPolic
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -584,8 +582,7 @@ exports[`JobQueue (job-queue.test.ts snapshot) Should synth with schedulingPolic
     "aws_batch_scheduling_policy": {
       "FairsharePolicy_A0C549BE": {
         "fair_share_policy": {
-          "share_distribution": [
-          ]
+          "share_distribution": []
         },
         "name": "g-FairsharePolicy",
         "tags": {
@@ -952,7 +949,7 @@ exports[`JobQueue (job-queue.test.ts snapshot) Should synth with schedulingPolic
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/batch/__snapshots__/managed-compute-environment.test.ts.snap
+++ b/test/aws/compute/batch/__snapshots__/managed-compute-environment.test.ts.snap
@@ -26,8 +26,7 @@ exports[`ManagedComputeEnvironment synth FargateComputeEnvironment synthesizes a
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -384,7 +383,7 @@ exports[`ManagedComputeEnvironment synth FargateComputeEnvironment synthesizes a
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -442,8 +441,7 @@ exports[`ManagedComputeEnvironment synth ManagedEc2EcsComputeEnvironment synthes
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -834,7 +832,7 @@ exports[`ManagedComputeEnvironment synth ManagedEc2EcsComputeEnvironment synthes
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/batch/__snapshots__/multinode-job-definition.test.ts.snap
+++ b/test/aws/compute/batch/__snapshots__/multinode-job-definition.test.ts.snap
@@ -92,8 +92,7 @@ exports[`MultiNodeJobDefinition Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -155,7 +154,7 @@ exports[`MultiNodeJobDefinition Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/batch/__snapshots__/scheduling-policy.test.ts.snap
+++ b/test/aws/compute/batch/__snapshots__/scheduling-policy.test.ts.snap
@@ -21,16 +21,14 @@ exports[`FairshareSchedulingPolicy Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
     "aws_batch_scheduling_policy": {
       "schedulingPolicy_EF30C9A9": {
         "fair_share_policy": {
-          "share_distribution": [
-          ]
+          "share_distribution": []
         },
         "name": "gTestStack553BDD39-TestStackschedulingPolicy1129156A",
         "tags": {
@@ -50,7 +48,7 @@ exports[`FairshareSchedulingPolicy Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -78,8 +76,7 @@ exports[`FairshareSchedulingPolicy Should synth and match SnapShot with shares a
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -117,7 +114,7 @@ exports[`FairshareSchedulingPolicy Should synth and match SnapShot with shares a
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/batch/__snapshots__/unmanaged-compute-environment.test.ts.snap
+++ b/test/aws/compute/batch/__snapshots__/unmanaged-compute-environment.test.ts.snap
@@ -46,8 +46,7 @@ exports[`UnmanagedComputeEnvironment Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -91,7 +90,7 @@ exports[`UnmanagedComputeEnvironment Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/__snapshots__/alternate-target-configuration.test.ts.snap
+++ b/test/aws/compute/ecs/__snapshots__/alternate-target-configuration.test.ts.snap
@@ -76,8 +76,7 @@ exports[`AlternateTarget snapshot Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -675,7 +674,7 @@ exports[`AlternateTarget snapshot Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/__snapshots__/amis.test.ts.snap
+++ b/test/aws/compute/ecs/__snapshots__/amis.test.ts.snap
@@ -26,8 +26,7 @@ exports[`amis synth BottleRocketImage synth matches snapshot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "terraform": {
@@ -39,7 +38,7 @@ exports[`amis synth BottleRocketImage synth matches snapshot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/__snapshots__/app-mesh-proxy-configuration.test.ts.snap
+++ b/test/aws/compute/ecs/__snapshots__/app-mesh-proxy-configuration.test.ts.snap
@@ -46,8 +46,7 @@ exports[`AppMeshProxyConfiguration Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -101,7 +100,7 @@ exports[`AppMeshProxyConfiguration Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/__snapshots__/aws-log-driver.test.ts.snap
+++ b/test/aws/compute/ecs/__snapshots__/aws-log-driver.test.ts.snap
@@ -78,8 +78,7 @@ exports[`aws log driver synth Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -150,7 +149,7 @@ exports[`aws log driver synth Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/__snapshots__/base-service.test.ts.snap
+++ b/test/aws/compute/ecs/__snapshots__/base-service.test.ts.snap
@@ -51,8 +51,7 @@ exports[`base-service synth FargateService with default properties should synth 
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -465,7 +464,7 @@ exports[`base-service synth FargateService with default properties should synth 
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -565,8 +564,7 @@ exports[`base-service synth FargateService with service connect and TLS should s
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -1017,7 +1015,7 @@ exports[`base-service synth FargateService with service connect and TLS should s
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/__snapshots__/cluster.test.ts.snap
+++ b/test/aws/compute/ecs/__snapshots__/cluster.test.ts.snap
@@ -26,8 +26,7 @@ exports[`cluster synth Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -259,7 +258,7 @@ exports[`cluster synth Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -292,8 +291,7 @@ exports[`cluster synth Should synth and match SnapShot with Fargate capacity pro
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -541,7 +539,7 @@ exports[`cluster synth Should synth and match SnapShot with Fargate capacity pro
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -809,12 +807,10 @@ exports[`cluster synth Should synth and match SnapShot with capacity 1`] = `
   },
   "provider": {
     "archive": [
-      {
-      }
+      {}
     ],
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -1372,7 +1368,7 @@ exports[`cluster synth Should synth and match SnapShot with capacity 1`] = `
       },
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/__snapshots__/container-definition.test.ts.snap
+++ b/test/aws/compute/ecs/__snapshots__/container-definition.test.ts.snap
@@ -99,8 +99,7 @@ exports[`container definition synth ContainerDefinition with a broad set of prop
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -185,7 +184,7 @@ exports[`container definition synth ContainerDefinition with a broad set of prop
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/__snapshots__/deployment-lifecycle-hook-target.test.ts.snap
+++ b/test/aws/compute/ecs/__snapshots__/deployment-lifecycle-hook-target.test.ts.snap
@@ -135,12 +135,10 @@ exports[`DeploymentLifecycleHookTarget synth default role and multiple lifecycle
   },
   "provider": {
     "archive": [
-      {
-      }
+      {}
     ],
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -332,8 +330,7 @@ exports[`DeploymentLifecycleHookTarget synth default role and multiple lifecycle
           "aws_iam_role_policy.TestFunction_ServiceRole_DefaultPolicy_ResourceRoles0_CDD32B69"
         ],
         "environment": {
-          "variables": {
-          }
+          "variables": {}
         },
         "filename": "\${data.archive_file.TestFunction_TestStackTestFunction5a9773525b9524a75790400a170a3d638094377B_097B9965.output_path}",
         "function_name": "gTestStack553BDD39-stStackTestFunction",
@@ -649,7 +646,7 @@ exports[`DeploymentLifecycleHookTarget synth default role and multiple lifecycle
       },
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/__snapshots__/environment-file.test.ts.snap
+++ b/test/aws/compute/ecs/__snapshots__/environment-file.test.ts.snap
@@ -46,8 +46,7 @@ exports[`EnvironmentFile synth EnvironmentFile.fromAsset synth matches snapshot 
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -101,7 +100,7 @@ exports[`EnvironmentFile synth EnvironmentFile.fromAsset synth matches snapshot 
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -154,8 +153,7 @@ exports[`EnvironmentFile synth EnvironmentFile.fromBucket synth matches snapshot
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -206,7 +204,7 @@ exports[`EnvironmentFile synth EnvironmentFile.fromBucket synth matches snapshot
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/__snapshots__/firelens-log-driver.test.ts.snap
+++ b/test/aws/compute/ecs/__snapshots__/firelens-log-driver.test.ts.snap
@@ -95,8 +95,7 @@ exports[`firelens log driver snapshots Should synth and match SnapShot with defa
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -158,7 +157,7 @@ exports[`firelens log driver snapshots Should synth and match SnapShot with defa
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -296,8 +295,7 @@ exports[`firelens log driver snapshots Should synth and match SnapShot with secr
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -382,7 +380,7 @@ exports[`firelens log driver snapshots Should synth and match SnapShot with secr
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/__snapshots__/fluentd-log-driver.test.ts.snap
+++ b/test/aws/compute/ecs/__snapshots__/fluentd-log-driver.test.ts.snap
@@ -46,8 +46,7 @@ exports[`FluentdLogDriver Should synth and match SnapShot with all possible opti
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -88,7 +87,7 @@ exports[`FluentdLogDriver Should synth and match SnapShot with all possible opti
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/__snapshots__/gelf-log-driver.test.ts.snap
+++ b/test/aws/compute/ecs/__snapshots__/gelf-log-driver.test.ts.snap
@@ -46,8 +46,7 @@ exports[`gelf log driver synth Should synth and match SnapShot with minimum opti
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -88,7 +87,7 @@ exports[`gelf log driver synth Should synth and match SnapShot with minimum opti
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/__snapshots__/journald-log-driver.test.ts.snap
+++ b/test/aws/compute/ecs/__snapshots__/journald-log-driver.test.ts.snap
@@ -46,8 +46,7 @@ exports[`JournaldLogDriver Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -88,7 +87,7 @@ exports[`JournaldLogDriver Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/__snapshots__/json-file-log-driver.test.ts.snap
+++ b/test/aws/compute/ecs/__snapshots__/json-file-log-driver.test.ts.snap
@@ -46,8 +46,7 @@ exports[`json file log driver synth Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -88,7 +87,7 @@ exports[`json file log driver synth Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/__snapshots__/splunk-log-driver.test.ts.snap
+++ b/test/aws/compute/ecs/__snapshots__/splunk-log-driver.test.ts.snap
@@ -78,8 +78,7 @@ exports[`SplunkLogDriver Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -137,7 +136,7 @@ exports[`SplunkLogDriver Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -229,8 +228,7 @@ exports[`SplunkLogDriver Should synth and match SnapShot with sourceType and ssm
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -288,7 +286,7 @@ exports[`SplunkLogDriver Should synth and match SnapShot with sourceType and ssm
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/__snapshots__/syslog-log-driver.test.ts.snap
+++ b/test/aws/compute/ecs/__snapshots__/syslog-log-driver.test.ts.snap
@@ -46,8 +46,7 @@ exports[`SyslogLogDriver Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -88,7 +87,7 @@ exports[`SyslogLogDriver Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/__snapshots__/task-definition.test.ts.snap
+++ b/test/aws/compute/ecs/__snapshots__/task-definition.test.ts.snap
@@ -46,8 +46,7 @@ exports[`TaskDefinition Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -91,7 +90,7 @@ exports[`TaskDefinition Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/ec2/__snapshots__/cross-stack.test.ts.snap
+++ b/test/aws/compute/ecs/ec2/__snapshots__/cross-stack.test.ts.snap
@@ -139,8 +139,7 @@ exports[`cross stack synth Should synth ALB next to Service and match SnapShot 1
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -202,8 +201,7 @@ exports[`cross stack synth Should synth ALB next to Service and match SnapShot 1
           "\${aws_ecs_capacity_provider.AsgCapacityProvider_760D11D9.name}"
         ],
         "cluster_name": "\${aws_ecs_cluster.Cluster_EB0386A7.name}",
-        "default_capacity_provider_strategy": [
-        ]
+        "default_capacity_provider_strategy": []
       }
     },
     "aws_eip": {
@@ -601,7 +599,7 @@ exports[`cross stack synth Should synth ALB next to Service and match SnapShot 1
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -662,8 +660,7 @@ exports[`cross stack synth Should synth ALB next to Service and match SnapShot 2
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -855,7 +852,7 @@ exports[`cross stack synth Should synth ALB next to Service and match SnapShot 2
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/ec2/__snapshots__/ec2-service.test.ts.snap
+++ b/test/aws/compute/ecs/ec2/__snapshots__/ec2-service.test.ts.snap
@@ -134,8 +134,7 @@ exports[`ec2 service synth Ec2Service with all properties set should synth and m
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -197,8 +196,7 @@ exports[`ec2 service synth Ec2Service with all properties set should synth and m
           "\${aws_ecs_capacity_provider.AsgCapacityProvider_760D11D9.name}"
         ],
         "cluster_name": "\${aws_ecs_cluster.EcsCluster_97242B84.name}",
-        "default_capacity_provider_strategy": [
-        ]
+        "default_capacity_provider_strategy": []
       }
     },
     "aws_ecs_service": {
@@ -738,7 +736,7 @@ exports[`ec2 service synth Ec2Service with all properties set should synth and m
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -879,8 +877,7 @@ exports[`ec2 service synth Ec2Service with only required properties set should s
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -942,8 +939,7 @@ exports[`ec2 service synth Ec2Service with only required properties set should s
           "\${aws_ecs_capacity_provider.AsgCapacityProvider_760D11D9.name}"
         ],
         "cluster_name": "\${aws_ecs_cluster.EcsCluster_97242B84.name}",
-        "default_capacity_provider_strategy": [
-        ]
+        "default_capacity_provider_strategy": []
       }
     },
     "aws_ecs_service": {
@@ -1393,7 +1389,7 @@ exports[`ec2 service synth Ec2Service with only required properties set should s
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/ec2/__snapshots__/ec2-task-definition.test.ts.snap
+++ b/test/aws/compute/ecs/ec2/__snapshots__/ec2-task-definition.test.ts.snap
@@ -46,8 +46,7 @@ exports[`Ec2TaskDefinition synth Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -94,7 +93,7 @@ exports[`Ec2TaskDefinition synth Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/external/__snapshots__/external-service.test.ts.snap
+++ b/test/aws/compute/ecs/external/__snapshots__/external-service.test.ts.snap
@@ -134,8 +134,7 @@ exports[`external service synth ExternalService with only required properties sh
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -197,8 +196,7 @@ exports[`external service synth ExternalService with only required properties sh
           "\${aws_ecs_capacity_provider.AsgCapacityProvider_760D11D9.name}"
         ],
         "cluster_name": "\${aws_ecs_cluster.EcsCluster_97242B84.name}",
-        "default_capacity_provider_strategy": [
-        ]
+        "default_capacity_provider_strategy": []
       }
     },
     "aws_ecs_service": {
@@ -647,7 +645,7 @@ exports[`external service synth ExternalService with only required properties sh
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/external/__snapshots__/external-task-definition.test.ts.snap
+++ b/test/aws/compute/ecs/external/__snapshots__/external-task-definition.test.ts.snap
@@ -78,8 +78,7 @@ exports[`ExternalTaskDefinition synth Should synth and match SnapShot with a ful
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -148,7 +147,7 @@ exports[`ExternalTaskDefinition synth Should synth and match SnapShot with a ful
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -201,8 +200,7 @@ exports[`ExternalTaskDefinition synth Should synth and match SnapShot with defau
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -243,7 +241,7 @@ exports[`ExternalTaskDefinition synth Should synth and match SnapShot with defau
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/fargate/__snapshots__/fargate-service.test.ts.snap
+++ b/test/aws/compute/ecs/fargate/__snapshots__/fargate-service.test.ts.snap
@@ -72,8 +72,7 @@ exports[`fargate service synth FargateService with a managed EBS volume should s
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -515,7 +514,7 @@ exports[`fargate service synth FargateService with a managed EBS volume should s
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -573,8 +572,7 @@ exports[`fargate service synth FargateService with all properties set should syn
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -1033,7 +1031,7 @@ exports[`fargate service synth FargateService with all properties set should syn
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -1091,8 +1089,7 @@ exports[`fargate service synth FargateService with an application load balancer 
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -1627,7 +1624,7 @@ exports[`fargate service synth FargateService with an application load balancer 
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -1685,8 +1682,7 @@ exports[`fargate service synth FargateService with only required properties set 
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -2099,7 +2095,7 @@ exports[`fargate service synth FargateService with only required properties set 
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -2157,8 +2153,7 @@ exports[`fargate service synth FargateService with service connect should synth 
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -2598,7 +2593,7 @@ exports[`fargate service synth FargateService with service connect should synth 
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/fargate/__snapshots__/fargate-task-definition.test.ts.snap
+++ b/test/aws/compute/ecs/fargate/__snapshots__/fargate-task-definition.test.ts.snap
@@ -81,8 +81,7 @@ exports[`fargate task definition synth FargateTaskDefinition with all properties
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -150,7 +149,7 @@ exports[`fargate task definition synth FargateTaskDefinition with all properties
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/compute/ecs/images/__snapshots__/tag-parameter-container-image.test.ts.snap
+++ b/test/aws/compute/ecs/images/__snapshots__/tag-parameter-container-image.test.ts.snap
@@ -88,8 +88,7 @@ exports[`tag parameter container image synth TagParameterContainerImage synth ma
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -159,7 +158,7 @@ exports[`tag parameter container image synth TagParameterContainerImage synth ma
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   },

--- a/test/aws/edge/__snapshots__/certificate.test.ts.snap
+++ b/test/aws/edge/__snapshots__/certificate.test.ts.snap
@@ -21,8 +21,7 @@ exports[`PublicCertificate Create multi-zone should synth and match SnapShot 1`]
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -109,7 +108,7 @@ exports[`PublicCertificate Create multi-zone should synth and match SnapShot 1`]
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -137,8 +136,7 @@ exports[`PublicCertificate Create should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -200,7 +198,7 @@ exports[`PublicCertificate Create should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -233,8 +231,7 @@ exports[`PublicCertificate Imported DnsZone should synth and match SnapShot 1`] 
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -283,7 +280,7 @@ exports[`PublicCertificate Imported DnsZone should synth and match SnapShot 1`] 
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/edge/__snapshots__/distribution.test.ts.snap
+++ b/test/aws/edge/__snapshots__/distribution.test.ts.snap
@@ -26,8 +26,7 @@ exports[`Distribution Should support multiple origins and cache behaviors 1`] = 
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -151,7 +150,7 @@ exports[`Distribution Should support multiple origins and cache behaviors 1`] = 
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -207,8 +206,7 @@ exports[`Distribution Should synth with OAI and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -287,7 +285,7 @@ exports[`Distribution Should synth with OAI and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -320,8 +318,7 @@ exports[`Distribution Should synth with websiteConfig and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -402,7 +399,7 @@ exports[`Distribution Should synth with websiteConfig and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/edge/__snapshots__/dns.test.ts.snap
+++ b/test/aws/edge/__snapshots__/dns.test.ts.snap
@@ -26,8 +26,7 @@ exports[`DnsZone Create should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -205,7 +204,7 @@ exports[`DnsZone Create should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -238,8 +237,7 @@ exports[`DnsZone Import should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -268,7 +266,7 @@ exports[`DnsZone Import should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/edge/__snapshots__/key-value-store.test.ts.snap
+++ b/test/aws/edge/__snapshots__/key-value-store.test.ts.snap
@@ -21,8 +21,7 @@ exports[`KeyValueStore Should associate with edge.Function and match SnapShot 1`
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -45,7 +44,12 @@ exports[`KeyValueStore Should associate with edge.Function and match SnapShot 1`
     },
     "aws_cloudfront_key_value_store": {
       "Store_1D2A845B": {
-        "name": "g-hello-world"
+        "name": "g-hello-world",
+        "tags": {
+          "Name": "Default-Store",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "g"
+        }
       }
     },
     "aws_cloudfrontkeyvaluestore_key": {
@@ -65,7 +69,7 @@ exports[`KeyValueStore Should associate with edge.Function and match SnapShot 1`
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -93,14 +97,18 @@ exports[`KeyValueStore Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
     "aws_cloudfront_key_value_store": {
       "Store_1D2A845B": {
-        "name": "g-hello-world"
+        "name": "g-hello-world",
+        "tags": {
+          "Name": "Default-Store",
+          "grid:EnvironmentName": "Default",
+          "grid:UUID": "g"
+        }
       }
     },
     "aws_cloudfrontkeyvaluestore_key": {
@@ -125,7 +133,7 @@ exports[`KeyValueStore Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/edge/cloudmap/__snapshots__/instance.test.ts.snap
+++ b/test/aws/edge/cloudmap/__snapshots__/instance.test.ts.snap
@@ -21,8 +21,7 @@ exports[`Instance Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -68,7 +67,7 @@ exports[`Instance Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/edge/cloudmap/__snapshots__/namespace.test.ts.snap
+++ b/test/aws/edge/cloudmap/__snapshots__/namespace.test.ts.snap
@@ -21,8 +21,7 @@ exports[`namespace snapshots HTTP namespace should synth and match SnapShot 1`] 
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -46,7 +45,7 @@ exports[`namespace snapshots HTTP namespace should synth and match SnapShot 1`] 
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -79,8 +78,7 @@ exports[`namespace snapshots Private DNS namespace should synth and match SnapSh
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -397,7 +395,7 @@ exports[`namespace snapshots Private DNS namespace should synth and match SnapSh
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -425,8 +423,7 @@ exports[`namespace snapshots Public DNS namespace should synth and match SnapSho
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -450,7 +447,7 @@ exports[`namespace snapshots Public DNS namespace should synth and match SnapSho
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/edge/cloudmap/__snapshots__/service.test.ts.snap
+++ b/test/aws/edge/cloudmap/__snapshots__/service.test.ts.snap
@@ -21,8 +21,7 @@ exports[`service snapshots Service for HTTP namespace should synth and match Sna
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -61,7 +60,7 @@ exports[`service snapshots Service for HTTP namespace should synth and match Sna
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -94,8 +93,7 @@ exports[`service snapshots Service for Private DNS namespace should synth and ma
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -434,7 +432,7 @@ exports[`service snapshots Service for Private DNS namespace should synth and ma
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -462,8 +460,7 @@ exports[`service snapshots Service for Public DNS namespace should synth and mat
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -512,7 +509,7 @@ exports[`service snapshots Service for Public DNS namespace should synth and mat
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/encryption/__snapshots__/policy.test.ts.snap
+++ b/test/aws/encryption/__snapshots__/policy.test.ts.snap
@@ -10,8 +10,7 @@ exports[`ResourcePolicy Should synth and match SnapShot 1`] = `
     },
     "aws_iam_policy_document": {
       "Policy_C96C8195": {
-        "statement": [
-        ]
+        "statement": []
       }
     },
     "aws_partition": {
@@ -38,8 +37,7 @@ exports[`ResourcePolicy Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -75,7 +73,7 @@ exports[`ResourcePolicy Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/encryption/__snapshots__/rotation-schedule.test.ts.snap
+++ b/test/aws/encryption/__snapshots__/rotation-schedule.test.ts.snap
@@ -122,12 +122,10 @@ exports[`RotationSchedule Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "archive": [
-      {
-      }
+      {}
     ],
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -179,8 +177,7 @@ exports[`RotationSchedule Should synth and match SnapShot 1`] = `
           "aws_iam_role_policy.Lambda_ServiceRole_DefaultPolicy_ResourceRoles0_DE66D1AF"
         ],
         "environment": {
-          "variables": {
-          }
+          "variables": {}
         },
         "filename": "\${data.archive_file.Lambda_Lambda977ac4c4b02ffbf33727a2b3dfd94f40A3E2D98D_FA6D0A46.output_path}",
         "function_name": "g-Lambda",
@@ -255,7 +252,7 @@ exports[`RotationSchedule Should synth and match SnapShot 1`] = `
       },
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/encryption/__snapshots__/secret.test.ts.snap
+++ b/test/aws/encryption/__snapshots__/secret.test.ts.snap
@@ -59,7 +59,7 @@ exports[`default secret 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -279,7 +279,7 @@ exports[`grantRead cross account 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -511,7 +511,7 @@ exports[`grantRead with KMS Key 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -753,7 +753,7 @@ exports[`grantRead with version label constraint 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -988,7 +988,7 @@ exports[`grantWrite with kms 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -1082,7 +1082,7 @@ exports[`secret with generate secret string excludeCharacters 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -1148,7 +1148,7 @@ exports[`secret with generate secret string options 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -1304,7 +1304,7 @@ exports[`secret with kms 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -1375,7 +1375,7 @@ exports[`secretName is simply the first segment when the provided secret name ha
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -1446,7 +1446,7 @@ exports[`secretName selects the 2 parts of the resource name when the secret nam
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -1517,7 +1517,7 @@ exports[`secretName selects the 3 parts of the resource name when the secret nam
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -1588,7 +1588,7 @@ exports[`secretName selects the 4 parts of the resource name when the secret nam
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -1659,7 +1659,7 @@ exports[`secretName selects the first two parts of the resource name when the na
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -1750,7 +1750,7 @@ exports[`secretObjectValue can be used with a mixture of plain text and a resolv
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -1841,7 +1841,7 @@ exports[`secretStringValue can reference an arbitrary resolvable token 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -1907,7 +1907,7 @@ exports[`templated secret string 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/iam/__snapshots__/policy-statement.test.ts.snap
+++ b/test/aws/iam/__snapshots__/policy-statement.test.ts.snap
@@ -54,15 +54,14 @@ exports[`IAM policy statement from JSON parses a given Principal 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "terraform": {
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -123,15 +122,14 @@ exports[`IAM policy statement from JSON parses a given notPrincipal 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "terraform": {
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -184,15 +182,14 @@ exports[`IAM policy statement from JSON parses with no principal 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "terraform": {
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -235,15 +232,14 @@ exports[`IAM policy statement from JSON parses with notAction 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "terraform": {
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -287,15 +283,14 @@ exports[`IAM policy statement from JSON parses with notActions 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "terraform": {
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -339,15 +334,14 @@ exports[`IAM policy statement from JSON parses with notResource 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "terraform": {
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -392,15 +386,14 @@ exports[`IAM policy statement from JSON parses with notResources 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "terraform": {
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -451,15 +444,14 @@ exports[`IAM policy statement from JSON should not convert \`Principal: *\` to \
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "terraform": {
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -534,15 +526,14 @@ exports[`IAM policy statement from JSON the kitchen sink 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "terraform": {
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/network/__snapshots__/simple-ipv4-vpc.test.ts.snap
+++ b/test/aws/network/__snapshots__/simple-ipv4-vpc.test.ts.snap
@@ -26,8 +26,7 @@ exports[`Environment Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -288,7 +287,7 @@ exports[`Environment Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/notify/__snapshots__/queue.test.ts.snap
+++ b/test/aws/notify/__snapshots__/queue.test.ts.snap
@@ -21,8 +21,7 @@ exports[`Queue Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -46,7 +45,7 @@ exports[`Queue Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -74,8 +73,7 @@ exports[`Queue Should synth and match SnapShot with prefix 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -102,7 +100,7 @@ exports[`Queue Should synth and match SnapShot with prefix 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -130,8 +128,7 @@ exports[`Queue Should synth with DLQ and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -170,7 +167,7 @@ exports[`Queue Should synth with DLQ and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -198,8 +195,7 @@ exports[`Queue Should synth with contentBasedDeduplication and match SnapShot 1`
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -228,7 +224,7 @@ exports[`Queue Should synth with contentBasedDeduplication and match SnapShot 1`
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -256,8 +252,7 @@ exports[`Queue Should synth with fifo suffix and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -285,7 +280,7 @@ exports[`Queue Should synth with fifo suffix and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/storage/__snapshots__/bucket.test.ts.snap
+++ b/test/aws/storage/__snapshots__/bucket.test.ts.snap
@@ -34,8 +34,7 @@ exports[`Bucket Should support multiple sources 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -73,8 +72,8 @@ exports[`Bucket Should support multiple sources 1`] = `
           "time_sleep.HelloWorld_VersioningSleep_FC16C7EC"
         ],
         "key": "/images/officespace-great.jpg",
-        "source": "assets/HelloWorld_source-0_PathAsset_B9F685AE/7C1CC84268AB29AAED03995506EAD038/images/officespace-great.jpg",
-        "source_hash": "\${filemd5(\\"assets/HelloWorld_source-0_PathAsset_B9F685AE/7C1CC84268AB29AAED03995506EAD038/images/officespace-great.jpg\\")}",
+        "source": "assets/HelloWorld_source-0_PathAsset_B9F685AE/8B4CCF788363CCDB02792BDB4DABA467/images/officespace-great.jpg",
+        "source_hash": "\${filemd5(\\"assets/HelloWorld_source-0_PathAsset_B9F685AE/8B4CCF788363CCDB02792BDB4DABA467/images/officespace-great.jpg\\")}",
         "tags": {
           "Name": "Default-HelloWorld",
           "grid:EnvironmentName": "Default",
@@ -88,8 +87,8 @@ exports[`Bucket Should support multiple sources 1`] = `
           "time_sleep.HelloWorld_VersioningSleep_FC16C7EC"
         ],
         "key": "/index.html",
-        "source": "assets/HelloWorld_source-0_PathAsset_B9F685AE/7C1CC84268AB29AAED03995506EAD038/index.html",
-        "source_hash": "\${filemd5(\\"assets/HelloWorld_source-0_PathAsset_B9F685AE/7C1CC84268AB29AAED03995506EAD038/index.html\\")}",
+        "source": "assets/HelloWorld_source-0_PathAsset_B9F685AE/8B4CCF788363CCDB02792BDB4DABA467/index.html",
+        "source_hash": "\${filemd5(\\"assets/HelloWorld_source-0_PathAsset_B9F685AE/8B4CCF788363CCDB02792BDB4DABA467/index.html\\")}",
         "tags": {
           "Name": "Default-HelloWorld",
           "grid:EnvironmentName": "Default",
@@ -103,8 +102,8 @@ exports[`Bucket Should support multiple sources 1`] = `
           "time_sleep.HelloWorld_VersioningSleep_FC16C7EC"
         ],
         "key": "/sample.html",
-        "source": "assets/HelloWorld_source-1_PathAsset_F1F0E41E/5E8FF9BF55BA3508199D22E984129BE6/sample.html",
-        "source_hash": "\${filemd5(\\"assets/HelloWorld_source-1_PathAsset_F1F0E41E/5E8FF9BF55BA3508199D22E984129BE6/sample.html\\")}",
+        "source": "assets/HelloWorld_source-1_PathAsset_F1F0E41E/DE70539DC27B7BC23E6B5BC3AC64A298/sample.html",
+        "source_hash": "\${filemd5(\\"assets/HelloWorld_source-1_PathAsset_F1F0E41E/DE70539DC27B7BC23E6B5BC3AC64A298/sample.html\\")}",
         "tags": {
           "Name": "Default-HelloWorld",
           "grid:EnvironmentName": "Default",
@@ -127,7 +126,7 @@ exports[`Bucket Should support multiple sources 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -178,8 +177,7 @@ exports[`Bucket Should synth and match SnapShot 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -239,8 +237,8 @@ exports[`Bucket Should synth and match SnapShot 1`] = `
         "bucket": "\${aws_s3_bucket.HelloWorld_7964D1E8.bucket}",
         "content_type": "image/jpeg",
         "key": "/images/officespace-great.jpg",
-        "source": "assets/HelloWorld_source-0_PathAsset_B9F685AE/7C1CC84268AB29AAED03995506EAD038/images/officespace-great.jpg",
-        "source_hash": "\${filemd5(\\"assets/HelloWorld_source-0_PathAsset_B9F685AE/7C1CC84268AB29AAED03995506EAD038/images/officespace-great.jpg\\")}",
+        "source": "assets/HelloWorld_source-0_PathAsset_B9F685AE/8B4CCF788363CCDB02792BDB4DABA467/images/officespace-great.jpg",
+        "source_hash": "\${filemd5(\\"assets/HelloWorld_source-0_PathAsset_B9F685AE/8B4CCF788363CCDB02792BDB4DABA467/images/officespace-great.jpg\\")}",
         "tags": {
           "Name": "Default-HelloWorld",
           "grid:EnvironmentName": "Default",
@@ -251,8 +249,8 @@ exports[`Bucket Should synth and match SnapShot 1`] = `
         "bucket": "\${aws_s3_bucket.HelloWorld_7964D1E8.bucket}",
         "content_type": "text/html; charset=utf-8",
         "key": "/index.html",
-        "source": "assets/HelloWorld_source-0_PathAsset_B9F685AE/7C1CC84268AB29AAED03995506EAD038/index.html",
-        "source_hash": "\${filemd5(\\"assets/HelloWorld_source-0_PathAsset_B9F685AE/7C1CC84268AB29AAED03995506EAD038/index.html\\")}",
+        "source": "assets/HelloWorld_source-0_PathAsset_B9F685AE/8B4CCF788363CCDB02792BDB4DABA467/index.html",
+        "source_hash": "\${filemd5(\\"assets/HelloWorld_source-0_PathAsset_B9F685AE/8B4CCF788363CCDB02792BDB4DABA467/index.html\\")}",
         "tags": {
           "Name": "Default-HelloWorld",
           "grid:EnvironmentName": "Default",
@@ -270,7 +268,7 @@ exports[`Bucket Should synth and match SnapShot 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }

--- a/test/aws/storage/__snapshots__/notification.test.ts.snap
+++ b/test/aws/storage/__snapshots__/notification.test.ts.snap
@@ -21,8 +21,7 @@ exports[`notification can specify prefix and suffix filter rules 1`] = `
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -62,7 +61,7 @@ exports[`notification can specify prefix and suffix filter rules 1`] = `
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }
@@ -90,8 +89,7 @@ exports[`notification when notification is added a custom s3 bucket notification
   },
   "provider": {
     "aws": [
-      {
-      }
+      {}
     ]
   },
   "resource": {
@@ -121,7 +119,7 @@ exports[`notification when notification is added a custom s3 bucket notification
     "required_providers": {
       "aws": {
         "source": "hashicorp/aws",
-        "version": "6.52.0"
+        "version": "6.58.0"
       }
     }
   }


### PR DESCRIPTION
## Upgrade to cdktn 0.24 and refresh dependency tree

Upgrades the core framework and all provider packages to their cdktn 0.24-compatible majors. Bumps bundled and peer dependencies to current versions.

### Breaking changes
- Minimum Node version raised from 20.9 to 22 (cdktn 0.24 requirement)
- `constructs` peer range narrowed to `>=10.6.0 <10.8.0`

### Dependency upgrades
| Package | Before | After |
|---------|--------|-------|
| cdktn | 0.23.0 | 0.24.0 |
| @cdktn/provider-aws | 24.8.0 | 25.0.0 |
| @cdktn/provider-time | 13.1.0 | 14.0.0 |
| @cdktn/provider-archive | 13.1.0 | 14.0.0 |
| @cdktn/provider-tls | 13.1.0 | 14.0.0 |
| @cdktn/provider-cloudinit | 13.1.0 | 14.0.0 |
| @cdktn/provider-docker | 15.3.0 | 16.0.0 |
| @aws-cdk/cloud-assembly-schema | 49.4.0 | 54.17.0 |
| change-case | ^4.1.1 | ^5.4.4 |
| ignore | ^5.3.2 | ^7.0.6 |

### Notes
- `change-case` v5 is ESM-only; switched to `require()` with type annotation in `src/aws/util.ts` and configured jest to transform the package for tests.
- Generated struct files updated to match new provider schemas.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.