### PR TITLE
fix(ecs): omit empty capabilities block and allow runtimePlatform on EC2 task definitions

### DIFF
--- a/src/aws/compute/ecs/base/base-service.ts
+++ b/src/aws/compute/ecs/base/base-service.ts
@@ -910,10 +910,13 @@ export abstract class BaseService
             rollback: props.circuitBreaker.rollback ?? false,
           }
         : undefined,
+      // TERRACONSTRUCTS DEVIATION: upstream (aws-ecs/lib/base/base-service.ts:743) emits
+      // `props.propagateTags` here, which silently drops the value when only the deprecated
+      // `propagateTaskTagsFrom` alias is set. Emit the resolved `propagateTagsFromSource` instead.
       propagateTags:
         propagateTagsFromSource === PropagatedTagSource.NONE
           ? undefined
-          : props.propagateTags,
+          : propagateTagsFromSource,
       enableEcsManagedTags: props.enableECSManagedTags ?? false,
       deploymentController: deploymentController,
       launchType: launchType,

--- a/src/aws/compute/ecs/base/task-definition.ts
+++ b/src/aws/compute/ecs/base/task-definition.ts
@@ -259,7 +259,8 @@ export interface TaskDefinitionProps extends CommonTaskDefinitionProps {
   /**
    * The operating system that your task definitions are running on.
    *
-   * A runtimePlatform is supported only for tasks using the Fargate launch type.
+   * Supported for tasks using the Fargate, EC2 and Managed Instances launch
+   * types. Not supported for External (ECS Anywhere) tasks.
    *
    * @default - Undefined.
    */
@@ -632,13 +633,16 @@ export class TaskDefinition extends TaskDefinitionBase {
       }
     }
 
-    if (
-      !this.isFargateCompatible &&
-      !this.isManagedInstancesCompatible &&
-      props.runtimePlatform
-    ) {
+    // TERRACONSTRUCTS DEVIATION: upstream rejects `runtimePlatform` on every non-Fargate,
+    // non-Managed-Instances task definition (aws-cdk-lib/aws-ecs/lib/base/task-definition.ts:522).
+    // Neither the ECS RegisterTaskDefinition API (cpuArchitecture is documented for "Linux Amazon
+    // EC2 instance" tasks, and the WINDOWS_SERVER_2016_FULL / _2004_CORE / _20H2_CORE families are
+    // EC2-only) nor terraform-provider-aws (`runtime_platform` on `aws_ecs_task_definition` is not
+    // gated on `requires_compatibilities`) has that restriction. Only EXTERNAL (ECS Anywhere)
+    // tasks, which run on customer-managed hardware ECS does not choose a platform for, keep it.
+    if (this.isExternalCompatible && props.runtimePlatform) {
       throw new ValidationError(
-        "Cannot specify runtimePlatform in non-Fargate and non-Managed Instances compatible tasks",
+        "Cannot specify runtimePlatform in External compatible tasks",
         this,
       );
     }
@@ -672,7 +676,13 @@ export class TaskDefinition extends TaskDefinitionBase {
     this.pidMode = props.pidMode;
 
     // validate the cpu and memory size for the Windows operation system family.
-    if (props.runtimePlatform?.operatingSystemFamily?.isWindows()) {
+    // NOTE: must stay gated on `isFargateCompatible` -- these are Fargate-only cpu/memory
+    // combinations, and EC2 Windows tasks legitimately leave cpu/memoryMiB undefined (which would
+    // make the checks below compare `Number(undefined)` === NaN and throw a bogus Fargate error).
+    if (
+      this.isFargateCompatible &&
+      props.runtimePlatform?.operatingSystemFamily?.isWindows()
+    ) {
       // We know that props.cpu and props.memoryMiB are defined because an error would have been thrown previously if they were not.
       // But, typescript is not able to figure this out, so using the `!` operator here to let the type-checker know they are defined.
       this.checkFargateWindowsBasedTasksSize(
@@ -756,17 +766,15 @@ export class TaskDefinition extends TaskDefinitionBase {
             sizeInGib: this.ephemeralStorageGiB,
           }
         : undefined,
-      runtimePlatform:
-        (this.isFargateCompatible || this.isManagedInstancesCompatible) &&
-        this.runtimePlatform
-          ? {
-              cpuArchitecture:
-                this.runtimePlatform?.cpuArchitecture?._cpuArchitecture,
-              operatingSystemFamily:
-                this.runtimePlatform?.operatingSystemFamily
-                  ?._operatingSystemFamily,
-            }
-          : undefined,
+      runtimePlatform: this.runtimePlatform
+        ? {
+            cpuArchitecture:
+              this.runtimePlatform?.cpuArchitecture?._cpuArchitecture,
+            operatingSystemFamily:
+              this.runtimePlatform?.operatingSystemFamily
+                ?._operatingSystemFamily,
+          }
+        : undefined,
       enableFaultInjection: props.enableFaultInjection,
     };
 

--- a/src/aws/compute/ecs/base/task-definition.ts
+++ b/src/aws/compute/ecs/base/task-definition.ts
@@ -1670,6 +1670,10 @@ export function isEc2Compatible(compatibility: Compatibility): boolean {
     Compatibility.EC2,
     Compatibility.EC2_AND_FARGATE,
     Compatibility.EC2_AND_MANAGED_INSTANCES,
+    // TERRACONSTRUCTS DEVIATION: upstream omits FARGATE_AND_EC2_AND_MANAGED_INSTANCES from all
+    // four compatibility predicates, so it renders `requiresCompatibilities: []` and skips every
+    // compatibility-gated validation.
+    Compatibility.FARGATE_AND_EC2_AND_MANAGED_INSTANCES,
   ].includes(compatibility);
 }
 
@@ -1681,6 +1685,7 @@ export function isFargateCompatible(compatibility: Compatibility): boolean {
     Compatibility.FARGATE,
     Compatibility.EC2_AND_FARGATE,
     Compatibility.FARGATE_AND_MANAGED_INSTANCES,
+    Compatibility.FARGATE_AND_EC2_AND_MANAGED_INSTANCES,
   ].includes(compatibility);
 }
 
@@ -1701,6 +1706,7 @@ export function isManagedInstancesCompatible(
     Compatibility.MANAGED_INSTANCES,
     Compatibility.EC2_AND_MANAGED_INSTANCES,
     Compatibility.FARGATE_AND_MANAGED_INSTANCES,
+    Compatibility.FARGATE_AND_EC2_AND_MANAGED_INSTANCES,
   ].includes(compatibility);
 }
 

--- a/src/aws/compute/ecs/ec2/ec2-task-definition.ts
+++ b/src/aws/compute/ecs/ec2/ec2-task-definition.ts
@@ -20,6 +20,7 @@ import {
   ContainerDefinitionOptions,
 } from "../container-definition";
 import { PlacementConstraint } from "../placement";
+import { RuntimePlatform } from "../runtime-platform";
 
 /**
  * The properties for a task definition run on an EC2 cluster.
@@ -69,6 +70,17 @@ export interface Ec2TaskDefinitionProps extends CommonTaskDefinitionProps {
    * @default - No inference accelerators.
    */
   readonly inferenceAccelerators?: InferenceAccelerator[];
+
+  /**
+   * The operating system that your task definitions are running on.
+   *
+   * Use this to target ARM64 or Windows based EC2 container instances -- the
+   * `WINDOWS_SERVER_2016_FULL`, `WINDOWS_SERVER_2004_CORE` and
+   * `WINDOWS_SERVER_20H2_CORE` operating system families are EC2 only.
+   *
+   * @default - Undefined.
+   */
+  readonly runtimePlatform?: RuntimePlatform;
 }
 
 /**

--- a/src/aws/compute/ecs/linux-parameters.ts
+++ b/src/aws/compute/ecs/linux-parameters.ts
@@ -181,16 +181,33 @@ export class LinuxParameters extends Construct {
       sharedMemorySize: this.sharedMemorySize,
       maxSwap: this.maxSwap?.toMebibytes(),
       swappiness: this.swappiness,
-      capabilities: {
-        add: Lazy.listValue(
-          { produce: () => this.capAdd },
-          { omitEmpty: true },
-        ),
-        drop: Lazy.listValue(
-          { produce: () => this.capDrop },
-          { omitEmpty: true },
-        ),
-      },
+      // TERRACONSTRUCTS DEVIATION: upstream unconditionally emits the `capabilities` wrapper (so an
+      // empty `Capabilities: {}` shows up whenever LinuxParameters is used for tmpfs/devices only).
+      // CloudFormation never diffs that against API read-back, but Terraform does: the ECS API drops
+      // an empty `capabilities` on read, the provider's container_definitions equivalence check does
+      // not normalise it away, and `container_definitions` is ForceNew -- so the stray `{}` churns a
+      // new task-definition revision and redeploys every service. Omit the wrapper when empty.
+      //
+      // The whole value must stay Lazy: renderLinuxParameters() is called EAGERLY from
+      // ContainerDefinition, so deciding emptiness here at render time would silently drop
+      // capabilities added after addContainer().
+      capabilities: Lazy.anyValue({
+        produce: () =>
+          this.capAdd.length === 0 && this.capDrop.length === 0
+            ? undefined
+            : {
+                add: Lazy.listValue(
+                  { produce: () => this.capAdd },
+                  { omitEmpty: true },
+                ),
+                drop: Lazy.listValue(
+                  { produce: () => this.capDrop },
+                  { omitEmpty: true },
+                ),
+              },
+        // cast keeps the public struct member's type unchanged (jsii compat); the token resolves
+        // inside the jsonencoded `container_definitions` blob exactly like `devices`/`tmpfs`.
+      }) as unknown as KernelCapabilitiesConfig,
       devices: Lazy.anyValue(
         { produce: () => this.devices.map(renderDevice) },
         { omitEmptyArray: true },

--- a/test/aws/compute/ecs/base-service.test.ts
+++ b/test/aws/compute/ecs/base-service.test.ts
@@ -629,6 +629,103 @@ describe("When specifying a task definition revision", () => {
   });
 });
 
+// TERRACONSTRUCTS-SPECIFIC: no upstream counterpart. Upstream aws-cdk only tests the mutual
+// exclusion error (aws-ecs/test/ec2/ec2-service.test.ts:2335,
+// aws-ecs/test/fargate/fargate-service.test.ts:5019) and never asserts what `propagateTags`
+// actually renders. Upstream's own render (aws-ecs/lib/base/base-service.ts:743) resolves the
+// deprecated `propagateTaskTagsFrom` alias into `propagateTagsFromSource` but then emits
+// `props.propagateTags`, so a service configured with ONLY the deprecated alias silently emits
+// nothing. `aws_ecs_service` has no server-side alias for this, so an omitted `propagate_tags`
+// means the provider sends `NONE` -- the tags are simply never propagated. These tests lock in
+// the fixed behaviour.
+describe("When specifying propagateTags", () => {
+  let stack: AwsStack;
+  let cluster: ecs.Cluster;
+  let taskDefinition: ecs.FargateTaskDefinition;
+
+  beforeEach(() => {
+    stack = new AwsStack();
+    const vpc = new compute.Vpc(stack, "Vpc");
+    cluster = new ecs.Cluster(stack, "EcsCluster", { vpc });
+    taskDefinition = new ecs.FargateTaskDefinition(stack, "FargateTaskDef");
+    taskDefinition.addContainer("web", {
+      image: ecs.ContainerImage.fromRegistry("amazon/amazon-ecs-sample"),
+    });
+  });
+
+  test.each([
+    ecs.PropagatedTagSource.SERVICE,
+    ecs.PropagatedTagSource.TASK_DEFINITION,
+  ])("renders propagate_tags when propagateTags is %s", (source) => {
+    // WHEN
+    new ecs.FargateService(stack, "FargateService", {
+      cluster,
+      taskDefinition,
+      propagateTags: source,
+    });
+
+    // THEN
+    expect(soleResource(stack, ecsService.EcsService).propagate_tags).toEqual(
+      source,
+    );
+  });
+
+  // upstream: testDeprecated (deprecated `propagateTaskTagsFrom` prop) -- no deprecation-warning
+  // test harness in this repo, use plain test.
+  test.each([
+    ecs.PropagatedTagSource.SERVICE,
+    ecs.PropagatedTagSource.TASK_DEFINITION,
+  ])(
+    "renders propagate_tags when only the deprecated propagateTaskTagsFrom is %s",
+    (source) => {
+      // WHEN
+      new ecs.FargateService(stack, "FargateService", {
+        cluster,
+        taskDefinition,
+        propagateTaskTagsFrom: source,
+      });
+
+      // THEN
+      expect(soleResource(stack, ecsService.EcsService).propagate_tags).toEqual(
+        source,
+      );
+    },
+  );
+
+  test("omits propagate_tags when neither prop is set", () => {
+    // WHEN
+    new ecs.FargateService(stack, "FargateService", {
+      cluster,
+      taskDefinition,
+    });
+
+    // THEN
+    expect(
+      soleResource(stack, ecsService.EcsService).propagate_tags,
+    ).toBeUndefined();
+  });
+
+  test.each([
+    ["propagateTags", { propagateTags: ecs.PropagatedTagSource.NONE }],
+    [
+      "propagateTaskTagsFrom",
+      { propagateTaskTagsFrom: ecs.PropagatedTagSource.NONE },
+    ],
+  ])("omits propagate_tags when %s is NONE", (_name, props) => {
+    // WHEN
+    new ecs.FargateService(stack, "FargateService", {
+      cluster,
+      taskDefinition,
+      ...props,
+    });
+
+    // THEN
+    expect(
+      soleResource(stack, ecsService.EcsService).propagate_tags,
+    ).toBeUndefined();
+  });
+});
+
 // TERRACONSTRUCTS DEVIATION: upstream's top-level test.each(...) ('circuitbreaker is %p /\\ flag
 // is %p => DeploymentController in output: %p') exercises the
 // `@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker` feature flag (via

--- a/test/aws/compute/ecs/container-definition.test.ts
+++ b/test/aws/compute/ecs/container-definition.test.ts
@@ -616,9 +616,12 @@ describe("container definition", () => {
           },
           hostname: "host.example.com",
           image: "/aws/aws-example-app",
-          linuxParameters: {
-            capabilities: {},
-          },
+          // upstream: aws-cdk-lib/aws-ecs/test/container-definition.test.ts:608 asserts
+          // `LinuxParameters: { Capabilities: {} }`. TERRACONSTRUCTS DEVIATION: an empty
+          // `capabilities` wrapper is omitted entirely -- see linux-parameters.ts.
+          linuxParameters: expect.not.objectContaining({
+            capabilities: expect.anything(),
+          }),
           logConfiguration: {
             logDriver: "awslogs",
             options: {
@@ -2624,12 +2627,15 @@ describe("container definition", () => {
       });
 
       // THEN
+      // upstream: aws-cdk-lib/aws-ecs/test/container-definition.test.ts:2528 asserts
+      // `LinuxParameters: { Capabilities: {} }`. TERRACONSTRUCTS DEVIATION: an empty
+      // `capabilities` wrapper is omitted entirely -- see linux-parameters.ts.
       expect(renderContainerDefinitions(stack)).toMatchObject([
         {
           image: "test",
-          linuxParameters: {
-            capabilities: {},
-          },
+          linuxParameters: expect.not.objectContaining({
+            capabilities: expect.anything(),
+          }),
         },
       ]);
       // Template.fromStack(stack).hasResourceProperties('AWS::ECS::TaskDefinition', {
@@ -2871,6 +2877,106 @@ describe("container definition", () => {
       //     }),
       //   ],
       // });
+    });
+
+    // TERRACONSTRUCTS-SPECIFIC: no upstream counterpart -- guards terraform-provider-aws
+    // behaviour. The ECS API drops an empty `capabilities` object on read-back, and the
+    // provider's `containerDefinitionsAreEquivalent` does not normalise it away. Because
+    // `aws_ecs_task_definition.container_definitions` is ForceNew, a stray `"capabilities": {}`
+    // is a permadiff: a new task-definition revision and a rolling redeploy of every service on
+    // every apply. Upstream CloudFormation never diffs against read-back, hence the divergence.
+    describe("TERRACONSTRUCTS-SPECIFIC: empty capabilities are omitted from container_definitions", () => {
+      test("no capabilities key at all when only tmpfs/devices are set", () => {
+        // GIVEN
+        const stack = new AwsStack(Testing.app({ fakeCdktfJsonPath: true }));
+        const taskDefinition = new ecs.Ec2TaskDefinition(stack, "TaskDef");
+        const linuxParameters = new ecs.LinuxParameters(
+          stack,
+          "LinuxParameters",
+        );
+
+        // WHEN
+        linuxParameters.addDevices({ hostPath: "a/b/c" });
+        linuxParameters.addTmpfs({ containerPath: "a/b/c", size: 1024 });
+
+        taskDefinition.addContainer("cont", {
+          image: ecs.ContainerImage.fromRegistry("test"),
+          memoryLimitMiB: 1024,
+          linuxParameters,
+        });
+
+        // THEN
+        const [containerDefinition] = renderContainerDefinitions(stack);
+        expect(Object.keys(containerDefinition.linuxParameters)).not.toContain(
+          "capabilities",
+        );
+        expect(containerDefinition.linuxParameters).toEqual({
+          devices: [{ hostPath: "a/b/c" }],
+          tmpfs: [{ containerPath: "a/b/c", size: 1024 }],
+        });
+      });
+
+      test("capabilities keys stay camelCase inside the jsonencoded blob", () => {
+        // GIVEN
+        const stack = new AwsStack(Testing.app({ fakeCdktfJsonPath: true }));
+        const taskDefinition = new ecs.Ec2TaskDefinition(stack, "TaskDef");
+        const linuxParameters = new ecs.LinuxParameters(
+          stack,
+          "LinuxParameters",
+        );
+
+        // WHEN
+        linuxParameters.addCapabilities(ecs.Capability.ALL);
+        linuxParameters.dropCapabilities(ecs.Capability.KILL);
+
+        taskDefinition.addContainer("cont", {
+          image: ecs.ContainerImage.fromRegistry("test"),
+          memoryLimitMiB: 1024,
+          linuxParameters,
+        });
+
+        // THEN
+        // `container_definitions` is a jsonencode()'d string destined for the ECS API, so no
+        // `*ToTerraform` converter may ever be applied to it -- the keys must stay camelCase.
+        const taskDefs = new Template(stack).resourceTypeArray(
+          ecsTaskDefinition.EcsTaskDefinition,
+        ) as Array<{ container_definitions: string }>;
+        const raw = taskDefs[0].container_definitions;
+        expect(raw).not.toMatch(/"(Capabilities|cap_add|cap_drop|Add|Drop)"/);
+
+        const [containerDefinition] = JSON.parse(raw);
+        expect(containerDefinition.linuxParameters).toEqual({
+          capabilities: { add: ["ALL"], drop: ["KILL"] },
+        });
+      });
+
+      test("capabilities added after addContainer are still rendered", () => {
+        // GIVEN
+        const stack = new AwsStack(Testing.app({ fakeCdktfJsonPath: true }));
+        const taskDefinition = new ecs.Ec2TaskDefinition(stack, "TaskDef");
+        const linuxParameters = new ecs.LinuxParameters(
+          stack,
+          "LinuxParameters",
+        );
+
+        // WHEN
+        // renderLinuxParameters() runs eagerly inside addContainer(), while both capability
+        // lists are still empty -- the omit decision must therefore happen at resolution time.
+        taskDefinition.addContainer("cont", {
+          image: ecs.ContainerImage.fromRegistry("test"),
+          memoryLimitMiB: 1024,
+          linuxParameters,
+        });
+
+        linuxParameters.addCapabilities(ecs.Capability.SYS_PTRACE);
+        linuxParameters.dropCapabilities(ecs.Capability.SETUID);
+
+        // THEN
+        const [containerDefinition] = renderContainerDefinitions(stack);
+        expect(containerDefinition.linuxParameters).toEqual({
+          capabilities: { add: ["SYS_PTRACE"], drop: ["SETUID"] },
+        });
+      });
     });
   });
 

--- a/test/aws/compute/ecs/ec2/ec2-task-definition.test.ts
+++ b/test/aws/compute/ecs/ec2/ec2-task-definition.test.ts
@@ -509,8 +509,12 @@ describe("ec2 task definition", () => {
             },
             hostname: "webHost",
             image: "amazon/amazon-ecs-sample",
+            // upstream: aws-cdk-lib/aws-ecs/test/ec2/ec2-task-definition.test.ts:374 also
+            // asserts `Capabilities: {}` here. TERRACONSTRUCTS DEVIATION: an empty
+            // `capabilities` wrapper is omitted entirely -- see linux-parameters.ts. Absence is
+            // asserted in container-definition.test.ts
+            // ("no capabilities key at all when only tmpfs/devices are set").
             linuxParameters: {
-              capabilities: {},
               initProcessEnabled: true,
               sharedMemorySize: 1024,
             },

--- a/test/aws/compute/ecs/ec2/ec2-task-definition.test.ts
+++ b/test/aws/compute/ecs/ec2/ec2-task-definition.test.ts
@@ -1855,6 +1855,85 @@ describe("ec2 task definition", () => {
       /Invalid placement constraint\(s\): distinctInstance. Only 'memberOf' is currently supported in the Ec2TaskDefinition class./,
     );
   });
+
+  // TERRACONSTRUCTS-SPECIFIC: no upstream counterpart -- upstream aws-cdk rejects `runtimePlatform`
+  // on every non-Fargate/non-Managed-Instances task definition
+  // (aws-cdk-lib/aws-ecs/lib/base/task-definition.ts:522) and therefore has no such test.
+  // terraform-provider-aws exposes `runtime_platform` on `aws_ecs_task_definition` without any
+  // `requires_compatibilities` gating, and the ECS API documents cpuArchitecture for Linux EC2
+  // instances plus EC2-only Windows operating system families.
+  describe("setting runtimePlatform", () => {
+    test("renders runtime_platform for an ARM64 EC2 task definition", () => {
+      // GIVEN
+      const stack = newStack();
+
+      // WHEN
+      new ecs.Ec2TaskDefinition(stack, "Ec2TaskDef", {
+        runtimePlatform: {
+          cpuArchitecture: ecs.CpuArchitecture.ARM64,
+        },
+      });
+
+      // THEN
+      Template.synth(stack).toHaveResourceWithProperties(
+        ecsTaskDefinition.EcsTaskDefinition,
+        {
+          requires_compatibilities: ["EC2"],
+          runtime_platform: {
+            cpu_architecture: "ARM64",
+          },
+        },
+      );
+    });
+
+    test("renders runtime_platform for a Windows EC2 task definition without cpu/memory", () => {
+      // GIVEN
+      const stack = newStack();
+
+      // WHEN
+      new ecs.Ec2TaskDefinition(stack, "Ec2TaskDef", {
+        runtimePlatform: {
+          cpuArchitecture: ecs.CpuArchitecture.X86_64,
+          operatingSystemFamily:
+            ecs.OperatingSystemFamily.WINDOWS_SERVER_2019_CORE,
+        },
+      });
+
+      // THEN
+      // the Fargate-only Windows cpu/memory combination check must not fire here: cpu/memoryMiB are
+      // legitimately undefined on EC2, and `Number(undefined)` would otherwise throw a bogus error.
+      const taskDef = soleTaskDefinition(synthTemplate(stack));
+      expect(taskDef.cpu).toBeUndefined();
+      expect(taskDef.memory).toBeUndefined();
+      expect(taskDef.runtime_platform).toEqual({
+        cpu_architecture: "X86_64",
+        operating_system_family: "WINDOWS_SERVER_2019_CORE",
+      });
+    });
+
+    test("renders EC2-only Windows operating system families", () => {
+      // GIVEN
+      const stack = newStack();
+
+      // WHEN
+      new ecs.Ec2TaskDefinition(stack, "Ec2TaskDef", {
+        runtimePlatform: {
+          operatingSystemFamily:
+            ecs.OperatingSystemFamily.WINDOWS_SERVER_2016_FULL,
+        },
+      });
+
+      // THEN
+      Template.synth(stack).toHaveResourceWithProperties(
+        ecsTaskDefinition.EcsTaskDefinition,
+        {
+          runtime_platform: {
+            operating_system_family: "WINDOWS_SERVER_2016_FULL",
+          },
+        },
+      );
+    });
+  });
 });
 
 // NOTE: not part of the upstream suite - added per harness convention (see

--- a/test/aws/compute/ecs/external/external-task-definition.test.ts
+++ b/test/aws/compute/ecs/external/external-task-definition.test.ts
@@ -342,8 +342,12 @@ describe("external task definition", () => {
         },
         hostname: "webHost",
         image: "amazon/amazon-ecs-sample",
+        // upstream: aws-cdk-lib/aws-ecs/test/external/external-task-definition.test.ts:261 also
+        // asserts `Capabilities: {}` here. TERRACONSTRUCTS DEVIATION: an empty `capabilities`
+        // wrapper is omitted entirely -- see linux-parameters.ts. Absence is asserted in
+        // container-definition.test.ts
+        // ("no capabilities key at all when only tmpfs/devices are set").
         linuxParameters: {
-          capabilities: {},
           initProcessEnabled: true,
           sharedMemorySize: 1024,
         },

--- a/test/aws/compute/ecs/task-definition.test.ts
+++ b/test/aws/compute/ecs/task-definition.test.ts
@@ -1288,6 +1288,79 @@ describe("Managed Instances compatibility", () => {
     });
   });
 
+  // TERRACONSTRUCTS-SPECIFIC: no upstream counterpart -- upstream rejects `runtimePlatform` on any
+  // non-Fargate/non-Managed-Instances task definition
+  // (aws-cdk-lib/aws-ecs/lib/base/task-definition.ts:522). The ECS RegisterTaskDefinition API has no
+  // such restriction and terraform-provider-aws puts `runtime_platform` on
+  // `aws_ecs_task_definition` with no `requires_compatibilities` gating.
+  describe("runtimePlatform compatibility", () => {
+    test("is rendered for EC2 compatible tasks", () => {
+      // GIVEN
+      const stack = getAwsStack();
+
+      // WHEN
+      new ecs.TaskDefinition(stack, "TD", {
+        compatibility: ecs.Compatibility.EC2,
+        runtimePlatform: {
+          cpuArchitecture: ecs.CpuArchitecture.ARM64,
+          operatingSystemFamily: ecs.OperatingSystemFamily.LINUX,
+        },
+      });
+
+      // THEN
+      Template.synth(stack).toHaveResourceWithProperties(
+        ecsTaskDefinition.EcsTaskDefinition,
+        {
+          requires_compatibilities: ["EC2"],
+          runtime_platform: {
+            cpu_architecture: "ARM64",
+            operating_system_family: "LINUX",
+          },
+        },
+      );
+    });
+
+    test("throws for External compatible tasks", () => {
+      // GIVEN
+      const stack = getAwsStack();
+
+      // THEN
+      expect(() => {
+        new ecs.TaskDefinition(stack, "TD", {
+          compatibility: ecs.Compatibility.EXTERNAL,
+          runtimePlatform: {
+            cpuArchitecture: ecs.CpuArchitecture.ARM64,
+          },
+        });
+      }).toThrow("Cannot specify runtimePlatform in External compatible tasks");
+    });
+
+    test("Windows EC2 tasks are not subject to the Fargate cpu/memory combinations", () => {
+      // GIVEN
+      const stack = getAwsStack();
+
+      // WHEN - cpu/memoryMiB are optional on EC2; a Fargate-only combination check would compare
+      // `Number(undefined)` here and throw.
+      new ecs.TaskDefinition(stack, "TD", {
+        compatibility: ecs.Compatibility.EC2,
+        cpu: "512",
+        memoryMiB: "512",
+        runtimePlatform: {
+          operatingSystemFamily:
+            ecs.OperatingSystemFamily.WINDOWS_SERVER_2019_CORE,
+        },
+      });
+
+      // THEN
+      Template.synth(stack).toHaveResourceWithProperties(
+        ecsTaskDefinition.EcsTaskDefinition,
+        {
+          runtime_platform: {
+            operating_system_family: "WINDOWS_SERVER_2019_CORE",
+          },
+        },
+      );
+    });
   });
 
   describe("Volume validation with configuredAtLaunch", () => {

--- a/test/aws/compute/ecs/task-definition.test.ts
+++ b/test/aws/compute/ecs/task-definition.test.ts
@@ -1240,6 +1240,54 @@ describe("Managed Instances compatibility", () => {
       //   PlacementConstraints: Match.absent(),
       // });
     });
+
+    // TERRACONSTRUCTS-SPECIFIC: no upstream counterpart. Upstream aws-cdk omits
+    // FARGATE_AND_EC2_AND_MANAGED_INSTANCES from all of its `isXxxCompatible` helpers
+    // (aws-cdk-lib/aws-ecs/lib/base/task-definition.ts:1395-1421), so a task definition using it
+    // renders an empty `requires_compatibilities` (terraform-provider-aws would then register a
+    // task definition with no launch types) and silently skips every compatibility-gated
+    // validation, including the Fargate cpu/memory check.
+    test("isXxxCompatible and requires_compatibilities for FARGATE_AND_EC2_AND_MANAGED_INSTANCES", () => {
+      // GIVEN
+      const stack = getAwsStack();
+
+      // WHEN
+      const taskDefinition = new ecs.TaskDefinition(stack, "TD", {
+        cpu: "512",
+        memoryMiB: "1024",
+        compatibility: ecs.Compatibility.FARGATE_AND_EC2_AND_MANAGED_INSTANCES,
+      });
+
+      // THEN
+      expect(taskDefinition.isEc2Compatible).toBe(true);
+      expect(taskDefinition.isFargateCompatible).toBe(true);
+      expect(taskDefinition.isManagedInstancesCompatible).toBe(true);
+      expect(taskDefinition.isExternalCompatible).toBe(false);
+
+      Template.synth(stack).toHaveResourceWithProperties(
+        ecsTaskDefinition.EcsTaskDefinition,
+        {
+          requires_compatibilities: ["EC2", "FARGATE", "MANAGED_INSTANCES"],
+        },
+      );
+    });
+
+    // TERRACONSTRUCTS-SPECIFIC: guards that FARGATE_AND_EC2_AND_MANAGED_INSTANCES now actually
+    // reaches the Fargate cpu/memory validation instead of silently skipping it.
+    test("FARGATE_AND_EC2_AND_MANAGED_INSTANCES requires cpu and memory", () => {
+      // GIVEN
+      const stack = getAwsStack();
+
+      // THEN
+      expect(() => {
+        new ecs.TaskDefinition(stack, "TD", {
+          compatibility:
+            ecs.Compatibility.FARGATE_AND_EC2_AND_MANAGED_INSTANCES,
+        });
+      }).toThrow(/Fargate-compatible tasks require both CPU .* and memory/);
+    });
+  });
+
   });
 
   describe("Volume validation with configuredAtLaunch", () => {


### PR DESCRIPTION
Addresses the actionable findings from #157, plus two related bugs found while investigating.

Full adjudication of all five reported findings — including the three not being changed and why — is
in a comment on #157.

## Fixed

**1. `LinuxParameters` always rendered `capabilities: {}`** (#157 finding 2)

`renderLinuxParameters()` emitted the `capabilities` wrapper unconditionally, so using
`LinuxParameters` for tmpfs/devices alone still produced `"capabilities": {}` inside the jsonencoded
`container_definitions`. The ECS API drops an empty `capabilities` on read-back, the provider's
`containerDefinitionsAreEquivalent` does not normalise it away, and `container_definitions` is
ForceNew — so the stray `{}` cuts a new task definition revision and rolls every task.

The value stays `Lazy` deliberately: `renderLinuxParameters()` is called eagerly from
`ContainerDefinition`, so deciding emptiness at render time would silently drop capabilities added
after `addContainer()`. There is a test that pins exactly this.

Upstream aws-cdk emits the empty wrapper too (and asserts it in its own tests) — harmless there
because CloudFormation never diffs against API read-back. Marked as a `TERRACONSTRUCTS DEVIATION`.

**2. `runtimePlatform` was rejected for EC2 task definitions** (#157 finding 4)

Neither the ECS API nor terraform-provider-aws restricts `runtimePlatform` to Fargate:

- `RegisterTaskDefinition.runtimePlatform` carries no launch-type constraint, and
  `RuntimePlatform.cpuArchitecture` is documented as available for tasks running on "Linux Amazon EC2
  instance".
- The EC2 task definition guide documents `operatingSystemFamily` values that do not exist on the
  Fargate page at all (`WINDOWS_SERVER_2016_FULL`, `WINDOWS_SERVER_2004_CORE`,
  `WINDOWS_SERVER_20H2_CORE`).
- `aws_ecs_task_definition.runtime_platform` is not gated on `requires_compatibilities`.

The upstream rule traces to a copy-paste error in AWS's own `API_TaskDefinition.runtimePlatform`
docs ("A *platform family* is specified only for tasks using the Fargate launch type" — a sentence
belonging to `Service.platformFamily`). The string "A runtimePlatform is supported only for tasks
using the Fargate launch type" exists only in CDK source, nowhere in AWS service documentation.

`runtimePlatform?` is now surfaced on `Ec2TaskDefinitionProps` (optional, additive). The guard is
kept for EXTERNAL (ECS Anywhere) tasks.

Also handled in the same commit: `checkFargateWindowsBasedTasksSize` was gated only on the OS family
being Windows. An EC2 Windows task legitimately omits `cpu`/`memoryMiB`, which would have compared
`Number(undefined)` and thrown a spurious Fargate cpu/memory error. It is now gated on
`isFargateCompatible`.

## Also fixed (found during review, not reported)

**3. `Compatibility.FARGATE_AND_EC2_AND_MANAGED_INSTANCES` was in none of the compatibility
predicates**

It appeared in neither `isEc2Compatible`, `isFargateCompatible` nor `isManagedInstancesCompatible`,
so a task definition using it rendered `requires_compatibilities: []` and silently skipped every
compatibility-gated branch — including the Fargate cpu/memory presence validation. The same omission
exists upstream.

**4. `BaseService` dropped the deprecated `propagateTaskTagsFrom` alias**

The alias was resolved into `propagateTagsFromSource` and used for the `NONE` check, but
`props.propagateTags` was emitted instead. Setting only the deprecated alias silently produced no
`propagate_tags` at all. Also present upstream (`aws-ecs/lib/base/base-service.ts:743`).

## Not changed

Three of the five reported findings are not being changed — `aws_ecs_service.cluster` (the provider
preserves the config's format; the reported perpetual-diff does not occur for services the L2
creates, and changing the default would force replacement for every existing user), task-level
`cpu`/`memoryMiB` on `Ec2TaskDefinitionProps` (the proposed change is a JSII/TS type conflict with
`FargateTaskDefinitionProps.cpu`, and the generic `TaskDefinition` already supports it), and a `tags`
prop (the repo's convention is the `Tags.of().add()` aspect, which merges via `tagsInput`
specifically to avoid the token error reported). Reasoning and sources are in the #157 comment.

## Testing

- `pnpm jest --ci --coverage=false ./test/aws/compute/ecs` — 26 suites / 774 tests / 38 snapshots
  pass (756 tests before this branch). `--ci` is used deliberately: the projen `test` task bakes in
  `--updateSnapshot`, which would mask snapshot breakage.
- `pnpm compile` (jsii) — 0 errors. `pnpm eslint` — clean.
- No snapshot churn: no `.snap` file contained `linuxParameters`, and no existing scenario changed.
- All changes are additive/optional, so no `.compatignore` entry is needed and `jsii-diff` stays
  green.
- Unit tests that have an upstream aws-cdk counterpart cite it by `file:line` so future ports stay
  easy to diff; Terraform-specific tests with no upstream counterpart are marked
  `TERRACONSTRUCTS-SPECIFIC` and explain the provider behaviour they guard.

Not validated against live AWS — the `integ/` harness has no post-apply idempotent-plan assertion,
which is what would prove the `capabilities` fix end to end. Worth adding separately.

Closes #157
